### PR TITLE
Replaces OpenAPI.NET.OData submodule with nuget package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Submodules/OpenAPI.NET.OData"]
-	path = Submodules/OpenAPI.NET.OData
-	url = https://github.com/microsoftgraph/OpenAPI.NET.OData.git

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -23,8 +23,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenAPIService", "OpenAPISe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenAPIService.Test", "OpenAPIService.Test\OpenAPIService.Test.csproj", "{B9FE6D79-3835-4A18-8FEE-551703838510}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OpenAPI.OData.Reader", "Submodules\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj", "{5E40F938-160A-4904-B256-946020B01042}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MockTestUtility", "MockTestUtility\MockTestUtility.csproj", "{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeSnippetsReflection.App", "CodeSnippetsReflection.App\CodeSnippetsReflection.App.csproj", "{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}"
@@ -79,10 +77,6 @@ Global
 		{B9FE6D79-3835-4A18-8FEE-551703838510}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9FE6D79-3835-4A18-8FEE-551703838510}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9FE6D79-3835-4A18-8FEE-551703838510}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5E40F938-160A-4904-B256-946020B01042}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5E40F938-160A-4904-B256-946020B01042}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5E40F938-160A-4904-B256-946020B01042}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5E40F938-160A-4904-B256-946020B01042}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.8.1" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.5" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Submodules\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj" />
     <ProjectReference Include="..\UriMatchService\UriMatchingService.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR proposes:

- Replacing the `OpenAPI.NET.OData` project submodule with the nuget package for [Microsoft.OpenApi.OData](https://www.nuget.org/packages/Microsoft.OpenApi.OData/1.0.5)
- Deleting the _.gitmodules_ file.
- Removing the OpenAPI.NET.OData project and its references.