### PR TITLE
Replace single-quotes in string literals with escape sequence for JS

### DIFF
--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -63,7 +63,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.filter('startswith(givenName, 'J')')", result);
+            Assert.Equal("\n\t.filter('startswith(givenName, \'J\')')", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -63,7 +63,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.filter('startswith(givenName, \'J\')')", result);
+            Assert.Equal("\n\t.filter('startswith(givenName, \\'J\\')')", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -893,5 +893,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string ReservedNameEscapeSequence => "@";
 
         public override string DoubleQuotesEscapeSequence => "\\\"";
+
+        public override string SingleQuotesEscapeSequence => "'";
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using Newtonsoft.Json.Linq;
+using CodeSnippetsReflection.StringExtensions;
 
 namespace CodeSnippetsReflection.LanguageGenerators
 {
@@ -43,15 +44,14 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     continue;
                 //append the header to the snippet
                 var valueString = value.First()
-                    .Replace("\"", languageExpressions.DoubleQuotesEscapeSequence)
-                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence);
                 snippetBuilder.Append(string.Format(languageExpressions.HeaderExpression, key, valueString));
             }
             //Append any filter queries
             if (snippetModel.FilterFieldList.Any())
             {
                 var filterResult = string.Join(languageExpressions.FilterExpressionDelimiter, snippetModel.FilterFieldList)
-                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence);
                 //append the filter to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.FilterExpression, filterResult));
             }
@@ -60,7 +60,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
             if (!string.IsNullOrEmpty(snippetModel.SearchExpression))
             {
                 snippetBuilder.Append(string.Format(languageExpressions.SearchExpression, 
-                    snippetModel.SearchExpression.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
+                    snippetModel.SearchExpression
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append the expand section
@@ -68,14 +69,15 @@ namespace CodeSnippetsReflection.LanguageGenerators
             {
                 //append the expand result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.ExpandExpression, 
-                    snippetModel.ExpandFieldExpression.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
+                    snippetModel.ExpandFieldExpression
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append any select queries
             if (snippetModel.SelectFieldList.Any())
             {
                 var selectResult = string.Join(languageExpressions.SelectExpressionDelimiter, snippetModel.SelectFieldList)
-                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence);
                 //append the select result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.SelectExpression, selectResult));
             }
@@ -84,7 +86,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             if (snippetModel.OrderByFieldList.Any())
             {
                 var orderByResult = string.Join(languageExpressions.OrderByExpressionDelimiter, snippetModel.OrderByFieldList)
-                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence);
                 //append the orderby result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.OrderByExpression, orderByResult));
             }
@@ -99,7 +101,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
             if (!string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
             {
                 snippetBuilder.Append(string.Format(languageExpressions.SkipTokenExpression, 
-                    snippetModel.ODataUri.SkipToken.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
+                    snippetModel.ODataUri.SkipToken
+                    .EscapeQuotesInLiteral(languageExpressions.DoubleQuotesEscapeSequence, languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append any top queries

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -42,13 +42,16 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 if (key.ToLower().Equals("host",StringComparison.Ordinal))
                     continue;
                 //append the header to the snippet
-                var valueString = value.First().Replace("\"", languageExpressions.DoubleQuotesEscapeSequence);
+                var valueString = value.First()
+                    .Replace("\"", languageExpressions.DoubleQuotesEscapeSequence)
+                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
                 snippetBuilder.Append(string.Format(languageExpressions.HeaderExpression, key, valueString));
             }
             //Append any filter queries
             if (snippetModel.FilterFieldList.Any())
             {
-                var filterResult = string.Join(languageExpressions.FilterExpressionDelimiter, snippetModel.FilterFieldList);
+                var filterResult = string.Join(languageExpressions.FilterExpressionDelimiter, snippetModel.FilterFieldList)
+                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
                 //append the filter to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.FilterExpression, filterResult));
             }
@@ -56,20 +59,23 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any search queries
             if (!string.IsNullOrEmpty(snippetModel.SearchExpression))
             {
-                snippetBuilder.Append(string.Format(languageExpressions.SearchExpression, snippetModel.SearchExpression));
+                snippetBuilder.Append(string.Format(languageExpressions.SearchExpression, 
+                    snippetModel.SearchExpression.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append the expand section
             if (!string.IsNullOrEmpty(snippetModel.ExpandFieldExpression))
             {
                 //append the expand result to the snippet
-                snippetBuilder.Append(string.Format(languageExpressions.ExpandExpression, snippetModel.ExpandFieldExpression));
+                snippetBuilder.Append(string.Format(languageExpressions.ExpandExpression, 
+                    snippetModel.ExpandFieldExpression.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append any select queries
             if (snippetModel.SelectFieldList.Any())
             {
-                var selectResult = string.Join(languageExpressions.SelectExpressionDelimiter, snippetModel.SelectFieldList);
+                var selectResult = string.Join(languageExpressions.SelectExpressionDelimiter, snippetModel.SelectFieldList)
+                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
                 //append the select result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.SelectExpression, selectResult));
             }
@@ -77,7 +83,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any orderby queries
             if (snippetModel.OrderByFieldList.Any())
             {
-                var orderByResult = string.Join(languageExpressions.OrderByExpressionDelimiter, snippetModel.OrderByFieldList);
+                var orderByResult = string.Join(languageExpressions.OrderByExpressionDelimiter, snippetModel.OrderByFieldList)
+                    .Replace("'", languageExpressions.SingleQuotesEscapeSequence);
                 //append the orderby result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.OrderByExpression, orderByResult));
             }
@@ -91,7 +98,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any skip token queries
             if (!string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
             {
-                snippetBuilder.Append(string.Format(languageExpressions.SkipTokenExpression, snippetModel.ODataUri.SkipToken));
+                snippetBuilder.Append(string.Format(languageExpressions.SkipTokenExpression, 
+                    snippetModel.ODataUri.SkipToken.Replace("'", languageExpressions.SingleQuotesEscapeSequence)));
             }
 
             //Append any top queries

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -729,5 +729,6 @@ namespace CodeSnippetsReflection.LanguageGenerators
             "transient","try","void","volatile","while","true","false","null"   };
         public override string ReservedNameEscapeSequence => "_";
         public override string DoubleQuotesEscapeSequence => "\\\"";
+        public override string SingleQuotesEscapeSequence => "'";
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -101,7 +101,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             if (snippetModel.CustomQueryOptions.Any())
             {
                 //just append the query string since its a custom query
-                path += snippetModel.QueryString;
+                path += snippetModel.QueryString.Replace("'", "\\'");
             }
             stringBuilder.Append($"let res = await client.api('{path}')");
             //append beta
@@ -164,5 +164,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string ReservedNameEscapeSequence => "_";
 
         public override string DoubleQuotesEscapeSequence => "\"";
+
+        public override string SingleQuotesEscapeSequence => "\\'";
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using CodeSnippetsReflection.StringExtensions;
 
 [assembly: InternalsVisibleTo("CodeSnippetsReflection.Test")]
 namespace CodeSnippetsReflection.LanguageGenerators
@@ -101,7 +102,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             if (snippetModel.CustomQueryOptions.Any())
             {
                 //just append the query string since its a custom query
-                path += snippetModel.QueryString.Replace("'", "\\'");
+                path += snippetModel.QueryString.EscapeQuotesInLiteral("\"", "\\'");
             }
             stringBuilder.Append($"let res = await client.api('{path}')");
             //append beta

--- a/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
@@ -17,5 +17,6 @@
         public abstract string[] ReservedNames { get; }
         public abstract string ReservedNameEscapeSequence { get; }
         public abstract string DoubleQuotesEscapeSequence { get; }
+        public abstract string SingleQuotesEscapeSequence { get; }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/ObjectiveCGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/ObjectiveCGenerator.cs
@@ -371,5 +371,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string ReservedNameEscapeSequence => "_";
 
         public override string DoubleQuotesEscapeSequence => "\\\"";
+
+        public override string SingleQuotesEscapeSequence => "'";
     }
 }

--- a/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
+++ b/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace CodeSnippetsReflection.StringExtensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Returns a new string with all double-quotes (") and single-quotes (')
+        /// escaped with the specified values
+        /// </summary>
+        /// <param name="stringLiteral">The string value to escape</param>
+        /// <param name="doubleQuoteEscapeSequence">The string value to replace double-quotes</param>
+        /// <param name="singleQuoteEscapeSequence">The string value to replace single-quotes</param>
+        /// <returns></returns>
+        public static string EscapeQuotesInLiteral(this string stringLiteral, 
+                                                   string doubleQuoteEscapeSequence,
+                                                   string singleQuoteEscapeSequence)
+        {
+            return stringLiteral
+                .Replace("\"", doubleQuoteEscapeSequence)
+                .Replace("'", singleQuoteEscapeSequence);
+        }
+    }
+}


### PR DESCRIPTION
- Following existing design in `LanguageExpressions`, added a property `SingleQuotesEscapeSequence`. Value is just `"'"` for C#, Java, and Obj-C, but is `"\\'"` for JavaScript.
- Updated `CommonGenerator.GenerateQuerySection` to call `.Replace("'", languageExpressions.SingleQuotesEscapeSequence)` on all string literals.
- Updated `JavaScriptGenerator.GenerateRequestSection` to call `Replace("'", "\\'")` on the `snippetModel.QueryString` to handle any custom query parameters that might have single-quotes in them.

It's probably a good idea to chain the `.Replace("'", languageExpressions.SingleQuotesEscapeSequence)` calls in `CommonGenerator.GenerateQuerySection` with a `.Replace("\"", languageExpressions.DoubleQuotesEscapeSequence)` to cover all the bases, but as that was outside the scope of #460, I left it alone.

Fixes #460