### PR TITLE
Updated \n to \r\n in string literals for consistency

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -52,8 +52,8 @@ namespace CodeSnippetsReflection.Test
                                       "\t}\r\n" +
                                   "};\r\n\r\n" +
 
-                                  "await graphClient.Users\n" +
-                                      "\t.Request()\n" +
+                                  "await graphClient.Users\r\n" +
+                                      "\t.Request()\r\n" +
                                       "\t.AddAsync(user);";
 
             //Assert the snippet generated is as expected
@@ -95,8 +95,8 @@ namespace CodeSnippetsReflection.Test
                                                "\tCity = \"city-value\"\r\n" +
                                            "};\r\n\r\n" +
 
-                                          "await graphClient.Me\n" +
-                                              "\t.Request()\n" +
+                                          "await graphClient.Me\r\n" +
+                                              "\t.Request()\r\n" +
                                               "\t.UpdateAsync(user);";
 
             //Assert the snippet generated is as expected
@@ -312,8 +312,8 @@ namespace CodeSnippetsReflection.Test
                                                "\t}\r\n" +
                                            "};\r\n\r\n" +
 
-                                          "await graphClient.Me.Messages\n" +
-                                              "\t.Request()\n" +
+                                          "await graphClient.Me.Messages\r\n" +
+                                              "\t.Request()\r\n" +
                                               "\t.AddAsync(message);";
 
             //Assert the snippet generated is as expected
@@ -353,9 +353,9 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "var mailTipsOptions = MailTipsType.AutomaticReplies | MailTipsType.MailboxFullStatus;\r\n" + //Asserting that this OR is done
                                            "\r\n" +
-                                           "await graphClient.Me\n" +
-                                               "\t.GetMailTips(emailAddresses,mailTipsOptions)\n" +
-                                               "\t.Request()\n" +
+                                           "await graphClient.Me\r\n" +
+                                               "\t.GetMailTips(emailAddresses,mailTipsOptions)\r\n" +
+                                               "\t.Request()\r\n" +
                                                "\t.PostAsync();";
 
             //Assert the snippet generated is as expected
@@ -383,8 +383,8 @@ namespace CodeSnippetsReflection.Test
                                                "\tnew QueryOption(\"endDateTime\", \"2017-01-07T19:00:00.0000000\")\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "var calendarView = await graphClient.Me.Calendar.CalendarView\n" +
-                                               "\t.Request( queryOptions )\n" +
+                                           "var calendarView = await graphClient.Me.Calendar.CalendarView\r\n" +
+                                               "\t.Request( queryOptions )\r\n" +
                                                "\t.GetAsync();";
 
             //Assert the snippet generated is as expected
@@ -405,8 +405,8 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "await graphClient.Groups[\"{id}\"].Owners[\"{id}\"].Reference\n" +
-                                        "\t.Request()\n" +
+            const string expectedSnippet = "await graphClient.Groups[\"{id}\"].Owners[\"{id}\"].Reference\r\n" +
+                                        "\t.Request()\r\n" +
                                         "\t.DeleteAsync();";
 
             //Assert the snippet generated is as expected
@@ -439,8 +439,8 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
 
                                            "await graphClient.Groups[\"{id}\"].Owners.References" +
-                                                "\n\t.Request()" +
-                                                "\n\t.AddAsync(directoryObject);";
+                                                "\r\n\t.Request()" +
+                                                "\r\n\t.AddAsync(directoryObject);";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
@@ -472,8 +472,8 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
 
                                            "await graphClient.Groups[\"{id}\"].Owners.References" +
-                                           "\n\t.Request()" +
-                                           "\n\t.AddAsync(directoryObject);";
+                                           "\r\n\t.Request()" +
+                                           "\r\n\t.AddAsync(directoryObject);";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
@@ -511,8 +511,8 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
 
                                            "await graphClient.Groups[\"{id}\"].Owners.References" +
-                                           "\n\t.Request()" +
-                                           "\n\t.AddAsync(directoryObject);";
+                                           "\r\n\t.Request()" +
+                                           "\r\n\t.AddAsync(directoryObject);";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
@@ -533,9 +533,9 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Worksheets[\"{id|name}\"]\n" +
-                                               "\t.Range(\"A1:B2\")\n" +//parameter has double quotes
-                                               "\t.Request()\n" +
+            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Worksheets[\"{id|name}\"]\r\n" +
+                                               "\t.Range(\"A1:B2\")\r\n" +//parameter has double quotes
+                                               "\t.Request()\r\n" +
                                                "\t.GetAsync();";
 
             //Assert the snippet generated is as expected
@@ -585,8 +585,8 @@ namespace CodeSnippetsReflection.Test
                                                "\tBodyPreview = \"bodyPreview-value\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.MailFolders[\"{id}\"].Messages\n" +
-                                               "\t.Request()\n" +
+                                           "await graphClient.Me.MailFolders[\"{id}\"].Messages\r\n" +
+                                               "\t.Request()\r\n" +
                                                "\t.AddAsync(message);";
 
             //Assert the snippet generated is as expected
@@ -623,8 +623,8 @@ namespace CodeSnippetsReflection.Test
                                            "\tChangeKey = \"changeKey-value\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.CalendarGroups\n" +
-                                           "\t.Request()\n" +
+                                           "await graphClient.Me.CalendarGroups\r\n" +
+                                           "\t.Request()\r\n" +
                                            "\t.AddAsync(calendarGroup);";
 
             //Assert the snippet generated is as expected
@@ -680,9 +680,9 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "var availabilityViewInterval = \"60\";\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Calendar\n" +
-                                               "\t.GetSchedule(schedules,endTime,startTime,availabilityViewInterval)\n" +
-                                               "\t.Request()\n" +
+                                           "await graphClient.Me.Calendar\r\n" +
+                                               "\t.GetSchedule(schedules,endTime,startTime,availabilityViewInterval)\r\n" +
+                                               "\t.Request()\r\n" +
                                                "\t.PostAsync();";
 
             //Assert the snippet generated is as expected
@@ -735,8 +735,8 @@ namespace CodeSnippetsReflection.Test
                                            "\tIsReminderOn = true\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{id}\"]\n" +
-                                           "\t.Request()\n" +
+                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
+                                           "\t.Request()\r\n" +
                                            "\t.UpdateAsync(@event);";
 
             //Assert the snippet generated is as expected
@@ -854,8 +854,8 @@ namespace CodeSnippetsReflection.Test
                                                    "\t\t}\r\n" +
                                                "\t}\r\n};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{id}\"]\n" +
-                                               "\t.Request()\n" +
+                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
+                                               "\t.Request()\r\n" +
                                                "\t.UpdateAsync(@event);";
 
             //Assert the snippet generated is as expected
@@ -886,9 +886,9 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "var hasHeaders = true;\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Tables\n" +
-                                           "\t.Add(hasHeaders,address)\n" +
-                                           "\t.Request()\n" +
+                                           "await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Tables\r\n" +
+                                           "\t.Add(hasHeaders,address)\r\n" +
+                                           "\t.Request()\r\n" +
                                            "\t.PostAsync();";
 
             //Assert the snippet generated is as expected
@@ -909,8 +909,8 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{item-id}\"].Content\n" +
-                                           "\t.Request()\n" +
+            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{item-id}\"].Content\r\n" +
+                                           "\t.Request()\r\n" +
                                            "\t.GetAsync();";
 
             //Assert the snippet generated is as expected
@@ -943,8 +943,8 @@ namespace CodeSnippetsReflection.Test
                                            "\tContentBytes = Encoding.ASCII.GetBytes(\"R0lGODdhEAYEAA7\")\r\n" +
                                            "};\r\n" +
 
-                                           "\r\nawait graphClient.Me.Messages[\"AAMkpsDRVK\"].Attachments\n" +
-                                           "\t.Request()\n" +
+                                           "\r\nawait graphClient.Me.Messages[\"AAMkpsDRVK\"].Attachments\r\n" +
+                                           "\t.Request()\r\n" +
                                            "\t.AddAsync(attachment);";
 
             //Assert the snippet generated is as expected
@@ -983,8 +983,8 @@ namespace CodeSnippetsReflection.Test
                                                "\t}\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Drive.Root.Children\n" +
-                                               "\t.Request()\n" +
+                                           "await graphClient.Me.Drive.Root.Children\r\n" +
+                                               "\t.Request()\r\n" +
                                                "\t.AddAsync(driveItem);";
 
             //Assert the snippet generated is as expected
@@ -1008,9 +1008,9 @@ namespace CodeSnippetsReflection.Test
                                                 "\tnew QueryOption(\"$skiptoken\", \"R0usmcCM996atia_s\")" +
                                            "\r\n};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.CalendarView\n" +
-                                                "\t.Delta()\n" +
-                                                "\t.Request()\n" +
+                                           "await graphClient.Me.CalendarView\r\n" +
+                                                "\t.Delta()\r\n" +
+                                                "\t.Request()\r\n" +
                                                 "\t.PostAsync();";
 
             //Assert the snippet generated is as expected
@@ -1041,8 +1041,8 @@ namespace CodeSnippetsReflection.Test
                                                 "\tDescription = \"mySet\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.TermStore.Sets[\"{setId}\"]\n" +
-                                                "\t.Request()\n" +
+                                           "await graphClient.TermStore.Sets[\"{setId}\"]\r\n" +
+                                                "\t.Request()\r\n" +
                                                 "\t.UpdateAsync(set);";
 
             //Assert the snippet generated is as expected

--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -163,7 +163,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Select(\"displayName,givenName,postalCode\")", result);
+            Assert.Equal("\r\n\t.Select(\"displayName,givenName,postalCode\")", result);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Filter(\"startswith(givenName, 'J')\")", result);
+            Assert.Equal("\r\n\t.Filter(\"startswith(givenName, 'J')\")", result);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Search(\"Irene McGowen\")", result);
+            Assert.Equal("\r\n\t.Search(\"Irene McGowen\")", result);
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Skip(20)", result);
+            Assert.Equal("\r\n\t.Skip(20)", result);
         }
 
         [Fact]
@@ -227,7 +227,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Top(5)", result);
+            Assert.Equal("\r\n\t.Top(5)", result);
         }
 
         [Fact]
@@ -245,7 +245,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Header(\"Prefer\",\"kenya-timezone\")", result);
+            Assert.Equal("\r\n\t.Header(\"Prefer\",\"kenya-timezone\")", result);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Header(\"Prefer\",\"outlook.timezone=\\\"Pacific Standard Time\\\"\")", result);
+            Assert.Equal("\r\n\t.Header(\"Prefer\",\"outlook.timezone=\\\"Pacific Standard Time\\\"\")", result);
         }
         #endregion
 

--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -47,7 +47,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.select('displayName,givenName,postalCode')", result);
+            Assert.Equal("\r\n\t.select('displayName,givenName,postalCode')", result);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.filter('startswith(givenName, 'J')')", result);
+            Assert.Equal("\r\n\t.filter('startswith(givenName, 'J')')", result);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.search('Irene McGowen')", result);
+            Assert.Equal("\r\n\t.search('Irene McGowen')", result);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.skip(20)", result);
+            Assert.Equal("\r\n\t.skip(20)", result);
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.top(5)", result);
+            Assert.Equal("\r\n\t.top(5)", result);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.header('Prefer','kenya-timezone')", result);
+            Assert.Equal("\r\n\t.header('Prefer','kenya-timezone')", result);
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.header('Prefer','outlook.timezone=\"Pacific Standard Time\"')", result);
+            Assert.Equal("\r\n\t.header('Prefer','outlook.timezone=\"Pacific Standard Time\"')", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
@@ -362,8 +362,8 @@ namespace CodeSnippetsReflection.Test
                                            "passwordProfile.password = \"password-value\";\r\n" +
                                            "user.passwordProfile = passwordProfile;\r\n" +
                                            "\r\n" +
-                                           "graphClient.users()\n" +
-                                                "\t.buildRequest()\n" +
+                                           "graphClient.users()\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.post(user);";
 
             //Assert the snippet generated is as expected
@@ -400,8 +400,8 @@ namespace CodeSnippetsReflection.Test
                                            "user.businessPhones = businessPhonesList;\r\n" +
                                            "user.city = \"city-value\";\r\n" +
                                            "\r\n" +
-                                           "graphClient.me()\n" +
-                                                "\t.buildRequest()\n" +
+                                           "graphClient.me()\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.patch(user);";
 
             //Assert the snippet generated is as expected
@@ -468,8 +468,8 @@ namespace CodeSnippetsReflection.Test
                                            "toRecipientsList.add(toRecipients1);\r\n" +
                                            "message.toRecipients = toRecipientsList;\r\n" +
                                            "\r\n" +
-                                           "graphClient.me().messages()\n" +
-                                                "\t.buildRequest()\n" +
+                                           "graphClient.me().messages()\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.post(message);";
 
             //Assert the snippet generated is as expected
@@ -495,8 +495,8 @@ namespace CodeSnippetsReflection.Test
                                            "requestOptions.add(new QueryOption(\"startDateTime\", \"2017-01-01T19:00:00.0000000\"));\r\n" + //Query Options present
                                            "requestOptions.add(new QueryOption(\"endDateTime\", \"2017-01-07T19:00:00.0000000\"));\r\n" + //Query Options present
                                            "\r\n" +
-                                           "IEventCollectionPage calendarView = graphClient.me().calendar().calendarView()\n" +
-                                                "\t.buildRequest( requestOptions )\n" +
+                                           "IEventCollectionPage calendarView = graphClient.me().calendar().calendarView()\r\n" +
+                                                "\t.buildRequest( requestOptions )\r\n" +
                                                 "\t.get();";
 
             //Assert the snippet generated is as expected
@@ -523,9 +523,9 @@ namespace CodeSnippetsReflection.Test
             const string expectedSnippet = "LinkedList<Option> requestOptions = new LinkedList<Option>();\r\n" +
                                            "requestOptions.add(new HeaderOption(\"Prefer\", \"outlook.timezone=\\\"Pacific Standard Time\\\"\"));\r\n" + //Header Options present
                                            "\r\n" +
-                                           "Event event = graphClient.me().events(\"AAMkAGIAAAoZDOFAAA=\")\n" +
-                                                "\t.buildRequest( requestOptions )\n" +
-                                                "\t.select(\"subject,body,bodyPreview,organizer,attendees,start,end,location\")\n" +
+                                           "Event event = graphClient.me().events(\"AAMkAGIAAAoZDOFAAA=\")\r\n" +
+                                                "\t.buildRequest( requestOptions )\r\n" +
+                                                "\t.select(\"subject,body,bodyPreview,organizer,attendees,start,end,location\")\r\n" +
                                                 "\t.get();";
 
             //Assert the snippet generated is as expected
@@ -546,8 +546,8 @@ namespace CodeSnippetsReflection.Test
             var result = new JavaGenerator(_edmModel).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "graphClient.groups(\"{id}\").owners(\"{id}\").reference()\n" +
-                                                "\t.buildRequest()\n" +
+            const string expectedSnippet = "graphClient.groups(\"{id}\").owners(\"{id}\").reference()\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.delete();";
 
             //Assert the snippet generated is as expected
@@ -578,8 +578,8 @@ namespace CodeSnippetsReflection.Test
                                            "directoryObject.id = \"{id}\";\r\n" +
 
                                            "\r\n" +
-                                           "graphClient.groups(\"{id}\").owners().references()\n" +
-                                               "\t.buildRequest()\n" +
+                                           "graphClient.groups(\"{id}\").owners().references()\r\n" +
+                                               "\t.buildRequest()\r\n" +
                                                "\t.post(directoryObject);";
 
             //Assert the snippet generated is as expected
@@ -611,8 +611,8 @@ namespace CodeSnippetsReflection.Test
                                            "directoryObject.id = \"{id}\";\r\n" +
                                            "directoryObject.additionalDataManager().put(\"@odata.context\", new JsonPrimitive(\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\"));\r\n" +
                                            "\r\n" +
-                                           "graphClient.groups(\"{id}\").owners().references()\n" +
-                                           "\t.buildRequest()\n" +
+                                           "graphClient.groups(\"{id}\").owners().references()\r\n" +
+                                           "\t.buildRequest()\r\n" +
                                            "\t.post(directoryObject);";
 
             //Assert the snippet generated is as expected
@@ -643,8 +643,8 @@ namespace CodeSnippetsReflection.Test
                                            "directoryObject.id = \"ExampleID\";\r\n" +
 
                                            "\r\n" +
-                                           "graphClient.groups(\"{id}\").owners().references()\n" +
-                                           "\t.buildRequest()\n" +
+                                           "graphClient.groups(\"{id}\").owners().references()\r\n" +
+                                           "\t.buildRequest()\r\n" +
                                            "\t.post(directoryObject);";
 
             //Assert the snippet generated is as expected
@@ -666,9 +666,9 @@ namespace CodeSnippetsReflection.Test
             var result = new JavaGenerator(_edmModel).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "WorkbookRange workbookRange = graphClient.me().drive().items(\"{id}\").workbook().worksheets(\"{id|name}\")\n" +
-                                           "\t.range(\"A1:B2\")\n" +//parameter has double quotes
-                                           "\t.buildRequest()\n" +
+            const string expectedSnippet = "WorkbookRange workbookRange = graphClient.me().drive().items(\"{id}\").workbook().worksheets(\"{id|name}\")\r\n" +
+                                           "\t.range(\"A1:B2\")\r\n" +//parameter has double quotes
+                                           "\t.buildRequest()\r\n" +
                                            "\t.get();";
 
             //Assert the snippet generated is as expected
@@ -700,9 +700,9 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "Boolean hasHeaders = true;\r\n" +
                                            "\r\n" +
-                                           "graphClient.me().drive().items(\"{id}\").workbook().tables()\n" +
-                                                "\t.add(address,hasHeaders)\n" +
-                                                "\t.buildRequest()\n" +
+                                           "graphClient.me().drive().items(\"{id}\").workbook().tables()\r\n" +
+                                                "\t.add(address,hasHeaders)\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.post();";
 
             //Assert the snippet generated is as expected
@@ -733,8 +733,8 @@ namespace CodeSnippetsReflection.Test
                                            "attachment.name = \"smile\";\r\n" +
                                            "attachment.contentBytes = Base64.getDecoder().decode(\"R0lGODdhEAYEAA7\");\r\n" +
                                            "\r\n" +
-                                           "graphClient.me().messages(\"AAMkpsDRVK\").attachments()\n" +
-                                           "\t.buildRequest()\n" +
+                                           "graphClient.me().messages(\"AAMkpsDRVK\").attachments()\r\n" +
+                                           "\t.buildRequest()\r\n" +
                                            "\t.post(attachment);";
 
             //Assert the snippet generated is as expected
@@ -768,8 +768,8 @@ namespace CodeSnippetsReflection.Test
                                            "driveItem.folder = folder;\r\n" +
                                            "driveItem.additionalDataManager().put(\"@microsoft.graph.conflictBehavior\", new JsonPrimitive(\"rename\"));\r\n" +
                                            "\r\n" +
-                                           "graphClient.me().drive().root().children()\n" +
-                                                "\t.buildRequest()\n" +
+                                           "graphClient.me().drive().root().children()\r\n" +
+                                                "\t.buildRequest()\r\n" +
                                                 "\t.post(driveItem);";
 
             //Assert the snippet generated is as expected

--- a/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
@@ -11,7 +11,7 @@ namespace CodeSnippetsReflection.Test
     {
         private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
         private readonly IEdmModel _edmModel = CsdlReader.Parse(XmlReader.Create(CommonGeneratorShould.CleanV1Metadata));
-        private const string AuthProviderPrefix = "const options = {\n\tauthProvider,\n};\n\nconst client = Client.init(options);\n\n";
+        private const string AuthProviderPrefix = "const options = {\r\n\tauthProvider,\r\n};\r\n\r\nconst client = Client.init(options);\r\n\r\n";
 
         [Fact]
         //This tests asserts that we can generate snippets from json objects with nested objects inside them.
@@ -85,7 +85,7 @@ namespace CodeSnippetsReflection.Test
                                            "  ]\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "let res = await client.api('/users')\n" +
+                                           "let res = await client.api('/users')\r\n" +
                                            "\t.post(user);";
 
             //Assert the snippet generated is as expected
@@ -126,7 +126,7 @@ namespace CodeSnippetsReflection.Test
                                            "  }\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "let res = await client.api('/users')\n" +
+                                           "let res = await client.api('/users')\r\n" +
                                            "\t.post(user);";
 
             //Assert the snippet generated is as expected
@@ -162,7 +162,7 @@ namespace CodeSnippetsReflection.Test
                                                "city: \"city-value\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "let res = await client.api('/me')\n\t.update(user);";
+                                           "let res = await client.api('/me')\r\n\t.update(user);";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
@@ -183,7 +183,7 @@ namespace CodeSnippetsReflection.Test
             var result = JavaScriptGenerator.GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "let res = await client.api('/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000')\n\t.get();";
+            const string expectedSnippet = "let res = await client.api('/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000')\r\n\t.get();";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -67,7 +67,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         actions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions);
                     }
                     snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.GetAsync();"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.GetAsync();"));
                     snippetBuilder.Append(extraSnippet);
 
                 }
@@ -83,7 +83,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
                             snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
                             snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
-                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.AddAsync({snippetModel.ResponseVariableName});"));
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.AddAsync({snippetModel.ResponseVariableName});"));
 
                             break;
 
@@ -137,7 +137,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     snippetBuilder.Append($"{typeHintOnTheLeftHandSide} {parameter} = {value}");
                                 }
                             }
-                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.PostAsync();"));
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.PostAsync();"));
                             break;
                         default:
                             throw new Exception("Unknown Segment Type in URI for method POST");
@@ -156,11 +156,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         snippetBuilder.Append(GeneratePropertySectionSnippet(snippetModel));
                     }
 
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.UpdateAsync({snippetModel.ResponseVariableName});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.UpdateAsync({snippetModel.ResponseVariableName});"));
                 }
                 else if (snippetModel.Method == HttpMethod.Delete)
                 {
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.DeleteAsync();"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.DeleteAsync();"));
                 }
                 else if (snippetModel.Method == HttpMethod.Put)
                 {
@@ -190,7 +190,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     }
                     else
                     {
-                        snippetBuilder.Append($"using var {snippetModel.ResponseVariableName} = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(\"{snippetModel.RequestBody.Trim()}\"));\n\n");
+                        snippetBuilder.Append($"using var {snippetModel.ResponseVariableName} = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(\"{snippetModel.RequestBody.Trim()}\"));\r\n\r\n");
 
                         // resolve type for PutAsync<T>
                         var genericEdmType = snippetModel.Segments[snippetModel.Segments.Count - 2].EdmType;
@@ -200,7 +200,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         }
                     }
 
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.PutAsync{genericType}({objectToBePut});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.PutAsync{genericType}({objectToBePut});"));
 
                 }
                 else
@@ -261,7 +261,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 return x;
                             }
                         }));
-                        resourcesPath.Append($"\n\t.{CommonGenerator.UppercaseFirstLetter(operationSegment.Identifier)}({parameters})");
+                        resourcesPath.Append($"\r\n\t.{CommonGenerator.UppercaseFirstLetter(operationSegment.Identifier)}({parameters})");
                         break;
                     case ValueSegment _:
                         resourcesPath.Append(".Content");
@@ -685,7 +685,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Generate the Resources path for Csharp
             stringBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
             //check if there are any custom query options appended
-            stringBuilder.Append(snippetModel.CustomQueryOptions.Any() ? "\n\t.Request( queryOptions )" : "\n\t.Request()");
+            stringBuilder.Append(snippetModel.CustomQueryOptions.Any() ? "\r\n\t.Request( queryOptions )" : "\r\n\t.Request()");
             //Append footers
             stringBuilder.Append(actions);
 
@@ -768,13 +768,13 @@ namespace CodeSnippetsReflection.LanguageGenerators
             {
                 //we are retrieving the value
                 snippetModel.SelectFieldList.Add(selectField);
-                stringBuilder.Append($"\n\nvar {variableName} = {snippetModel.ResponseVariableName}{properties};");
+                stringBuilder.Append($"\r\n\r\nvar {variableName} = {snippetModel.ResponseVariableName}{properties};");
             }
             else
             {
                 //we are modifying the value
                 stringBuilder.Append($"var {snippetModel.ResponseVariableName} = new {parentClassName}();");//initialise the classname
-                stringBuilder.Append($"\n{snippetModel.ResponseVariableName}{properties} = {propertyName};\n\n");
+                stringBuilder.Append($"\r\n{snippetModel.ResponseVariableName}{properties} = {propertyName};\r\n\r\n");
             }
 
             return stringBuilder.ToString();
@@ -865,18 +865,18 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
     internal class CSharpExpressions : LanguageExpressions
     {
-        public override string FilterExpression => "\n\t.Filter(\"{0}\")";
-        public override string SearchExpression => "\n\t.Search(\"{0}\")";
-        public override string ExpandExpression => "\n\t.Expand(\"{0}\")";
-        public override string SelectExpression => "\n\t.Select(\"{0}\")";
-        public override string OrderByExpression => "\n\t.OrderBy(\"{0}\")";
-        public override string SkipExpression => "\n\t.Skip({0})";
+        public override string FilterExpression => "\r\n\t.Filter(\"{0}\")";
+        public override string SearchExpression => "\r\n\t.Search(\"{0}\")";
+        public override string ExpandExpression => "\r\n\t.Expand(\"{0}\")";
+        public override string SelectExpression => "\r\n\t.Select(\"{0}\")";
+        public override string OrderByExpression => "\r\n\t.OrderBy(\"{0}\")";
+        public override string SkipExpression => "\r\n\t.Skip({0})";
         public override string SkipTokenExpression => "";
-        public override string TopExpression => "\n\t.Top({0})";
+        public override string TopExpression => "\r\n\t.Top({0})";
         public override string FilterExpressionDelimiter => ",";
         public override string SelectExpressionDelimiter => ",";
         public override string OrderByExpressionDelimiter => " ";
-        public override string HeaderExpression => "\n\t.Header(\"{0}\",\"{1}\")";
+        public override string HeaderExpression => "\r\n\t.Header(\"{0}\",\"{1}\")";
 
         public override string[] ReservedNames => new string[] {
             "abstract","as","base","bool","break","byte","case","catch","char",

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -57,7 +57,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     if (segment is PropertySegment)
                         return GenerateCustomRequestForPropertySegment(snippetBuilder, snippetModel);
 
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.get();"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.get();"));
                 }
                 else if (snippetModel.Method == HttpMethod.Post)
                 {
@@ -70,7 +70,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 throw new Exception("No request Body present for Java POST request");
 
                             snippetBuilder.Append(JavaGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
-                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.post({snippetModel.ResponseVariableName});"));
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.post({snippetModel.ResponseVariableName});"));
                             break;
 
                         case OperationSegment _:
@@ -83,7 +83,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     snippetBuilder.Append(JavaGenerateObjectFromJson(segment, jsonString, new List<string> { CommonGenerator.LowerCaseFirstLetter(key) }));
                                 }
                             }
-                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.post();"));
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.post();"));
                             break;
                         default:
                             throw new Exception("Unknown Segment Type in URI for method POST");
@@ -99,7 +99,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     if (segment is PropertySegment)
                         return GenerateCustomRequestForPropertySegment(snippetBuilder, snippetModel);
 
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.patch({snippetModel.ResponseVariableName});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.patch({snippetModel.ResponseVariableName});"));
                 }
                 else if (snippetModel.Method == HttpMethod.Put)
                 {
@@ -109,12 +109,12 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     if (snippetModel.ContentType?.Contains("json") ?? false)
                         snippetBuilder.Append(JavaGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
                     else
-                        snippetBuilder.Append($"byte[] {snippetModel.ResponseVariableName} = Base64.getDecoder().decode({AddQuotesIfMising(snippetModel.RequestBody?.Replace("\n", string.Empty)?.Replace("\r", string.Empty))});\n\t");
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.put({snippetModel.ResponseVariableName});"));
+                        snippetBuilder.Append($"byte[] {snippetModel.ResponseVariableName} = Base64.getDecoder().decode({AddQuotesIfMising(snippetModel.RequestBody?.Replace("\n", string.Empty)?.Replace("\r", string.Empty))});\r\n\t");
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.put({snippetModel.ResponseVariableName});"));
                 }
                 else if (snippetModel.Method == HttpMethod.Delete)
                 {
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\n\t.delete();"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{requestActions}\r\n\t.delete();"));
                 }
                 else
                 {
@@ -139,10 +139,10 @@ namespace CodeSnippetsReflection.LanguageGenerators
         private string GenerateCustomRequestForPropertySegment(StringBuilder stringBuilder, SnippetModel snippetModel)
         {
             stringBuilder.Append($"graphClient.customRequest(\"{snippetModel.Path}\", { GetJavaReturnTypeName(snippetModel.Segments.Last()) }.class)");
-            stringBuilder.Append(JavaModelHasRequestOptionsParameters(snippetModel) ? "\n\t.buildRequest( requestOptions )" : "\n\t.buildRequest()");
+            stringBuilder.Append(JavaModelHasRequestOptionsParameters(snippetModel) ? "\r\n\t.buildRequest( requestOptions )" : "\r\n\t.buildRequest()");
             stringBuilder.Append(snippetModel.Method == HttpMethod.Get
-                ? "\n\t.get();"
-                : $"\n\t.patch({snippetModel.ResponseVariableName});");
+                ? "\r\n\t.get();"
+                : $"\r\n\t.patch({snippetModel.ResponseVariableName});");
 
             return stringBuilder.ToString();
         }
@@ -567,7 +567,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             stringBuilder.Append("graphClient");
             stringBuilder.Append(JavaGenerateResourcesPath(snippetModel));//Generate the Resources path for Csharp
             //check if there are any custom query options appended
-            stringBuilder.Append(JavaModelHasRequestOptionsParameters(snippetModel) ? "\n\t.buildRequest( requestOptions )" : "\n\t.buildRequest()");
+            stringBuilder.Append(JavaModelHasRequestOptionsParameters(snippetModel) ? "\r\n\t.buildRequest( requestOptions )" : "\r\n\t.buildRequest()");
             stringBuilder.Append(requestActions);//Append footers
             return stringBuilder.ToString();
         }
@@ -595,7 +595,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     //handle functions/requestActions and any parameters present into collections
                     case OperationSegment operationSegment:
                         var paramList = CommonGenerator.GetParameterListFromOperationSegment(operationSegment, snippetModel, "List", false);
-                        resourcesPath.Append($"\n\t.{CommonGenerator.LowerCaseFirstLetter(operationSegment.Identifier)}({string.Join(",", paramList)})");
+                        resourcesPath.Append($"\r\n\t.{CommonGenerator.LowerCaseFirstLetter(operationSegment.Identifier)}({string.Join(",", paramList)})");
                         break;
                     case ReferenceSegment _:
                         resourcesPath.Append(".reference()");
@@ -707,17 +707,17 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
     internal class JavaExpressions : LanguageExpressions
     {
-        public override string ExpandExpression => "\n\t.expand(\"{0}\")";
-        public override string SelectExpression => "\n\t.select(\"{0}\")";
+        public override string ExpandExpression => "\r\n\t.expand(\"{0}\")";
+        public override string SelectExpression => "\r\n\t.select(\"{0}\")";
         public override string SelectExpressionDelimiter => ",";
-        public override string TopExpression => "\n\t.top({0})";
-        public override string FilterExpression => "\n\t.filter(\"{0}\")";
+        public override string TopExpression => "\r\n\t.top({0})";
+        public override string FilterExpression => "\r\n\t.filter(\"{0}\")";
         public override string FilterExpressionDelimiter => ",";
         public override string SearchExpression => string.Empty;
-        public override string SkipExpression => "\n\t.skip({0})";
+        public override string SkipExpression => "\r\n\t.skip({0})";
         public override string HeaderExpression => string.Empty;
-        public override string SkipTokenExpression => "\n\t.skipToken(\"{0}\")";
-        public override string OrderByExpression => "\n\t.orderBy(\"{0}\")";
+        public override string SkipTokenExpression => "\r\n\t.skipToken(\"{0}\")";
+        public override string OrderByExpression => "\r\n\t.orderBy(\"{0}\")";
         public override string OrderByExpressionDelimiter => " ";
         public override string[] ReservedNames => new[] {
             "abstract","assert","boolean","break","byte","case","catch","char",

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -23,15 +23,15 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 var snippetBuilder = new StringBuilder();
                 snippetModel.ResponseVariableName = CommonGenerator.EnsureVariableNameIsNotReserved(snippetModel.ResponseVariableName,languageExpressions);
                 //setup the auth snippet section
-                snippetBuilder.Append("const options = {\n");
-                snippetBuilder.Append("\tauthProvider,\n};\n\n");
+                snippetBuilder.Append("const options = {\r\n");
+                snippetBuilder.Append("\tauthProvider,\r\n};\r\n\r\n");
                 //init the client
-                snippetBuilder.Append("const client = Client.init(options);\n\n");
+                snippetBuilder.Append("const client = Client.init(options);\r\n\r\n");
 
                 if (snippetModel.Method == HttpMethod.Get)
                 {
                     //append any queries with the actions
-                    var getActions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions) + "\n\t.get();";
+                    var getActions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions) + "\r\n\t.get();";
                     snippetBuilder.Append(GenerateRequestSection(snippetModel, getActions));
                 }
                 else if (snippetModel.Method == HttpMethod.Post)
@@ -39,11 +39,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     if (!string.IsNullOrEmpty(snippetModel.RequestBody))
                     {
                         snippetBuilder.Append(JavascriptGenerateObjectFromJson(snippetModel.RequestBody, snippetModel.ResponseVariableName));
-                        snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\n\t.post({snippetModel.ResponseVariableName});"));
+                        snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\r\n\t.post({snippetModel.ResponseVariableName});"));
                     }
                     else
                     {
-                        snippetBuilder.Append(GenerateRequestSection(snippetModel, "\n\t.post();"));
+                        snippetBuilder.Append(GenerateRequestSection(snippetModel, "\r\n\t.post();"));
                     }
                 }
                 else if (snippetModel.Method == HttpMethod.Patch)
@@ -52,11 +52,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         throw new Exception("No body present for PATCH method in Javascript");
 
                     snippetBuilder.Append(JavascriptGenerateObjectFromJson(snippetModel.RequestBody, snippetModel.ResponseVariableName));
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\n\t.update({snippetModel.ResponseVariableName});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\r\n\t.update({snippetModel.ResponseVariableName});"));
                 }
                 else if (snippetModel.Method == HttpMethod.Delete)
                 {
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, "\n\t.delete();"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, "\r\n\t.delete();"));
                 }
                 else if (snippetModel.Method == HttpMethod.Put)
                 {
@@ -64,7 +64,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         throw new Exception("No body present for PUT method in Javascript");
 
                     snippetBuilder.Append(JavascriptGenerateObjectFromJson(snippetModel.RequestBody, snippetModel.ResponseVariableName));
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\n\t.put({snippetModel.ResponseVariableName});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\r\n\t.put({snippetModel.ResponseVariableName});"));
                 }
                 else
                 {
@@ -86,7 +86,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <returns>String of the snippet in JS code</returns>
         private static string BetaSectionString(string apiVersion)
         {
-            return apiVersion.Equals("beta",StringComparison.Ordinal) ? "\n\t.version('beta')" : "";
+            return apiVersion.Equals("beta",StringComparison.Ordinal) ? "\r\n\t.version('beta')" : "";
         }
 
         /// <summary>
@@ -134,14 +134,14 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
     internal class JavascriptExpressions : LanguageExpressions
     {
-        public override string FilterExpression => "\n\t.filter('{0}')"; 
-        public override string SearchExpression => "\n\t.search('{0}')"; 
-        public override string ExpandExpression => "\n\t.expand('{0}')"; 
-        public override string SelectExpression => "\n\t.select('{0}')"; 
-        public override string OrderByExpression => "\n\t.orderby('{0}')"; 
-        public override string SkipExpression => "\n\t.skip({0})"; 
-        public override string SkipTokenExpression  => "\n\t.skiptoken('{0}')"; 
-        public override string TopExpression => "\n\t.top({0})"; 
+        public override string FilterExpression => "\r\n\t.filter('{0}')"; 
+        public override string SearchExpression => "\r\n\t.search('{0}')"; 
+        public override string ExpandExpression => "\r\n\t.expand('{0}')"; 
+        public override string SelectExpression => "\r\n\t.select('{0}')"; 
+        public override string OrderByExpression => "\r\n\t.orderby('{0}')"; 
+        public override string SkipExpression => "\r\n\t.skip({0})"; 
+        public override string SkipTokenExpression  => "\r\n\t.skiptoken('{0}')"; 
+        public override string TopExpression => "\r\n\t.top({0})"; 
 
         public override string FilterExpressionDelimiter => ",";
 
@@ -149,7 +149,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
         public override string OrderByExpressionDelimiter => " ";
 
-        public override string HeaderExpression => "\n\t.header('{0}','{1}')";
+        public override string HeaderExpression => "\r\n\t.header('{0}','{1}')";
 
         public override string[] ReservedNames => new string [] {
             "await","abstract", "arguments", "boolean", "break", "byte", "case",

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -71,7 +71,7 @@ namespace GraphWebApi.Controllers
         public async Task ExecuteResultAsync(ActionContext context)
         {
             context.HttpContext.Response.ContentType = "text/plain";
-            using var streamWriter = new StreamWriter(context.HttpContext.Response.Body);
+            var streamWriter = new StreamWriter(context.HttpContext.Response.Body);
             streamWriter.Write(this._value);
             await streamWriter.FlushAsync().ConfigureAwait(false);
         }

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -71,8 +71,8 @@ namespace GraphWebApi.Controllers
         public async Task ExecuteResultAsync(ActionContext context)
         {
             context.HttpContext.Response.ContentType = "text/plain";
-            var streamWriter = new StreamWriter(context.HttpContext.Response.Body);
-            streamWriter.Write(this._value);
+            using var streamWriter = new StreamWriter(context.HttpContext.Response.Body);
+            await streamWriter.WriteAsync(this._value);
             await streamWriter.FlushAsync().ConfigureAwait(false);
         }
     }

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -72,7 +72,7 @@ namespace GraphWebApi.Controllers
         {
             context.HttpContext.Response.ContentType = "text/plain";
             using var streamWriter = new StreamWriter(context.HttpContext.Response.Body);
-            await streamWriter.WriteAsync(this._value);
+            streamWriter.Write(this._value);
             await streamWriter.FlushAsync().ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Used `\r\n` as the majority of newline constants seemed to use that sequence.

Fixes #459