### PR TITLE
Quote fixes in JavascriptGenerateObjectFromJson

### DIFF
--- a/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
@@ -58,29 +58,29 @@ namespace CodeSnippetsReflection.Test
 
             //Assert code snippet string matches expectation
             const string expectedSnippet = "const user = {\r\n" +
-                                           "  subject: \"Let's go for lunch\",\r\n" +
+                                           "  subject: 'Let's go for lunch',\r\n" +
                                            "  body: {\r\n" +
-                                           "    contentType: \"HTML\",\r\n" +
-                                           "    content: \"Does mid month work for you?\"\r\n" +
+                                           "    contentType: 'HTML',\r\n" +
+                                           "    content: 'Does mid month work for you?'\r\n" +
                                            "  },\r\n" +
                                            "  start: {\r\n" +
-                                           "      dateTime: \"2019-03-15T12:00:00\",\r\n" +
-                                           "      timeZone: \"Pacific Standard Time\"\r\n" +
+                                           "      dateTime: '2019-03-15T12:00:00',\r\n" +
+                                           "      timeZone: 'Pacific Standard Time'\r\n" +
                                            "  },\r\n" +
                                            "  end: {\r\n" +
-                                           "      dateTime: \"2019-03-15T14:00:00\",\r\n" +
-                                           "      timeZone: \"Pacific Standard Time\"\r\n" +
+                                           "      dateTime: '2019-03-15T14:00:00',\r\n" +
+                                           "      timeZone: 'Pacific Standard Time'\r\n" +
                                            "  },\r\n" +
-                                           "  location:{\r\n" +
-                                           "      displayName:\"Harry's Bar\"\r\n" +
+                                           "  location: {\r\n" +
+                                           "      displayName: 'Harry's Bar'\r\n" +
                                            "  },\r\n" +
                                            "  attendees: [\r\n" +
                                            "    {\r\n" +
                                            "      emailAddress: {\r\n" +
-                                           "        address:\"adelev@contoso.onmicrosoft.com\",\r\n" +
-                                           "        name: \"Adele Vance\"\r\n" +
+                                           "        address: 'adelev@contoso.onmicrosoft.com',\r\n" +
+                                           "        name: 'Adele Vance'\r\n" +
                                            "      },\r\n" +
-                                           "      type: \"required\"\r\n" +
+                                           "      type: 'required'\r\n" +
                                            "    }\r\n" +
                                            "  ]\r\n" +
                                            "};\r\n" +
@@ -117,12 +117,12 @@ namespace CodeSnippetsReflection.Test
             //Assert code snippet string matches expectation
             const string expectedSnippet = "const user = {\r\n" +
                                            "  accountEnabled: true,\r\n" +
-                                           "  displayName: \"displayName-value\",\r\n" +
-                                           "  mailNickname: \"mailNickname-value\",\r\n" +
-                                           "  userPrincipalName: \"upn-value@tenant-value.onmicrosoft.com\",\r\n" +
-                                           "  \"passwordProfile\" : {\r\n" +
+                                           "  displayName: 'displayName-value',\r\n" +
+                                           "  mailNickname: 'mailNickname-value',\r\n" +
+                                           "  userPrincipalName: 'upn-value@tenant-value.onmicrosoft.com',\r\n" +
+                                           "  passwordProfile: {\r\n" +
                                            "    forceChangePasswordNextSignIn: true,\r\n" +
-                                           "    password: \"password-value\"\r\n" +
+                                           "    password: 'password-value'\r\n" +
                                            "  }\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
@@ -157,9 +157,9 @@ namespace CodeSnippetsReflection.Test
             const string expectedSnippet = "const user = {\r\n  " +
                                                "accountEnabled: true,\r\n  " +
                                                "businessPhones: [\r\n" +
-                                               "    \"businessPhones-value\",\"businessPhones-value2\",\"businessPhones-value3\"\r\n" +
+                                               "    'businessPhones-value','businessPhones-value2','businessPhones-value3'\r\n" +
                                                "  ],\r\n  " +
-                                               "city: \"city-value\"\r\n" +
+                                               "city: 'city-value'\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
                                            "let res = await client.api('/me')\r\n\t.update(user);";
@@ -184,6 +184,38 @@ namespace CodeSnippetsReflection.Test
 
             //Assert code snippet string matches expectation
             const string expectedSnippet = "let res = await client.api('/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000')\r\n\t.get();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
+        [Fact]
+        // This test asserts that we can generate snippets with @odata properties
+        public void GenerateSnippetsWithOdataProperties()
+        {
+            //Arrange
+            LanguageExpressions expressions = new JavascriptExpressions();C:\Source\Repos\microsoft-graph-recipes\SnippetGen\Generation\JavaScriptCodeGenerator.cs
+
+            const string directoryObj = "{\r\n  \"@odata.id\": \"https://graph.microsoft.com/v1.0/users/{id}\"\r\n}";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Put,
+                "https://graph.microsoft.com/v1.0/users/{id}/manager/$ref")
+            {
+                Content = new StringContent(directoryObj)
+            };
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = JavaScriptGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "const directoryObject = {\r\n" +
+                "  '@odata.id': 'https://graph.microsoft.com/v1.0/users/{id}'\r\n" + 
+                "};\r\n" +
+                "\r\n" +
+                "let res = await client.api('/users/{id}/manager/$ref')\r\n" +
+                "\t.put(directoryObject);";
 
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);

--- a/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavascriptGeneratorShould.cs
@@ -194,7 +194,7 @@ namespace CodeSnippetsReflection.Test
         public void GenerateSnippetsWithOdataProperties()
         {
             //Arrange
-            LanguageExpressions expressions = new JavascriptExpressions();C:\Source\Repos\microsoft-graph-recipes\SnippetGen\Generation\JavaScriptCodeGenerator.cs
+            LanguageExpressions expressions = new JavascriptExpressions();
 
             const string directoryObj = "{\r\n  \"@odata.id\": \"https://graph.microsoft.com/v1.0/users/{id}\"\r\n}";
 

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -124,9 +124,20 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 return "";//nothing to generate with no body
 
             var stringBuilder = new StringBuilder();
-            //remove the quotation marks from the JSON keys
-            const string pattern = "\"(.*?) *\":";
-            var javascriptObject = Regex.Replace(jsonBody.Trim(), pattern, "$1:");
+            // Remove the quotation marks from the JSON keys
+            // EXCEPT ones with punctuation in them (like @odata.id)
+            var javascriptObject = Regex.Replace(jsonBody.Trim(), @"""(\w*?)"" *: *", "$1: ");
+
+            // Replace double-quotes in any remaining keys with
+            // single quotes
+            javascriptObject = Regex.Replace(javascriptObject, @"""(.*?)"" *:", "'$1':");
+
+            // Replace double quotes in all values with single-quotes (`)
+            // Yes this Regex looks insane - it's there to weed out any escaped double-quotes
+            // (like in the value "Bob says \"Hello!\""
+            javascriptObject = Regex.Replace(javascriptObject,
+                @"(?<!\\)(?:\\\\)*""(.*?)(?<!\\)(?:\\\\)*""", "'$1'");
+
             stringBuilder.Append($"const {variableName} = {javascriptObject};");
             stringBuilder.Append("\r\n\r\n");
             return stringBuilder.ToString();

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -124,15 +124,19 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 return "";//nothing to generate with no body
 
             var stringBuilder = new StringBuilder();
+
+            // Escape any single-quotes in values
+            var javascriptObject = jsonBody.Trim().Replace("'", "\\'");
+
             // Remove the quotation marks from the JSON keys
             // EXCEPT ones with punctuation in them (like @odata.id)
-            var javascriptObject = Regex.Replace(jsonBody.Trim(), @"""(\w*?)"" *: *", "$1: ");
+            javascriptObject = Regex.Replace(javascriptObject, @"""(\w*?)"" *: *", "$1: ");
 
             // Replace double-quotes in any remaining keys with
             // single quotes
             javascriptObject = Regex.Replace(javascriptObject, @"""(.*?)"" *:", "'$1':");
 
-            // Replace double quotes in all values with single-quotes (`)
+            // Replace double quotes in all values with single-quotes (')
             // Yes this Regex looks insane - it's there to weed out any escaped double-quotes
             // (like in the value "Bob says \"Hello!\""
             javascriptObject = Regex.Replace(javascriptObject,


### PR DESCRIPTION
- Changed regex that stripped quotes from key names to skip keys with punctuation.
- Added additional regex to change those to single-quotes.
- Added additional regex to replace surrounding double-quotes on values to single quotes.

These changes also force consistent spacing around the colon in JSON objects.

Fixes #476 
Fixes #477