### PR TITLE
Consistent ID placeholders in C# snippets

### DIFF
--- a/CodeSnippetsReflection.App/Program.cs
+++ b/CodeSnippetsReflection.App/Program.cs
@@ -79,8 +79,8 @@ namespace CodeSnippetsReflection.App
             }
 
             var generator = customMetadataPathArg.Exists()
-                ? new SnippetsGenerator(customMetadataPathArg.Value)
-                : new SnippetsGenerator();
+                ? new SnippetsGenerator(isCommandLine: true, customMetadataPathArg.Value)
+                : new SnippetsGenerator(isCommandLine: true);
             var files = Directory.EnumerateFiles(httpSnippetsDir, "*-httpSnippet");
 
             Console.WriteLine($"Running snippet generation for these languages: {string.Join(" ", supportedLanguages)}");

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -207,8 +207,8 @@ namespace CodeSnippetsReflection.Test
 
             // Assert that stream is set as a property of a full object and full object is passed in in the PATCH request.
             Assert.Contains("pages.Content = stream;", result);
-            Assert.Contains("await graphClient.Me.Onenote.Pages[\"{id}\"]", result);
-            Assert.DoesNotContain("await graphClient.Me.Onenote.Pages[\"{id}\"].Content", result);
+            Assert.Contains("await graphClient.Me.Onenote.Pages[\"{onenotePage-id}\"]", result);
+            Assert.DoesNotContain("await graphClient.Me.Onenote.Pages[\"{onenotePage-id}\"].Content", result);
             Assert.Contains("UpdateAsync(pages)", result);
         }
 
@@ -405,7 +405,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "await graphClient.Groups[\"{id}\"].Owners[\"{id}\"].Reference\r\n" +
+            const string expectedSnippet = "await graphClient.Groups[\"{group-id}\"].Owners[\"{directoryObject-id}\"].Reference\r\n" +
                                         "\t.Request()\r\n" +
                                         "\t.DeleteAsync();";
 
@@ -438,7 +438,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
                                                 "\r\n\t.Request()" +
                                                 "\r\n\t.AddAsync(directoryObject);";
 
@@ -471,7 +471,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
                                            "\r\n\t.Request()" +
                                            "\r\n\t.AddAsync(directoryObject);";
 
@@ -510,7 +510,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
                                            "\r\n\t.Request()" +
                                            "\r\n\t.AddAsync(directoryObject);";
 
@@ -533,7 +533,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Worksheets[\"{id|name}\"]\r\n" +
+            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"]\r\n" +
                                                "\t.Range(\"A1:B2\")\r\n" +//parameter has double quotes
                                                "\t.Request()\r\n" +
                                                "\t.GetAsync();";
@@ -585,7 +585,7 @@ namespace CodeSnippetsReflection.Test
                                                "\tBodyPreview = \"bodyPreview-value\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.MailFolders[\"{id}\"].Messages\r\n" +
+                                           "await graphClient.Me.MailFolders[\"{mailFolder-id}\"].Messages\r\n" +
                                                "\t.Request()\r\n" +
                                                "\t.AddAsync(message);";
 
@@ -735,7 +735,7 @@ namespace CodeSnippetsReflection.Test
                                            "\tIsReminderOn = true\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
+                                           "await graphClient.Me.Events[\"{event-id}\"]\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.UpdateAsync(@event);";
 
@@ -854,7 +854,7 @@ namespace CodeSnippetsReflection.Test
                                                    "\t\t}\r\n" +
                                                "\t}\r\n};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
+                                           "await graphClient.Me.Events[\"{event-id}\"]\r\n" +
                                                "\t.Request()\r\n" +
                                                "\t.UpdateAsync(@event);";
 
@@ -886,7 +886,7 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "var hasHeaders = true;\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Tables\r\n" +
+                                           "await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Workbook.Tables\r\n" +
                                            "\t.Add(hasHeaders,address)\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.PostAsync();";
@@ -909,7 +909,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{item-id}\"].Content\r\n" +
+            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Content\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.GetAsync();";
 
@@ -943,7 +943,7 @@ namespace CodeSnippetsReflection.Test
                                            "\tContentBytes = Encoding.ASCII.GetBytes(\"R0lGODdhEAYEAA7\")\r\n" +
                                            "};\r\n" +
 
-                                           "\r\nawait graphClient.Me.Messages[\"AAMkpsDRVK\"].Attachments\r\n" +
+                                           "\r\nawait graphClient.Me.Messages[\"{message-id}\"].Attachments\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.AddAsync(attachment);";
 
@@ -1041,7 +1041,7 @@ namespace CodeSnippetsReflection.Test
                                                 "\tDescription = \"mySet\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.TermStore.Sets[\"{setId}\"]\r\n" +
+                                           "await graphClient.TermStore.Sets[\"{termStore.set-id}\"]\r\n" +
                                                 "\t.Request()\r\n" +
                                                 "\t.UpdateAsync(set);";
 

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1049,5 +1049,40 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
 
+        [Fact]
+        public void CreatesPlaceHolderIDForCommandLineCaller()
+        {
+            const bool isCommandLine = true; // Command line caller (e.g. generation pipeline for the docs)
+
+            const string itemIdFromOriginalSnippet = "{item-id-from-original-snippet}";
+            const string itemIdBasedOnTypeInformation = "{driveItem-id}";
+
+            var expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/me/drive/items/{itemIdFromOriginalSnippet}/content");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
+
+            var result = new CSharpGenerator(_edmModel.Value, isCommandLine).GenerateCodeSnippet(snippetModel, expressions);
+
+            Assert.Contains(itemIdBasedOnTypeInformation, result);
+            Assert.DoesNotContain(itemIdFromOriginalSnippet, result);
+        }
+
+        [Fact]
+        public void UsesIDFromHTTPSnippetForDevXAPICallers()
+        {
+            const bool isCommandLine = false; // DevX API caller (e.g. Graph Explorer "Code Snippets" tab)
+
+            const string itemIdFromOriginalSnippet = "{item-id-from-original-snippet}";
+            const string itemIdBasedOnTypeInformation = "{driveItem-id}";
+
+            var expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/me/drive/items/{itemIdFromOriginalSnippet}/content");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
+
+            var result = new CSharpGenerator(_edmModel.Value, isCommandLine).GenerateCodeSnippet(snippetModel, expressions);
+
+            Assert.DoesNotContain(itemIdBasedOnTypeInformation, result);
+            Assert.Contains(itemIdFromOriginalSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1072,17 +1072,17 @@ namespace CodeSnippetsReflection.Test
         {
             const bool isCommandLine = false; // DevX API caller (e.g. Graph Explorer "Code Snippets" tab)
 
-            const string itemIdFromOriginalSnippet = "{item-id-from-original-snippet}";
+            const string itemIdFromDevXApiSnippet = "e56b1746-25a4-4a4e-86cf-a7223fa1fee1";
             const string itemIdBasedOnTypeInformation = "{driveItem-id}";
 
             var expressions = new CSharpExpressions();
-            var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/me/drive/items/{itemIdFromOriginalSnippet}/content");
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/me/drive/items/{itemIdFromDevXApiSnippet}/content");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
 
             var result = new CSharpGenerator(_edmModel.Value, isCommandLine).GenerateCodeSnippet(snippetModel, expressions);
 
             Assert.DoesNotContain(itemIdBasedOnTypeInformation, result);
-            Assert.Contains(itemIdFromOriginalSnippet, result);
+            Assert.Contains(itemIdFromDevXApiSnippet, result);
         }
     }
 }

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -207,8 +207,8 @@ namespace CodeSnippetsReflection.Test
 
             // Assert that stream is set as a property of a full object and full object is passed in in the PATCH request.
             Assert.Contains("pages.Content = stream;", result);
-            Assert.Contains("await graphClient.Me.Onenote.Pages[\"{onenotePage-id}\"]", result);
-            Assert.DoesNotContain("await graphClient.Me.Onenote.Pages[\"{onenotePage-id}\"].Content", result);
+            Assert.Contains("await graphClient.Me.Onenote.Pages[\"{id}\"]", result);
+            Assert.DoesNotContain("await graphClient.Me.Onenote.Pages[\"{id}\"].Content", result);
             Assert.Contains("UpdateAsync(pages)", result);
         }
 
@@ -405,7 +405,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "await graphClient.Groups[\"{group-id}\"].Owners[\"{directoryObject-id}\"].Reference\r\n" +
+            const string expectedSnippet = "await graphClient.Groups[\"{id}\"].Owners[\"{id}\"].Reference\r\n" +
                                         "\t.Request()\r\n" +
                                         "\t.DeleteAsync();";
 
@@ -438,7 +438,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
                                                 "\r\n\t.Request()" +
                                                 "\r\n\t.AddAsync(directoryObject);";
 
@@ -471,7 +471,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
                                            "\r\n\t.Request()" +
                                            "\r\n\t.AddAsync(directoryObject);";
 
@@ -510,7 +510,7 @@ namespace CodeSnippetsReflection.Test
                                            "};\r\n" +
                                            "\r\n" +
 
-                                           "await graphClient.Groups[\"{group-id}\"].Owners.References" +
+                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
                                            "\r\n\t.Request()" +
                                            "\r\n\t.AddAsync(directoryObject);";
 
@@ -533,7 +533,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"]\r\n" +
+            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Worksheets[\"{id|name}\"]\r\n" +
                                                "\t.Range(\"A1:B2\")\r\n" +//parameter has double quotes
                                                "\t.Request()\r\n" +
                                                "\t.GetAsync();";
@@ -585,7 +585,7 @@ namespace CodeSnippetsReflection.Test
                                                "\tBodyPreview = \"bodyPreview-value\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.MailFolders[\"{mailFolder-id}\"].Messages\r\n" +
+                                           "await graphClient.Me.MailFolders[\"{id}\"].Messages\r\n" +
                                                "\t.Request()\r\n" +
                                                "\t.AddAsync(message);";
 
@@ -735,7 +735,7 @@ namespace CodeSnippetsReflection.Test
                                            "\tIsReminderOn = true\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{event-id}\"]\r\n" +
+                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.UpdateAsync(@event);";
 
@@ -854,7 +854,7 @@ namespace CodeSnippetsReflection.Test
                                                    "\t\t}\r\n" +
                                                "\t}\r\n};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Events[\"{event-id}\"]\r\n" +
+                                           "await graphClient.Me.Events[\"{id}\"]\r\n" +
                                                "\t.Request()\r\n" +
                                                "\t.UpdateAsync(@event);";
 
@@ -886,7 +886,7 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "var hasHeaders = true;\r\n" +
                                            "\r\n" +
-                                           "await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Workbook.Tables\r\n" +
+                                           "await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Tables\r\n" +
                                            "\t.Add(hasHeaders,address)\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.PostAsync();";
@@ -909,7 +909,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{driveItem-id}\"].Content\r\n" +
+            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{item-id}\"].Content\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.GetAsync();";
 
@@ -943,7 +943,7 @@ namespace CodeSnippetsReflection.Test
                                            "\tContentBytes = Encoding.ASCII.GetBytes(\"R0lGODdhEAYEAA7\")\r\n" +
                                            "};\r\n" +
 
-                                           "\r\nawait graphClient.Me.Messages[\"{message-id}\"].Attachments\r\n" +
+                                           "\r\nawait graphClient.Me.Messages[\"AAMkpsDRVK\"].Attachments\r\n" +
                                            "\t.Request()\r\n" +
                                            "\t.AddAsync(attachment);";
 
@@ -1041,7 +1041,7 @@ namespace CodeSnippetsReflection.Test
                                                 "\tDescription = \"mySet\"\r\n" +
                                            "};\r\n" +
                                            "\r\n" +
-                                           "await graphClient.TermStore.Sets[\"{termStore.set-id}\"]\r\n" +
+                                           "await graphClient.TermStore.Sets[\"{setId}\"]\r\n" +
                                                 "\t.Request()\r\n" +
                                                 "\t.UpdateAsync(set);";
 

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -226,6 +226,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         {
             var resourcesPath = new StringBuilder();
             var resourcesPathSuffix = string.Empty;
+            string previousSegment = null;
 
             // lets append all resources
             foreach (var item in snippetModel.Segments)
@@ -240,7 +241,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     // IThumbnailSetRequestBuilder has a manually written extension which allows indexing on {size}
                     // https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph/Requests/Extensions/IThumbnailSetRequestBuilderExtensions.cs
                     case DynamicPathSegment pathSegment when pathSegment.Identifier.Contains("{"):
-                        resourcesPath.Append($"[\"{pathSegment.Identifier}\"]");
+                        var id = previousSegment == null ? "UNKNOWN-ID" : previousSegment + "-id";
+                        resourcesPath.Append($"[\"{id}\"]");
                         break;
                     //handle functions/actions and any parameters present into collections
                     case OperationSegment operationSegment:
@@ -304,6 +306,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
                         break;
                 }
+
+                previousSegment = item.EdmType?.ToString();
             }
 
             if (!string.IsNullOrEmpty(resourcesPathSuffix))

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -226,23 +226,22 @@ namespace CodeSnippetsReflection.LanguageGenerators
         {
             var resourcesPath = new StringBuilder();
             var resourcesPathSuffix = string.Empty;
-            string nextId = null;
-            List<string> paths = new List<string>();
+            ODataPathSegment previousSegment = null;
 
             // lets append all resources
-            foreach (var item in snippetModel.Segments)
+            foreach (var segment in snippetModel.Segments)
             {
-                switch (item)
+                switch (segment)
                 {
                     //handle indexing into collections
                     case KeySegment keySegment:
-                        resourcesPath.Append($"[\"{nextId}\"]");
+                        resourcesPath.Append($"[\"{NextId(previousSegment)}\"]");
                         break;
                     // handle special case of indexing on a property through extensions, e.g.
                     // IThumbnailSetRequestBuilder has a manually written extension which allows indexing on {size}
                     // https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph/Requests/Extensions/IThumbnailSetRequestBuilderExtensions.cs
                     case DynamicPathSegment pathSegment when pathSegment.Identifier.Contains("{"):
-                        resourcesPath.Append($"[\"{nextId}\"]");
+                        resourcesPath.Append($"[\"{NextId(previousSegment)}\"]");
                         break;
                     //handle functions/actions and any parameters present into collections
                     case OperationSegment operationSegment:
@@ -272,7 +271,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         if (propertySegment.EdmType.IsStream() //don't append anything that is not a stream since this is not accessed directly in C#
                            && snippetModel.Method != HttpMethod.Patch) // while patching we pass the encapsulating object in the request
                         {
-                            resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
+                            resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(segment.Identifier)}");
                         }
                         break;
                     case ReferenceSegment _:
@@ -289,26 +288,25 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         if (snippetModel.Path.Contains("$ref") && !(snippetModel.Segments.Last() is ReferenceSegment))
                         {
 
-                            var nextSegmentIndex = snippetModel.Segments.IndexOf(item) + 1;
+                            var nextSegmentIndex = snippetModel.Segments.IndexOf(segment) + 1;
                             if (nextSegmentIndex >= snippetModel.Segments.Count)
                                 nextSegmentIndex = snippetModel.Segments.Count-1;
 
                             var nextSegment = snippetModel.Segments[nextSegmentIndex];
                             //check if the next segment is a KeySegment to know if we will be accessing a single entity of a collection.
-                            resourcesPathSuffix = (item.EdmType is IEdmCollectionType) && !(nextSegment is KeySegment) ? ".References" : ".Reference";
+                            resourcesPathSuffix = (segment.EdmType is IEdmCollectionType) && !(nextSegment is KeySegment) ? ".References" : ".Reference";
                         }
-                        resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
+                        resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(segment.Identifier)}");
                         break;
                     case TypeSegment _:
                         break; // type segment is not part of the resource path.
                     default:
                         //its most likely just a resource so append it
-                        resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
+                        resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(segment.Identifier)}");
                         break;
                 }
 
-                paths.Add(item.Identifier);
-                nextId = GetCsharpClassName(item, paths) + "-id";
+                previousSegment = segment;
             }
 
             if (!string.IsNullOrEmpty(resourcesPathSuffix))
@@ -317,6 +315,22 @@ namespace CodeSnippetsReflection.LanguageGenerators
             }
 
             return resourcesPath.ToString();
+        }
+
+        private static string NextId(ODataPathSegment segment)
+        {
+            const string unknownId = "{UNKNOWN-id}";
+            if (segment is null || segment.EdmType is null)
+            {
+                return unknownId;
+            }
+
+            var currentType = segment.EdmType.FullTypeName()
+                .Replace("Collection(", string.Empty)           // remove collection wrapper
+                .Replace("microsoft.graph.", string.Empty)      // assumption is that all namespaces are under microsoft.graph
+                .Replace(")", string.Empty);                    // remove collection wrapper
+
+            return $"{{{currentType}-id}}";
         }
 
         /// <summary>

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -29,11 +29,18 @@ namespace CodeSnippetsReflection.LanguageGenerators
         private static readonly HashSet<string> EdmTypesNonNullableByDefault = new HashSet<string>{ "Int32", "Single", "Double", "Boolean", "Guid", "DateTimeOffset", "Byte" };
 
         /// <summary>
+        /// Determines whether the snippet generation is running through the command line interface
+        /// (as opposed to in DevX HTTP API)
+        /// </summary>
+        private readonly bool IsCommandLine;
+
+        /// <summary>
         /// CSharpGenerator constructor
         /// </summary>
         /// <param name="model">Model representing metadata</param>
-        public CSharpGenerator(IEdmModel model)
+        public CSharpGenerator(IEdmModel model, bool isCommandLine = false)
         {
+            IsCommandLine = isCommandLine;
             CommonGenerator = new CommonGenerator(model);
         }
 
@@ -222,7 +229,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// </summary>
         /// <param name="snippetModel">Model of the Snippets info <see cref="SnippetModel"/></param>
         /// <returns>String of the resources in Csharp code</returns>
-        private static string CSharpGenerateResourcesPath(SnippetModel snippetModel)
+        private string CSharpGenerateResourcesPath(SnippetModel snippetModel)
         {
             var resourcesPath = new StringBuilder();
             var resourcesPathSuffix = string.Empty;
@@ -235,13 +242,13 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 {
                     //handle indexing into collections
                     case KeySegment keySegment:
-                        resourcesPath.Append($"[\"{GetIDPlaceholder(previousSegment)}\"]");
+                        resourcesPath.Append($"[\"{GetIDPlaceholder(keySegment, previousSegment)}\"]");
                         break;
                     // handle special case of indexing on a property through extensions, e.g.
                     // IThumbnailSetRequestBuilder has a manually written extension which allows indexing on {size}
                     // https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph/Requests/Extensions/IThumbnailSetRequestBuilderExtensions.cs
                     case DynamicPathSegment pathSegment when pathSegment.Identifier.Contains("{"):
-                        resourcesPath.Append($"[\"{GetIDPlaceholder(previousSegment)}\"]");
+                        resourcesPath.Append($"[\"{GetIDPlaceholder(pathSegment, previousSegment)}\"]");
                         break;
                     //handle functions/actions and any parameters present into collections
                     case OperationSegment operationSegment:
@@ -318,24 +325,44 @@ namespace CodeSnippetsReflection.LanguageGenerators
         }
 
         /// <summary>
-        /// constructs a string {type-id} if given segment has a type.
+        /// For command line callers: constructs a string {type-id} if previous segment has a type.
+        /// For DevX API callers: uses ID from the original http snippet
         /// </summary>
-        /// <param name="segment">odata path segment</param>
-        /// <returns>{UNKNOWN-id} if segment doesn't have a type, {segmentType-id} if segment's type is segmentType.</returns>
-        private static string GetIDPlaceholder(ODataPathSegment segment)
+        /// <param name="currentSegment">current odata path segment</param>
+        /// <param name="previousSegment">previous odata path segment</param>
+        /// <returns>
+        /// For command line callers:
+        ///   {UNKNOWN-id} if previous segment doesn't have type information
+        ///   {segmentType-id} if previous segment's type is segmentType.
+        /// For DevX API callers:
+        ///   ID value from the given HTTP snippet
+        /// </returns>
+        private string GetIDPlaceholder(ODataPathSegment currentSegment, ODataPathSegment previousSegment)
         {
-            const string unknownId = "{UNKNOWN-id}";
-            if (segment is null || segment.EdmType is null)
+            if (IsCommandLine)
             {
-                return unknownId;
+                const string unknownId = "{UNKNOWN-id}";
+                if (previousSegment is null || previousSegment.EdmType is null)
+                {
+                    return unknownId;
+                }
+
+                var currentType = previousSegment.EdmType.FullTypeName()
+                    .Replace("Collection(", string.Empty)           // remove collection wrapper
+                    .Replace("microsoft.graph.", string.Empty)      // assumption is that all namespaces are under microsoft.graph
+                    .Replace(")", string.Empty);                    // remove collection wrapper
+
+                return $"{{{currentType}-id}}";
             }
-
-            var currentType = segment.EdmType.FullTypeName()
-                .Replace("Collection(", string.Empty)           // remove collection wrapper
-                .Replace("microsoft.graph.", string.Empty)      // assumption is that all namespaces are under microsoft.graph
-                .Replace(")", string.Empty);                    // remove collection wrapper
-
-            return $"{{{currentType}-id}}";
+            else // HTTP API calls should preserve the ID from original snippet
+            {
+                return currentSegment switch
+                {
+                    KeySegment keySegment => keySegment.Keys.FirstOrDefault().Value.ToString(),
+                    DynamicPathSegment pathSegment => pathSegment.Identifier,
+                    _ => throw new ArgumentException("currentSegment is expected to be either a key or dynamic path segment!", nameof(currentSegment)),
+                };
+            }
         }
 
         /// <summary>
@@ -701,7 +728,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// </summary>
         /// <param name="snippetModel">Snippet model built from the request</param>
         /// <param name="actions">String of actions to be done inside the code block</param>
-        private static string GenerateRequestSection(SnippetModel snippetModel, string actions)
+        private string GenerateRequestSection(SnippetModel snippetModel, string actions)
         {
             var stringBuilder = new StringBuilder();
 

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -235,7 +235,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 {
                     //handle indexing into collections
                     case KeySegment keySegment:
-                        resourcesPath.Append($"[\"{keySegment.Keys.FirstOrDefault().Value}\"]");
+                        var id = previousSegment == null ? "UNKNOWN-ID" : previousSegment + "-id";
+                        resourcesPath.Append($"[\"{id}\"]");
                         break;
                     // handle special case of indexing on a property through extensions, e.g.
                     // IThumbnailSetRequestBuilder has a manually written extension which allows indexing on {size}

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -222,7 +222,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// </summary>
         /// <param name="snippetModel">Model of the Snippets info <see cref="SnippetModel"/></param>
         /// <returns>String of the resources in Csharp code</returns>
-        private string CSharpGenerateResourcesPath(SnippetModel snippetModel)
+        private static string CSharpGenerateResourcesPath(SnippetModel snippetModel)
         {
             var resourcesPath = new StringBuilder();
             var resourcesPathSuffix = string.Empty;
@@ -317,6 +317,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
             return resourcesPath.ToString();
         }
 
+        /// <summary>
+        /// constructs a string {type-id} if given segment has a type.
+        /// </summary>
+        /// <param name="segment">odata path segment</param>
+        /// <returns>{UNKNOWN-id} if segment doesn't have a type, {segmentType-id} if segment's type is segmentType.</returns>
         private static string NextId(ODataPathSegment segment)
         {
             const string unknownId = "{UNKNOWN-id}";
@@ -696,7 +701,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// </summary>
         /// <param name="snippetModel">Snippet model built from the request</param>
         /// <param name="actions">String of actions to be done inside the code block</param>
-        private string GenerateRequestSection(SnippetModel snippetModel, string actions)
+        private static string GenerateRequestSection(SnippetModel snippetModel, string actions)
         {
             var stringBuilder = new StringBuilder();
 

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -38,11 +38,19 @@ namespace CodeSnippetsReflection
         private JavaExpressions JavaExpressions { get; }
 
         /// <summary>
+        /// Determines whether the snippet generation is running through the command line interface
+        /// (as opposed to DevX HTTP API)
+        /// </summary>
+        private readonly bool IsCommandLine;
+
+        /// <summary>
         /// Class holding the Edm model and request processing for snippet generations
         /// </summary>
+        /// <param name="isCommandLine">Determines whether we are running the snippet generation in command line</param>
         /// <param name="customMetadataPath">Full file path to the metadata</param>
-        public SnippetsGenerator(string customMetadataPath = null)
+        public SnippetsGenerator(bool isCommandLine = false, string customMetadataPath = null)
         {
+            IsCommandLine = isCommandLine;
             LoadGraphMetadata(customMetadataPath);
             JavascriptExpressions = new JavascriptExpressions();
             CSharpExpressions = new CSharpExpressions();
@@ -96,7 +104,7 @@ namespace CodeSnippetsReflection
             switch (language.ToLower())
             {
                 case "c#":
-                    var csharpGenerator = new CSharpGenerator(edmModel);
+                    var csharpGenerator = new CSharpGenerator(edmModel, IsCommandLine);
                     return csharpGenerator.GenerateCodeSnippet(snippetModel, CSharpExpressions);
 
                 case "javascript":


### PR DESCRIPTION
Fixes: https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/202

Generates consistent id output for C# snippets so that we can replace them with real values while running the snippets in Raptor.

ID placeholder value is extracted from previous segment's type. 

Examples:
- `graphClient.Me.Drive.Items["{driveItem-id}"]`
- `graphClient.Me.PendingAccessReviewInstances["{accessReviewInstance-id}"]`
- `graphClient.Me.MailFolders["{mailFolder-id}"].Messages`
- `graphClient.TermStore.Sets["{termStore.set-id}"]`

Namespaces are shortened by dropping `microsoft.graph` from the name as it is a shared prefix for all the types. Subnamespaces like `termStore` are kept to cover the case of name collisions between two different namespaces.

Full diff on the docs repo:
https://github.com/microsoftgraph/microsoft-graph-docs/commit/3257bee01450b32df17c592dc30477f92c334761