### PR TITLE
Fix escaped double double quotes in generated Csharp multiline strings

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -952,6 +952,63 @@ namespace CodeSnippetsReflection.Test
         }
 
         [Fact]
+        //This test asserts that a request with multiline string is escaped correctly
+        public void GeneratesSnippetsWithMultilineStringEscaped()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            const string jsonObject = @"{
+                ""id"": ""60860cdd-fb4d-4054-91ba-f75e04444aa6"",
+                ""displayName"": ""Test world UPDATED NAME!"",
+                ""descriptionForAdmins"": ""Test world"",
+                ""descriptionForReviewers"": ""Test world"",
+                ""scope"": {
+                    ""query"": ""/groups/b7a059cb-038a-4802-8fc9-b9d1ed0cf11f/transitiveMembers"",
+                    ""queryType"": ""MicrosoftGraph""
+                },
+                ""instanceEnumerationScope"": {
+                    ""query"": ""/groups/b7a059cb-038a-4802-8fc9-b9d1ed0cf11f"",
+                    ""queryType"": ""MicrosoftGraph""
+                },
+                ""reviewers"": [],
+                ""settings"": {
+                    ""mailNotificationsEnabled"": true,
+                    ""reminderNotificationsEnabled"": true,
+                    ""justificationRequiredOnApproval"": true,
+                    ""defaultDecisionEnabled"": false,
+                    ""defaultDecision"": ""None"",
+                    ""instanceDurationInDays"": 3,
+                    ""autoApplyDecisionsEnabled"": false,
+                    ""recommendationsEnabled"": true,
+                    ""recurrence"": {
+                    ""pattern"": {
+                        ""type"": ""weekly"",
+                        ""interval"": 1
+                    },
+                    ""range"": {
+                        ""type"": ""noEnd"",
+                        ""startDate"": ""2020-09-15""
+                    }
+                    }
+                }
+            }";
+            var url = "https://graph.microsoft.com/beta/identityGovernance/accessReviews/definitions/60860cdd-fb4d-4054-91ba-f75e04444aa6";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Put, url)
+            {
+                Content = new StringContent(jsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+            //Act by generating the code snippet
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+
+            const string doubleDoubleQuotedString = "\"\"id\"\": \"\"60860cdd-fb4d-4054-91ba-f75e04444aa6\"\"";
+            const string stream = "new System.IO.MemoryStream(Encoding.UTF8.GetBytes(@\"{";
+            //Assert the snippet generated is as expected
+            Assert.Contains(doubleDoubleQuotedString, result);
+            Assert.Contains(stream, result);
+        }
+
+        [Fact]
         // This tests asserts that a type beginning with "@" character is also added to the AdditionalData bag
         public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
         {

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -197,7 +197,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     }
                     else
                     {
-                        snippetBuilder.Append($"using var {snippetModel.ResponseVariableName} = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(\"{snippetModel.RequestBody.Trim()}\"));\r\n\r\n");
+                        snippetBuilder.Append($"using var {snippetModel.ResponseVariableName} = new System.IO.MemoryStream(Encoding.UTF8.GetBytes(@\"{snippetModel.RequestBody.Replace("\"", "\"\"").Trim()}\"));\r\n\r\n");
 
                         // resolve type for PutAsync<T>
                         var genericEdmType = snippetModel.Segments[snippetModel.Segments.Count - 2].EdmType;


### PR DESCRIPTION
Fixes #484 

This PR modifies the output of C# snippet generation such that when a request body object is supplied in a PUT request, the resultant snippet uses verbatim string literal syntax to display the resultant request-body-corresponding C# variable.

Originally the resultant C# variable would not be readily usable as quotes were not escaped.