### PR TITLE
Fix handling of Enums in Snippet generation

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1009,6 +1009,29 @@ namespace CodeSnippetsReflection.Test
         }
 
         [Fact]
+        //This test asserts that Enums are displayed Correctly in Csharp Snippets
+        public void GeneratesSnippetsWithEnumsCorrectlyDisplayed()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var url = "https://graph.microsoft.com/beta/reports/authenticationMethods/usersRegisteredByMethod(includedUserTypes='all',includedUserRoles='all')";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+            //Act by generating the code snippet
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+
+           
+            //Assert the snippet generated is as expected
+            var expected = "GraphServiceClient graphClient = new GraphServiceClient( authProvider );\r\n\r\n" +
+                        "var userRegistrationMethodSummary = await graphClient.Reports.AuthenticationMethods\r\n" +
+                        "\t.UsersRegisteredByMethod(IncludedUserTypes.All,IncludedUserRoles.All)\r\n" +
+                        "\t.Request()\r\n" +
+                        "\t.GetAsync();";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         // This tests asserts that a type beginning with "@" character is also added to the AdditionalData bag
         public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
         {

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -252,7 +252,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         break;
                     //handle functions/actions and any parameters present into collections
                     case OperationSegment operationSegment:
-                        var paramList = CommonGenerator.GetParameterListFromOperationSegment(operationSegment, snippetModel);
+                        var paramList = CommonGenerator.GetParameterListFromOperationSegment(
+                            operationSegment, snippetModel, returnEnumTypeIfEnum:true);
                         var parameters = string.Join(",", paramList.Select(x =>
                         {
                             if (x.Contains("'"))

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -261,7 +261,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 // do we have other special types that show up in URLs?
                                 var split = x.Split("'");
                                 var enumType = CommonGenerator.UppercaseFirstLetter(split[0].Split(".").Last()); // TimeZoneStandard
-                                var enumValue = split[1];
+                                var enumValue = CommonGenerator.UppercaseFirstLetter(split[1]);
                                 return $"{enumType}.{enumValue}";
                             }
                             else

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -326,7 +326,9 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <param name="collectionSuffix">Suffix to be added to elements that are proved to be members collections</param>
         /// <param name="isOrderedByOptionalParameters">Flag to show whether the parameters are ordered by the the metadata or optionality of params</param>
         /// <returns></returns>
-        public static IEnumerable<string> GetParameterListFromOperationSegment(OperationSegment operationSegment, SnippetModel snippetModel, string collectionSuffix = "", bool isOrderedByOptionalParameters = true)
+        public static IEnumerable<string> GetParameterListFromOperationSegment(
+            OperationSegment operationSegment, SnippetModel snippetModel, string collectionSuffix = "",
+            bool isOrderedByOptionalParameters = true, bool returnEnumTypeIfEnum = false)
         {
             var paramList = new List<string>();
 
@@ -375,9 +377,9 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 break;
                             }
                         case ConstantNode constantNode:
-                            if (constantNode.TypeReference.Definition.TypeKind == EdmTypeKind.Enum)
+                            if (constantNode.TypeReference.Definition.TypeKind == EdmTypeKind.Enum && returnEnumTypeIfEnum)
                             {
-                                var enumType =  constantNode.TypeReference.FullName();
+                                var enumType = parameter.Name;
                                 paramList.Add($"{enumType}{constantNode.LiteralText}");
                                 break;
                             }

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -375,8 +375,17 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 break;
                             }
                         case ConstantNode constantNode:
-                            paramList.Add(constantNode.LiteralText);
-                            break;
+                            if (constantNode.TypeReference.Definition.TypeKind == EdmTypeKind.Enum)
+                            {
+                                var enumType =  constantNode.TypeReference.FullName();
+                                paramList.Add($"{enumType}{constantNode.LiteralText}");
+                                break;
+                            }
+                            else
+                            {
+                                paramList.Add($"{constantNode.LiteralText}");
+                                break;
+                            }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #482 

This PR Fixes handling of Enums in C# Snippet generation by prepending the `enum` type name to the `enum` value in the common language agnostic generator if the `returnEnumTypeIfEnum` optional named param is set, then uppercasing the enum value in the Csharp generator. Using the optional named param makes it possible for languages that make use of the enum type to specify the need of prepending the enumtype in the returned parameter list.