### PR TITLE
Add test for InvitationParticipantInfo Using AdditionalData property

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1159,5 +1159,39 @@ namespace CodeSnippetsReflection.Test
             Assert.DoesNotContain(itemIdBasedOnTypeInformation, result);
             Assert.Contains(itemIdFromDevXApiSnippet, result);
         }
+
+        [Fact]
+        public void TestInvitationParticipantInfo_UsesAdditionalDataProperties()
+        {
+            LanguageExpressions expressions = new CSharpExpressions();
+            const string targetJsonObject = @"
+                {
+                    ""transferTarget"": {
+                        ""endpointType"": ""default"",
+                        ""identity"": {
+                        ""user"": {
+                            ""id"": ""550fae72-d251-43ec-868c-373732c2704f"",
+                            ""tenantId"": ""72f988bf-86f1-41af-91ab-2d7cd011db47"",
+                            ""displayName"": ""Heidi Steen""
+                        }
+                        },
+                        ""languageId"": ""languageId-value"",
+                        ""region"": ""region-value"",
+                        ""ReplacesCallId"": ""replacesCallId-value""
+                    },
+                }
+            ";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/beta/communications/calls/{id}/transfer")
+            {
+                Content = new StringContent(targetJsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+            //Act by generating the code snippet
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+
+            Assert.DoesNotContain("LanguageId = ", result); // LanguageId as a property
+            Assert.Contains("AdditionalData", result);
+            Assert.Contains("\"languageId\", \"languageId-value\"", result);    // LanguageId as part of AdditionalData
+        } 
     }
 }


### PR DESCRIPTION
Resolves #296
If well provided, the data for `InvitationParticipantInfo`, correctly nests additionalData since it's an open type object. Testing this with the help of @zengin  also worked and revealed that the issue did not lie in use of additionalData property but in the documentation in that 
1. the sample sent in the documentation, contained a "clientContext" property as part of `InvitationParticipantInfo` which was contrary to the definition in the metadata/source of truth. This has since been fixed after email conversations with the SBS platform team.
2. the metadata in the code blocks of the `InvitationParticipantInfo` are wrong and I have raised an issue in the docs repo to get that fixed as well. Referenced issue :https://github.com/microsoftgraph/microsoft-graph-docs/issues/12184

This test is therefore ready to merge as it adds test coverage for any future modifications. 