### PR TITLE
Escapes # character in graph.networkInterface schema

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -418,11 +418,98 @@ namespace OpenAPIService.Test
                                 }
                             }
                         }
+                    },
+                    ["/security/hostSecurityProfiles"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        {
+                                            new OpenApiTag()
+                                            {
+                                                Name = "security.hostSecurityProfile"
+                                            }
+                                        }
+                                    },
+                                    OperationId = "security.ListHostSecurityProfiles",
+                                    Summary = "Get hostSecurityProfiles from security",
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200", new OpenApiResponse()
+                                            {
+                                                Description = "Retrieved navigation property",
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    {
+                                                        applicationJsonMediaType,
+                                                        new OpenApiMediaType
+                                                        {
+                                                            Schema = new OpenApiSchema
+                                                            {
+                                                                Title = "Collection of hostSecurityProfile",
+                                                                Type = "object",
+                                                                Properties = new Dictionary<string, OpenApiSchema>
+                                                                {
+                                                                    {
+                                                                        "value",
+                                                                        new OpenApiSchema
+                                                                        {
+                                                                            Type = "array",
+                                                                            Items = new OpenApiSchema
+                                                                            {
+                                                                                Reference = new OpenApiReference
+                                                                                {
+                                                                                    Type = ReferenceType.Schema,
+                                                                                    Id = "microsoft.graph.networkInterface"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Components = new OpenApiComponents
+                {
+                    Schemas = new Dictionary<string, OpenApiSchema>
+                    {
+                        {
+                            "microsoft.graph.networkInterface", new OpenApiSchema
+                            {
+                                Title = "networkInterface",
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>
+                                {
+                                    {
+                                        "description", new OpenApiSchema
+                                        {
+                                            Type = "string",
+                                            Description = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <#>, etc.).",
+                                            Nullable = true
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
 
-            return document;
+            return OpenApiService.FixReferences(document);
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -287,7 +287,7 @@ namespace OpenAPIService.Test
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;
-            var expectedDescription = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <`#>, etc.).";
+            var expectedDescription = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <#/>, etc.).";
 
             // Act
             var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/security/hostSecurityProfiles", source: source)

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -281,5 +281,26 @@ namespace OpenAPIService.Test
             // Assert
             Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
         }
+
+        [Fact]
+        public void EscapePoundCharacterFromNetworkInterfaceSchemaDescription()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+            var expectedDescription = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <`#>, etc.).";
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/security/hostSecurityProfiles", source: source)
+                                .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+
+            var parentSchema = subsetOpenApiDocument.Components.Schemas["microsoft.graph.networkInterface"];
+            var descriptionSchema = parentSchema.Properties["description"];
+
+            // Assert
+            Assert.Equal(expectedDescription, descriptionSchema.Description);
+        }
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -550,7 +550,7 @@ namespace OpenAPIService
                 if (parentSchema.Properties.TryGetValue("description", out OpenApiSchema descriptionSchema))
                 {
                     // PowerShell uses ` to escape special characters
-                    descriptionSchema.Description = descriptionSchema.Description.Replace("#", "`#");
+                    descriptionSchema.Description = descriptionSchema.Description.Replace("<#>", "<#/>");
                 }
             }
         }


### PR DESCRIPTION
Fixes #514 

**Issue:**
The presence of the # character in the `Description` property of the `Properties` property of the `microsoft.graph.networkInterface` schema is breaking Powershell Comment Based Help System, and by extension breaking modules.

e.g.
![MicrosoftTeams-image (12)](https://user-images.githubusercontent.com/40403681/113302261-8d070100-9308-11eb-9859-97cdb447c4e3.png)

produces...
![MicrosoftTeams-image (13)](https://user-images.githubusercontent.com/40403681/113302346-9db77700-9308-11eb-8ea9-e4e63e77afa6.png)


**Fix:**
By appending a ` before the # to escape it.

**Test:**
- A unit test has been added to validate this fix.
- The mock test class has been updated to include the test schema and test path.

NB: This is a temporary fix as a more permanent solution is awaited from AutoRest. AutoRest should be able to parse the document without breaking if a # character is included within string characters ' '