### PR TITLE
Use parameter type instead of parameter name for enum type resolution

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1014,21 +1014,16 @@ namespace CodeSnippetsReflection.Test
         {
             //Arrange
             LanguageExpressions expressions = new CSharpExpressions();
-            var url = "https://graph.microsoft.com/beta/reports/authenticationMethods/usersRegisteredByMethod(includedUserTypes='all',includedUserRoles='all')";
+            var url = "https://graph.microsoft.com/v1.0/identityGovernance/appConsent/appConsentRequests/ee245379-e3bb-4944-a997-24115f0b8b5e/userConsentRequests/filterByCurrentUser(on='reviewer')?$filter= (status eq 'Completed')";
 
             var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
             //Act by generating the code snippet
-            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+            var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
-           
             //Assert the snippet generated is as expected
-            var expected = "GraphServiceClient graphClient = new GraphServiceClient( authProvider );\r\n\r\n" +
-                        "var userRegistrationMethodSummary = await graphClient.Reports.AuthenticationMethods\r\n" +
-                        "\t.UsersRegisteredByMethod(IncludedUserTypes.All,IncludedUserRoles.All)\r\n" +
-                        "\t.Request()\r\n" +
-                        "\t.GetAsync();";
-            Assert.Equal(expected, result);
+            Assert.Contains("ConsentRequestFilterByCurrentUserOptions.Reviewer", result);
+            Assert.DoesNotContain("On.Reviewer", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -422,7 +422,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 case ConvertNode convertNode when convertNode.Source is ConstantNode cNode:
                     return $"\"{cNode.Value}\"";
                 case ConstantNode constantNode when constantNode.TypeReference.Definition.TypeKind == EdmTypeKind.Enum && returnEnumTypeIfEnum:
-                    return $"{parameter.Name}{constantNode.LiteralText}";
+                    return $"{constantNode.TypeReference.Definition.FullTypeName()}{constantNode.LiteralText}";
                 case ConstantNode constantNode:
                     return constantNode.LiteralText;
                 default:


### PR DESCRIPTION
Fixes #519

The old test on enum types was passing accidentally because the parameter name and the parameter type were the same. I changed the test to an example where they are different (parameter name: on, parameter type: consentRequestFilterByCurrentUserOptions).

[Full Snippet Generation Diff](https://github.com/microsoftgraph/microsoft-graph-docs/commit/43e48dffbca5ef429596d30d0bb0750d3ed37b94)