### PR TITLE
Support Casting of CollectionWithReferencesPage

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1193,5 +1193,69 @@ namespace CodeSnippetsReflection.Test
             Assert.Contains("AdditionalData", result);
             Assert.Contains("\"languageId\", \"languageId-value\"", result);    // LanguageId as part of AdditionalData
         } 
+
+        [Fact]
+        public void ShouldSupportCastingToCollectionWithReferencesPage()
+        {
+            var expressions = new CSharpExpressions();
+            const string jsonObject = @"{
+                ""id"": ""Customer"",
+                ""userFlowType"": ""signUpOrSignIn"",
+                ""userFlowTypeVersion"": 3,
+                ""identityProviders"": [
+                    {
+                        ""id"": ""Facebook-OAuth"",
+                        ""type"": ""Facebook"",
+                        ""Name"": ""Facebook""
+                    }
+                ]
+            }";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/beta/identity/b2cUserFlows")
+            {
+                Content = new StringContent(jsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+
+            var replacedType = "IdentityProviders = new B2cIdentityUserFlowIdentityProvidersCollectionPage()";
+            var expectedReplacement = "IdentityProviders = new B2cIdentityUserFlowIdentityProvidersCollectionWithReferencesPage";
+            Assert.DoesNotContain(replacedType, result);
+            Assert.Contains(expectedReplacement, result);
+        }
+
+        [Fact]
+        public void ShouldSupportCastingToCollectionPage()
+        {
+            var expressions = new CSharpExpressions();
+            const string jsonObject = @"{
+                ""displayName"": ""Books"",
+                ""columns"": [
+                    {
+                    ""name"": ""Author"",
+                    ""text"": { }
+                    },
+                    {
+                    ""name"": ""PageCount"",
+                    ""number"": { }
+                    }
+                ],
+                ""list"": {
+                    ""template"": ""genericList""
+                }
+            }";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/beta/sites/{site-id}/lists")
+            {
+                Content = new StringContent(jsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+
+            var wrongType = "Columns = new ListColumnsCollectionWithReferencesPage()";
+            var expectedType = "Columns = new ListColumnsCollectionPage()";
+            Assert.DoesNotContain(wrongType, result);
+            Assert.Contains(expectedType, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -775,7 +775,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <returns>ICollectionPage Interface name</returns>
         private string GetCollectionPageClassName(ODataPathSegment pathSegment, ICollection<string> path)
         {
-            var type = GetCsharpClassName(pathSegment, path.ToList().GetRange(0, path.Count - 1));
+            var type = GetCsharpClassName(pathSegment, path.Take(path.Count-1).ToList());
             var property = path.Last();
             var uppercasedProperty = CommonGenerator.UppercaseFirstLetter(property);
 

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -768,7 +768,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         }
 
         /// <summary>
-        /// Generates CollectionPage class name
+        /// Generates CollectionPage and CollectionWithReferencesPage class name
         /// </summary>
         /// <param name="pathSegment">The OdataPathSegment in use</param>
         /// <param name="path">path in edm model</param>
@@ -776,8 +776,16 @@ namespace CodeSnippetsReflection.LanguageGenerators
         private string GetCollectionPageClassName(ODataPathSegment pathSegment, ICollection<string> path)
         {
             var type = GetCsharpClassName(pathSegment, path.ToList().GetRange(0, path.Count - 1));
-            var property = CommonGenerator.UppercaseFirstLetter(path.Last());
-            return $"{type}{property}CollectionPage";
+            var property = path.Last();
+            var uppercasedProperty = CommonGenerator.UppercaseFirstLetter(property);
+
+            var structuredType = (pathSegment.EdmType as IEdmCollectionType)?.ElementType?.Definition as IEdmStructuredType;
+            var containsTarget = (structuredType?.FindProperty(property) as IEdmNavigationProperty)?.ContainsTarget
+                ?? throw new InvalidOperationException("Path doesn't match with the metadata property description!" +
+                    $"path: { string.Join(' ', path) }");
+
+            var navCollectionType = containsTarget ? "CollectionPage" : "CollectionWithReferencesPage";
+            return $"{type}{uppercasedProperty}{navCollectionType}";
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #327
 
Initially, casting to CollectionWithReferencesPage was not supported. Navigation properties with attribute `ContainsTarget=false` e.g `identityProviders` would be converted to type "ICollectionPage" instead of type `CollectionWithReferencesPage`.

This PR fixes this by checking the ContainsTarget attribute and deciding on the type to return base on the value of the attribute.

Changes have been tested and verified to affect only b2xuserflows and b2cuserflows as expected: [here](https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/47479...snippet-generation/47480?expand=1)