### PR TITLE
Search Github Sample Queries by id

### DIFF
--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -36,7 +36,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                SampleQueriesList sampleQueriesList = await FetchSampleQueries(org, branchName);
+                SampleQueriesList sampleQueriesList = await FetchSampleQueriesListAsync(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {
@@ -80,7 +80,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                SampleQueriesList sampleQueriesList = await FetchSampleQueries(org, branchName);
+                SampleQueriesList sampleQueriesList = await FetchSampleQueriesListAsync(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {
@@ -305,12 +305,11 @@ namespace GraphWebApi.Controllers
         /// <param name="org">The name of the organisation i.e microsoftgraph or a member's username in the case of a forked repo.</param>
         /// <param name="branchName">The name of the branch.</param>
         /// <returns>A list of Sample Queries.</returns>
-        private async Task<SampleQueriesList> FetchSampleQueries(string org, string branchName)
+        private async Task<SampleQueriesList> FetchSampleQueriesListAsync(string org, string branchName)
         {
             string locale = RequestHelper.GetPreferredLocaleLanguage(Request);
 
-            SampleQueriesList sampleQueriesList = null;
-
+            SampleQueriesList sampleQueriesList;
             if (!string.IsNullOrEmpty(org) && !string.IsNullOrEmpty(branchName))
             {
                 // Fetch samples file from Github

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -36,19 +36,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                string locale = RequestHelper.GetPreferredLocaleLanguage(Request);
-                SampleQueriesList sampleQueriesList = null;
-
-                if (!string.IsNullOrEmpty(org) && !string.IsNullOrEmpty(branchName))
-                {
-                    // Fetch samples file from Github
-                    sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale, org, branchName);
-                }
-                else
-                {
-                    // Fetch sample queries from Azure Blob
-                    sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale);
-                }
+                var sampleQueriesList = await FetchSampleQueries(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {
@@ -88,14 +76,11 @@ namespace GraphWebApi.Controllers
        [Route("samples/{id}")]
        [Produces("application/json")]
        [HttpGet]
-        public async Task<IActionResult> GetSampleQueryByIdAsync(string id)
+        public async Task<IActionResult> GetSampleQueryByIdAsync(string id, string org, string branchName)
         {
             try
             {
-                string locale = RequestHelper.GetPreferredLocaleLanguage(Request);
-
-                // Fetch sample queries
-                SampleQueriesList sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale);
+                var sampleQueriesList = await FetchSampleQueries(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -315,6 +315,32 @@ namespace GraphWebApi.Controllers
         }
 
         /// <summary>
+        /// Fetches a list of Sample Queries from Github or blob storage
+        /// </summary>
+        /// <param name="org">The name of the organisation i.e microsoftgraph or a member's username in the case of a forked repo.</param>
+        /// <param name="branchName">The name of the branch.</param>
+        /// <returns>A list of Sample Queries.</returns>
+        private async Task<SampleQueriesList> FetchSampleQueries(string org, string branchName)
+        {
+            string locale = RequestHelper.GetPreferredLocaleLanguage(Request);
+
+            SampleQueriesList sampleQueriesList = null;
+
+            if (!string.IsNullOrEmpty(org) && !string.IsNullOrEmpty(branchName))
+            {
+                // Fetch samples file from Github
+                sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale, org, branchName);
+            }
+            else
+            {
+                // Fetch sample queries from Azure Blob
+                sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale);
+            }
+
+            return sampleQueriesList;
+        }
+
+        /// <summary>
         /// Gets the JSON file contents of the policies and returns a deserialized instance of a
         /// <see cref="SampleQueriesPolicies"/> from this.
         /// </summary>

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -36,7 +36,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                var sampleQueriesList = await FetchSampleQueries(org, branchName);
+                SampleQueriesList sampleQueriesList = await FetchSampleQueries(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {
@@ -80,7 +80,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                var sampleQueriesList = await FetchSampleQueries(org, branchName);
+                SampleQueriesList sampleQueriesList = await FetchSampleQueries(org, branchName);
 
                 if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
                 {


### PR DESCRIPTION
This PR allows searching of Sample Queries from the [DevX-Content repo](https://github.com/microsoftgraph/microsoft-graph-devx-content) by id

### Screenshot
![image](https://user-images.githubusercontent.com/36787645/114875009-8b0f6880-9e05-11eb-909e-b27a23f70dae.png)
Fixes #530 