### PR TITLE
Fix omision of subnamespaces in odata.type specified variables

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1285,8 +1285,11 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
 
             var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
-            var expectedType = "var legalHold = new Microsoft.Graph.Ediscovery.LegalHold";
+            var expectedType = "var legalHold = new Microsoft.Graph.Ediscovery.LegalHold";  // namespaced 
+            var controltype = "CreatedBy = new IdentitySet";  // Not namespaced since it's within graph namespace
             Assert.Contains(expectedType, result);
+            Assert.Contains(controltype, result);
+
         }
     }
 }

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1257,5 +1257,36 @@ namespace CodeSnippetsReflection.Test
             Assert.DoesNotContain(wrongType, result);
             Assert.Contains(expectedType, result);
         }
+
+        [Fact]
+        public void ShouldHaveOdataTypeInferencesRespectingSubnamespaces()
+        {
+            var expressions = new CSharpExpressions();
+            const string jsonObject = @"{
+                ""@odata.type"": ""#microsoft.graph.ediscovery.legalHold"",
+                ""description"": ""String"",
+                ""createdBy"": {
+                    ""@odata.type"": ""microsoft.graph.identitySet""
+                },
+                ""isEnabled"": ""Boolean"",
+                ""status"": ""String"",
+                ""contentQuery"": ""String"",
+                ""errors"": [
+                    ""String""
+                ],
+                ""displayName"": ""String""
+            }";
+            var requestPayload = new HttpRequestMessage(
+                HttpMethod.Post,
+                "https://graph.microsoft.com/beta/compliance/ediscovery/cases/{caseId}/legalHolds")
+            {
+                Content = new StringContent(jsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrlBeta, _edmModelBeta.Value);
+
+            var result = new CSharpGenerator(_edmModelBeta.Value).GenerateCodeSnippet(snippetModel, expressions);
+            var expectedType = "var legalHold = new Microsoft.Graph.Ediscovery.LegalHold";
+            Assert.Contains(expectedType, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -651,7 +651,10 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     break;
 
                 case "@odata.type":
-                    var proposedType = CommonGenerator.UppercaseFirstLetter(value.Split(".").Last());
+                    // Remove the prefixed #, then uppercase the individual strings in the odata path to make the proposedType
+                    var proposedType = String.Join(".", value.Split("#").Last().Split(".").Select(
+                        (item, _) => CommonGenerator.UppercaseFirstLetter(item))
+                    );
                     proposedType = proposedType.EndsWith("Request") ? proposedType + "Object" : proposedType; // disambiguate class names that end with Request
                     //check if the odata type specified is different
                     // maybe due to the declaration of a subclass of the type specified from the url.

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -637,7 +637,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         {
             if(String.IsNullOrEmpty(value))
             {
-                throw new ArgumentException(nameof(value), "Value for @odata.type cannot be empty");
+                throw new ArgumentNullException(nameof(value), "Value for @odata.type cannot be empty");
             }
 
             switch (key)

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -651,10 +651,19 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     break;
 
                 case "@odata.type":
-                    // Remove the prefixed #, then uppercase the individual strings in the odata path to make the proposedType
-                    var proposedType = String.Join(".", value.Split("#").Last().Split(".").Select(
-                        (item, _) => CommonGenerator.UppercaseFirstLetter(item))
-                    );
+                    string proposedType;
+                    // If type contains subnamespace of Microsoft.Graph e.g Microsoft.Graph.Ediscovery.LegalHold, prefix the namespace to the typeName
+                    // else if type not in graph namespace e.g Microsoft.OutlookServices or is a type directly within the graph subnamespace e.g Microsoft.Graph.IdentitySet
+                    // then proposedType is the <typeName> without prefix 
+                    var graphSubspaces = value.StartsWith("#microsoft.graph.") ? value.Substring("#microsoft.graph.".Length).Split(".".ToCharArray()) : new List<string>().ToArray() ; 
+                    if (graphSubspaces.Length > 1) {
+                        // Remove the prefixed `#`, then uppercase the individual strings in the odata path
+                        var namespacedTypeName = value.Split("#").Last().Split(".").Select((item, _) => CommonGenerator.UppercaseFirstLetter(item));
+                        proposedType = String.Join(".", namespacedTypeName);
+                    }
+                    else{
+                        proposedType = CommonGenerator.UppercaseFirstLetter(value.Split(".").Last());
+                    }
                     proposedType = proposedType.EndsWith("Request") ? proposedType + "Object" : proposedType; // disambiguate class names that end with Request
                     //check if the odata type specified is different
                     // maybe due to the declaration of a subclass of the type specified from the url.

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -635,6 +635,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <returns>a string builder with the relevant odata code added</returns>
         private static StringBuilder ProcessOdataIdAndType(StringBuilder stringBuilder, string key, string value, string className, string tabSpace)
         {
+            if(String.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(nameof(value), "Value for @odata.type cannot be empty");
+            }
+
             switch (key)
             {
                 case "@odata.id" when className.Equals("DirectoryObject") :
@@ -655,7 +660,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     // If type contains subnamespace of Microsoft.Graph e.g Microsoft.Graph.Ediscovery.LegalHold, prefix the namespace to the typeName
                     // else if type not in graph namespace e.g Microsoft.OutlookServices or is a type directly within the graph subnamespace e.g Microsoft.Graph.IdentitySet
                     // then proposedType is the <typeName> without prefix 
-                    var graphSubspaces = value.StartsWith("#microsoft.graph.") ? value.Substring("#microsoft.graph.".Length).Split(".".ToCharArray()) : new List<string>().ToArray() ; 
+                    var graphSubspaces = value.StartsWith("#microsoft.graph.") ? value["#microsoft.graph.".Length..].Split(".".ToCharArray()) : new string[] {} ; 
                     if (graphSubspaces.Length > 1) {
                         // Remove the prefixed `#`, then uppercase the individual strings in the odata path
                         var namespacedTypeName = value.Split("#").Last().Split(".").Select((item, _) => CommonGenerator.UppercaseFirstLetter(item));


### PR DESCRIPTION
Fixes #505 

If there is an @odata.type specified in the request object, snippet generation uses that over the inferred type from the URL structure to determine the type name.However, in generating @odata.type specified value to create variables, the subnamespaces were being ignored such that the typeNames generated are not prefixed with `Microsoft.Graph.*` subnamespace. This PR fixes this.

Acceptance Criteria:
- If type contains subnamespace of Microsoft.Graph e.g `Microsoft.Graph.Ediscovery.LegalHold`, prefix the namespace to the typeName.
- If type not in graph namespace e.g `Microsoft.OutlookServices.*` or is a type directly within the graph subnamespace e.g `Microsoft.Graph.IdentitySet`
                    - then proposedType is the typeName without prefix 
- Create an issue to fix non-graph odata.types in the docs repo: https://github.com/microsoftgraph/microsoft-graph-docs/issues/12364
                   - Currently only the entry `"@odata.type":"#Microsoft.OutlookServices.ConversationThread"` exists in both beta and V1 docs.


Generated docs diff from this PR: https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/47837...snippet-generation/47838?expand=1