### PR TITLE
Revert OpenApi.OData lib. version to 1.0.6

### DIFF
--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.8.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.7" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.6" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/542
This is a temporary fix to unblock PowerShell's release. More info can be found in the [issue](https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/542).

@baywet you can ignore any future dependabot's PRs for this lib. in the meantime, until a more permanent fix is achieved.