### PR TITLE
Resolves action and function OperationIds for PowerShell style

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,6 +2,8 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -476,6 +478,161 @@ namespace OpenAPIService.Test
                                                     }
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ["/communications/calls/{call-id}/microsoft.graph.keepAlive"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Post, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        {
+                                            new OpenApiTag()
+                                            {
+                                                Name = "communications.Actions"
+                                            }
+                                        }
+                                    },
+                                    OperationId = "communications.calls.call.keepAlive",
+                                    Summary = "Invoke action keepAlive",
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        {
+                                            new OpenApiParameter()
+                                            {
+                                                Name = "call-id",
+                                                In = ParameterLocation.Path,
+                                                Description = "key: id of call",
+                                                Required = true,
+                                                Schema = new OpenApiSchema()
+                                                {
+                                                    Type = "string"
+                                                },
+                                                Extensions = new Dictionary<string, IOpenApiExtension>
+                                                {
+                                                    {
+                                                        "x-ms-docs-key-type", new OpenApiString("call")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "204", new OpenApiResponse()
+                                            {
+                                                Description = "Success"
+                                            }
+                                        }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("action")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ["/groups/{group-id}/events/{event-id}/calendar/events/microsoft.graph.delta"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        {
+                                            new OpenApiTag()
+                                            {
+                                                Name = "groups.Functions"
+                                            }
+                                        }
+                                    },
+                                    OperationId = "groups.group.events.event.calendar.events.delta",
+                                    Summary = "Invoke function delta",
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        {
+                                            new OpenApiParameter()
+                                            {
+                                                Name = "group-id",
+                                                In = ParameterLocation.Path,
+                                                Description = "key: id of group",
+                                                Required = true,
+                                                Schema = new OpenApiSchema()
+                                                {
+                                                    Type = "string"
+                                                },
+                                                Extensions = new Dictionary<string, IOpenApiExtension>
+                                                {
+                                                    {
+                                                        "x-ms-docs-key-type", new OpenApiString("group")
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            new OpenApiParameter()
+                                            {
+                                                Name = "event-id",
+                                                In = ParameterLocation.Path,
+                                                Description = "key: id of event",
+                                                Required = true,
+                                                Schema = new OpenApiSchema()
+                                                {
+                                                    Type = "string"
+                                                },
+                                                Extensions = new Dictionary<string, IOpenApiExtension>
+                                                {
+                                                    {
+                                                        "x-ms-docs-key-type", new OpenApiString("event")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200", new OpenApiResponse()
+                                            {
+                                                Description = "Success",
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    {
+                                                        applicationJsonMediaType,
+                                                        new OpenApiMediaType
+                                                        {
+                                                            Schema = new OpenApiSchema
+                                                            {
+                                                                Type = "array",
+                                                                Reference = new OpenApiReference
+                                                                {
+                                                                    Type = ReferenceType.Schema,
+                                                                    Id = "microsoft.graph.event"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("function")
                                         }
                                     }
                                 }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -28,11 +28,17 @@ namespace OpenAPIService.Test
             string operationId_2 = "reports.getTeamsUserActivityUserDetail-a3f1";
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1, tags: null, url: null, source: source)
-                .GetAwaiter().GetResult();
+            var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1,
+                                                             tags: null,
+                                                             url: null,
+                                                             source: source)
+                                                             .GetAwaiter().GetResult();
 
-            var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2, tags: null, url: null, source: source)
-                .GetAwaiter().GetResult();
+            var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2,
+                                                             tags: null,
+                                                             url: null,
+                                                             source: source)
+                                                             .GetAwaiter().GetResult();
 
             // Act
             var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
@@ -73,8 +79,11 @@ namespace OpenAPIService.Test
             }
             else
             {
-                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
-                                .GetAwaiter().GetResult()).Message;
+                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                                                                            tags: tags,
+                                                                                                            url: url,
+                                                                                                            source: source)
+                                                                                                            .GetAwaiter().GetResult()).Message;
 
                 if (url != null && (operationIds != null || tags != null))
                 {
@@ -94,8 +103,11 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act and Assert
-            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/foo", source: source)
-                                .GetAwaiter().GetResult()).Message;
+            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null,
+                                                                                                tags: null,
+                                                                                                url: "/foo",
+                                                                                                source: source)
+                                                                                                .GetAwaiter().GetResult()).Message;
             Assert.Equal("The url supplied could not be found.", message);
         }
 
@@ -105,8 +117,10 @@ namespace OpenAPIService.Test
             // Arrange
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/", source: source)
-                                .GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
+            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/",
+                                                           source: source).GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -123,8 +137,11 @@ namespace OpenAPIService.Test
             // Arrange
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: null, source: source)
-                                .GetAwaiter().GetResult();
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                           tags: tags,
+                                                           url: null,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
 
             // Act & Assert
             var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
@@ -141,8 +158,11 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
-                                .GetAwaiter().GetResult();
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                           tags: tags,
+                                                           url: url,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
 
             // Assert
             Assert.NotNull(predicate);
@@ -158,8 +178,11 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
-                                .GetAwaiter().GetResult();
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                           tags: tags,
+                                                           url: url,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -187,15 +210,20 @@ namespace OpenAPIService.Test
         [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post, "administrativeUnits_restore")]
         [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch, "users.user_UpdateUser")]
         [InlineData(OpenApiStyle.PowerShell, "/applications/{application-id}/logo", OperationType.Put, "applications.application_SetLogo")]
-        public void ReturnStyledOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url,
-            OperationType operationType, string expectedOperationId = null)
+        public void ReturnStyledOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style,
+                                                                               string url,
+                                                                               OperationType operationType,
+                                                                               string expectedOperationId = null)
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: url, source: source)
-                                .GetAwaiter().GetResult();
+            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: url,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -271,8 +299,11 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: "*", tags: null, url: null, source: source)
-                                .GetAwaiter().GetResult(); // fetch all paths/operations
+            var predicate = OpenApiService.CreatePredicate(operationIds: "*",
+                                                           tags: null,
+                                                           url: null,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult(); // fetch all paths/operations
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -290,8 +321,11 @@ namespace OpenAPIService.Test
             var expectedDescription = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <#/>, etc.).";
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/security/hostSecurityProfiles", source: source)
-                                .GetAwaiter().GetResult();
+            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/security/hostSecurityProfiles",
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
             subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
@@ -301,6 +335,31 @@ namespace OpenAPIService.Test
 
             // Assert
             Assert.Equal(expectedDescription, descriptionSchema.Description);
+        }
+
+        [Theory]
+        [InlineData("/communications/calls/{call-id}/microsoft.graph.keepAlive", OperationType.Post, "communications.calls_keepAlive")]
+        [InlineData("/groups/{group-id}/events/{event-id}/calendar/events/microsoft.graph.delta", OperationType.Get, "groups.events.calendar.events_delta")]
+        public void ResolveActionFunctionOperationIdsForPowerShellStyle(string url, OperationType operationType, string expectedOperationId)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: url,
+                                                           source: source)
+                                                           .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var operationId = subsetOpenApiDocument.Paths[url]
+                              .Operations[operationType]
+                              .OperationId;
+
+            // Assert
+            Assert.Equal(expectedOperationId, operationId);
         }
     }
 }

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.8.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.7" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.6" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.8.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.6" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.7" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
   </ItemGroup>
 

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -2,15 +2,18 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
+using System;
+using System.Linq;
 using System.Text;
 
 namespace OpenAPIService
 {
-   /// <summary>
-   /// Apply changes to ensure compatibility with the AutoREST PowerShell generator
-   /// </summary>
+    /// <summary>
+    /// Apply changes to ensure compatibility with the AutoREST PowerShell generator
+    /// </summary>
     internal class PowershellFormatter : OpenApiVisitorBase
     {
         private const string DefaultPutPrefix = ".Update";
@@ -47,6 +50,23 @@ namespace OpenAPIService
         {
             var operationId = operation.OperationId;
 
+            if (operation.Extensions.TryGetValue("x-ms-docs-operation-type",
+                                                  out var value) && value != null)
+            {
+                var strValue = ((OpenApiString)value).Value;
+
+                if (strValue.Equals("action", StringComparison.OrdinalIgnoreCase) ||
+                    strValue.Equals("function", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Only valid if Microsoft.OpenApi.OData package ver. 1.0.7 and greater is used.
+                    // This fix: https://github.com/microsoft/OpenAPI.NET.OData/pull/98
+                    // in the above library changed how action and function OperationIds are constructed.
+                    // To maintain pre-existing cmdlet names in PowerShell, we need to resolve their
+                    // OperationIds to how they were being constructed in earlier versions of the lib.
+                    operationId = ResolveActionFunctionOperationId(operation);
+                }
+            }
+
             int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
 
             // Check whether Put operation id already got updated
@@ -63,9 +83,49 @@ namespace OpenAPIService
         {
             if (schema?.Type == "object")
             {
-                schema.AdditionalProperties = new OpenApiSchema() {Type = "object"};  // To make AutoREST happy
+                schema.AdditionalProperties = new OpenApiSchema() { Type = "object" };  // To make AutoREST happy
             }
             base.Visit(schema);
+        }
+
+        /// <summary>
+        /// Resolves action and function OperationIds by reverting their signatures
+        /// to how they were being defined in package Microsoft.OpenApi.OData ver. 1.0.6 and below.
+        /// </summary>
+        /// <remarks>
+        /// This is to prevent change of cmdlet names already defined using the previous version's format.
+        /// </remarks>
+        /// <example>
+        /// Default OperationId --> communications.calls.call_keepAlive
+        /// Resolved OperationId --> communications.calls_keepAlive
+        /// </example>
+        /// <param name="operation">The target OpenAPI operation.</param>
+        /// <returns>The resolved OperationId.</returns>
+        private string ResolveActionFunctionOperationId(OpenApiOperation operation)
+        {
+            var operationId = operation.OperationId;
+            var segments = operationId.Split('.', (char)StringSplitOptions.RemoveEmptyEntries).ToList();
+
+            foreach (var parameter in operation.Parameters)
+            {
+                // Get the ODataKeySegment value.
+                // Paths containing the above segment are
+                // the ones needing to be resolved
+                if (parameter.Extensions.TryGetValue("x-ms-docs-key-type",
+                                                     out var value) && value != null)
+                {
+                    var strValue = ((OpenApiString)value).Value;
+
+                    // This is the EntityType string representation of the ODataKeySegment,
+                    // remove from the operation id
+                    if (operationId.Contains(strValue))
+                    {
+                        segments.Remove(strValue);
+                    }
+                }
+            }
+
+            return string.Join(".", segments);
         }
     }
 }

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -53,7 +53,7 @@ namespace OpenAPIService
             if (operation.Extensions.TryGetValue("x-ms-docs-operation-type",
                                                   out var value) && value != null)
             {
-                var operationType = ((OpenApiString)value).Value;
+                var operationType = (value as OpenApiString)?.Value;
 
                 if (operationType.Equals("action", StringComparison.OrdinalIgnoreCase) ||
                     operationType.Equals("function", StringComparison.OrdinalIgnoreCase))

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -114,7 +114,7 @@ namespace OpenAPIService
                 if (parameter.Extensions.TryGetValue("x-ms-docs-key-type",
                                                      out var value) && value != null)
                 {
-                    var keyType = ((OpenApiString)value).Value;
+                    var keyType = (value as OpenApiString)?.Value;
 
                     if (operationId.Contains(keyType))
                     {

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -104,7 +104,7 @@ namespace OpenAPIService
         private string ResolveActionFunctionOperationId(OpenApiOperation operation)
         {
             var operationId = operation.OperationId;
-            var segments = operationId.Split('.', (char)StringSplitOptions.RemoveEmptyEntries).ToList();
+            var segments = operationId.Split(new char[] {'.'}, StringSplitOptions.RemoveEmptyEntries).ToList();
 
             foreach (var parameter in operation.Parameters)
             {

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -116,7 +116,7 @@ namespace OpenAPIService
                 {
                     var keyType = (value as OpenApiString)?.Value;
 
-                    if (operationId.Contains(keyType))
+                    if (!string.IsNullOrEmpty(keyType) && operationId.Contains(keyType))
                     {
                         segments.Remove(keyType);
                     }

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -55,7 +55,7 @@ namespace OpenAPIService
             {
                 var operationType = (value as OpenApiString)?.Value;
 
-                if (operationType.Equals("action", StringComparison.OrdinalIgnoreCase) ||
+                if ("action".Equals(operationType, StringComparison.OrdinalIgnoreCase) ||
                     operationType.Equals("function", StringComparison.OrdinalIgnoreCase))
                 {
                     // Only valid if Microsoft.OpenApi.OData package ver. 1.0.7 and greater is used.

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -56,7 +56,7 @@ namespace OpenAPIService
                 var operationType = (value as OpenApiString)?.Value;
 
                 if ("action".Equals(operationType, StringComparison.OrdinalIgnoreCase) ||
-                    operationType.Equals("function", StringComparison.OrdinalIgnoreCase))
+                    "function".Equals(operationType, StringComparison.OrdinalIgnoreCase))
                 {
                     // Only valid if Microsoft.OpenApi.OData package ver. 1.0.7 and greater is used.
                     // This fix: https://github.com/microsoft/OpenAPI.NET.OData/pull/98

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -53,10 +53,10 @@ namespace OpenAPIService
             if (operation.Extensions.TryGetValue("x-ms-docs-operation-type",
                                                   out var value) && value != null)
             {
-                var strValue = ((OpenApiString)value).Value;
+                var operationType = ((OpenApiString)value).Value;
 
-                if (strValue.Equals("action", StringComparison.OrdinalIgnoreCase) ||
-                    strValue.Equals("function", StringComparison.OrdinalIgnoreCase))
+                if (operationType.Equals("action", StringComparison.OrdinalIgnoreCase) ||
+                    operationType.Equals("function", StringComparison.OrdinalIgnoreCase))
                 {
                     // Only valid if Microsoft.OpenApi.OData package ver. 1.0.7 and greater is used.
                     // This fix: https://github.com/microsoft/OpenAPI.NET.OData/pull/98
@@ -110,17 +110,15 @@ namespace OpenAPIService
             {
                 // Get the ODataKeySegment value.
                 // Paths containing the above segment are
-                // the ones needing to be resolved
+                // the ones needing to be resolved.
                 if (parameter.Extensions.TryGetValue("x-ms-docs-key-type",
                                                      out var value) && value != null)
                 {
-                    var strValue = ((OpenApiString)value).Value;
+                    var keyType = ((OpenApiString)value).Value;
 
-                    // This is the EntityType string representation of the ODataKeySegment,
-                    // remove from the operation id
-                    if (operationId.Contains(strValue))
+                    if (operationId.Contains(keyType))
                     {
-                        segments.Remove(strValue);
+                        segments.Remove(keyType);
                     }
                 }
             }


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/543

**Summary:**
PowerShell had breaking changes due to this fix: https://github.com/microsoft/OpenAPI.NET.OData/pull/98. 
This fix was included in the `Microsoft.OpenApi.OData` package `v1.0.7`. This caused cmdlets names generated from _action_ and _function_ operations to change due to changed _OperationIds_. The target library version had to be reverted (to `v1.0.6`) to reverse this breaking change. There is need however, for bumping up the version while still continuing to provide the previous experience to PowerShell. In the OpenApiService in DevX API, we can modify certain aspects of the output OpenAPI doc. before serving the payload back to the requesting client. For the PowerShell style, we need to have a way of resolving _action_/_functions_ _OperationIds_ generated by the `Microsoft.OpenApi.OData` package. This PR aims to achieve that.

**Proposes:**
- Updating  `Microsoft.OpenApi.OData` from `v1.0.6` to `v1.0.7`
- Adding support for resolving _action_ and _function_ OperationIds by reverting their signatures to how they were being defined in the package `Microsoft.OpenApi.OData` `v1.0.6` and below.
- Adding and updating tests to validate the above.
- Minor code cleanup in the test file.

An example of an _action_ _OperationId_ generated from `v1.0.7` --> `communications.calls.call_keepAlive`
The same _OperationId_ generated from `v1.0.6` (and as expected by PowerShell so as to maintain the cmdlet names) --> `communications.calls_keepAlive`