### PR TITLE
Decode incoming url before parsing

### DIFF
--- a/GraphWebApi/Telemetry/CustomPIIFilter.cs
+++ b/GraphWebApi/Telemetry/CustomPIIFilter.cs
@@ -8,6 +8,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Web;
 
 namespace GraphWebApi.Telemetry
 {
@@ -185,7 +186,8 @@ namespace GraphWebApi.Telemetry
         /// <returns>A sanitized request path string.</returns>
         private string RedactUserName(string requestPathValue)
         {
-            var queryString = requestPathValue.Split("\'");
+            var decodedUrl = HttpUtility.UrlDecode(requestPathValue);
+            var queryString = decodedUrl.Split("\'");
 
             // Get the property name and sanitize it
             var propertyName = queryString[1];


### PR DESCRIPTION
Request urls with special characters are encoded by replacing them with one or more character triplets that consist of the percent character "%" followed by two hexadecimal digits for transmission over the web.

 Eg: `https://localhost:44399/permissions?requestUrl=/users?$filter(displayName eq 'Meghan')&method=GET` 
 becomes 
`https://localhost:44399/permissions?requestUrl=/users?$filter(displayName%20eq%20%27Meghan%27)&method=GET`

This PR decodes the encoded url before parsing it and filtering the user property name contained in it.
