### PR TITLE
Refactors, fixes and updates the TelemetryService

### DIFF
--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -25,14 +25,17 @@ namespace Telemetry.Test
             Assert.Throws<ArgumentNullException>(() => new CustomPIIFilter(null));
         }
 
-        [Fact]
-        public void SanitizeGUIDFromEventTelemetry()
+        [Theory]
+        [InlineData("/permissions?requestUrl=/users/20463493-79c2-4116-b87b-a20d06242e6a&method=GET",
+                    "/permissions?requestUrl=/users/****&method=GET")]
+        [InlineData("/permissions?requestUrl=/me/people/9f376303-1936-44a9-b4fd-7271483525bb/drives&method=GET",
+                    "/permissions?requestUrl=/me/people/****/drives&method=GET")]
+        public void SanitizeGUIDFromEventTelemetry(string requestPath, string expectedPath)
         {
             // Arrange
             var httpMethod = "GET";
             var statusCode = "200";
             var elapsed = "5000";
-            var requestPath = "/permissions?requestUrl=/users/1d201493-c13f-4e36-bd06-a20d06242e6a&method=GET";
             var renderedMessage = $"HTTP {httpMethod + requestPath} responded {statusCode} in {elapsed} ms";
 
             var eventTelemetry = new EventTelemetry();
@@ -47,7 +50,7 @@ namespace Telemetry.Test
                 _telemetryProcessor.Process(eventTelemetry);
             }
 
-            var expectedPath = "/permissions?requestUrl=/users/****&method=GET";
+            //var expectedPath = "/permissions?requestUrl=/users/****&method=GET";
             var expectedMessage = $"HTTP {httpMethod + expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert
@@ -63,7 +66,7 @@ namespace Telemetry.Test
             var statusCode = "200";
             var elapsed = "5000";
             var requestPath = "openapi?url=/users?$filter(emailAddress eq 'MiriamG@M365x214355.onmicrosoft.com')";
-            var renderedMessage = $"HTTP {httpMethod + requestPath} responded {statusCode} in {elapsed} ms";
+            var renderedMessage = $"HTTP {httpMethod} {requestPath} responded {statusCode} in {elapsed} ms";
 
             var eventTelemetry = new EventTelemetry();
             eventTelemetry.Properties.Add("RequestPath", requestPath);
@@ -78,7 +81,7 @@ namespace Telemetry.Test
             }
 
             var expectedPath = "openapi?url=/users?$filter(emailAddress eq '****')";
-            var expectedMessage = $"HTTP {httpMethod + expectedPath} responded {statusCode} in {elapsed} ms";
+            var expectedMessage = $"HTTP {httpMethod} {expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert
             Assert.Equal(expectedPath, eventTelemetry.Properties["RequestPath"]);
@@ -93,7 +96,7 @@ namespace Telemetry.Test
             var statusCode = "200";
             var elapsed = "5000";
             var requestPath = "/openapi?url=/users?$filter(displayName eq 'Megan Bowen')";
-            var renderedMessage = $"HTTP {httpMethod + requestPath} responded {statusCode} in {elapsed} ms";
+            var renderedMessage = $"HTTP {httpMethod} {requestPath} responded {statusCode} in {elapsed} ms";
 
             var eventTelemetry = new EventTelemetry();
             eventTelemetry.Properties.Add("RequestPath", requestPath);
@@ -108,7 +111,7 @@ namespace Telemetry.Test
             }
 
             var expectedPath = "/openapi?url=/users?$filter(displayName eq '****')";
-            var expectedMessage = $"HTTP {httpMethod + expectedPath} responded {statusCode} in {elapsed} ms";
+            var expectedMessage = $"HTTP {httpMethod} {expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert
             Assert.Equal(expectedPath, eventTelemetry.Properties["RequestPath"]);
@@ -123,7 +126,7 @@ namespace Telemetry.Test
             var statusCode = "200";
             var elapsed = "5000";
             var requestPath = "/openapi?url=/users?$filter(firstName eq 'Megan')";
-            var renderedMessage = $"HTTP {httpMethod + requestPath} responded {statusCode} in {elapsed} ms";
+            var renderedMessage = $"HTTP {httpMethod} {requestPath} responded {statusCode} in {elapsed} ms";
 
             var eventTelemetry = new EventTelemetry();
             eventTelemetry.Properties.Add("RequestPath", requestPath);
@@ -138,7 +141,7 @@ namespace Telemetry.Test
             }
 
             var expectedPath = "/openapi?url=/users?$filter(firstName eq '****')";
-            var expectedMessage = $"HTTP {httpMethod + expectedPath} responded {statusCode} in {elapsed} ms";
+            var expectedMessage = $"HTTP {httpMethod} {expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert
             Assert.Equal(expectedPath, eventTelemetry.Properties["RequestPath"]);

--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -50,7 +50,6 @@ namespace Telemetry.Test
                 _telemetryProcessor.Process(eventTelemetry);
             }
 
-            //var expectedPath = "/permissions?requestUrl=/users/****&method=GET";
             var expectedMessage = $"HTTP {httpMethod + expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert

--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -79,7 +79,7 @@ namespace Telemetry.Test
                 _telemetryProcessor.Process(eventTelemetry);
             }
 
-            var expectedPath = "openapi?url=/users?$filter(emailAddress eq '****')";
+            var expectedPath = "openapi?url=/users?$filter(emailAddress eq ****)";
             var expectedMessage = $"HTTP {httpMethod} {expectedPath} responded {statusCode} in {elapsed} ms";
 
             // Assert
@@ -158,7 +158,7 @@ namespace Telemetry.Test
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=firstName eq ****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=emailAddress eq 'MiriamG@M365x214355.onmicrosoft.com'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=emailAddress eq '****'")]
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=emailAddress eq ****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users/1d201493-c13f-4e36-bd06-a20d06242e6a&method=GET",
                     "https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users/****&method=GET")]
@@ -175,6 +175,9 @@ namespace Telemetry.Test
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith(givenName,'Alex')",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith****")]
 
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=testProperty eq 'arbitraryPropertyData'",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=testProperty eq ****")]
+
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c",
                     "https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c")]
 
@@ -189,11 +192,7 @@ namespace Telemetry.Test
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples?search='hello world'",
                     "https://graphexplorerapi.azurewebsites.net/samples?search='hello world'")]
-
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/me/people/e3d0513b-449e-4198-ba6f-bd97ae7cae85",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/me/people/****")]
-
-        public void RedactUserPropertyFromRequestTelemetry(string incomingUrl, string expectedUrl)
+        public void SanitizeODataQueryOptionsFromTelemetry(string incomingUrl, string expectedUrl)
         {
             // Arrange
             var request = new RequestTelemetry

--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -26,8 +26,8 @@ namespace Telemetry.Test
         }
 
         [Theory]
-        [InlineData("/permissions?requestUrl=/users/20463493-79c2-4116-b87b-a20d06242e6a&method=GET",
-                    "/permissions?requestUrl=/users/****&method=GET")]
+        [InlineData("/permissions?requestUrl=/groups/20463493-79c2-4116-b87b-a20d06242e6a&method=GET",
+                    "/permissions?requestUrl=/groups/****&method=GET")]
         [InlineData("/permissions?requestUrl=/me/people/9f376303-1936-44a9-b4fd-7271483525bb/drives&method=GET",
                     "/permissions?requestUrl=/me/people/****/drives&method=GET")]
         public void SanitizeGUIDFromEventTelemetry(string requestPath, string expectedPath)
@@ -175,8 +175,11 @@ namespace Telemetry.Test
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith(givenName,'Alex')",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith****")]
 
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=testProperty eq 'arbitraryPropertyData'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=testProperty eq ****")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=startswith(displayName, 'a')&$count=true&$top=1&$orderby=displayName",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=startswith****&$count=true&$top=1&$orderby=displayName")]
+
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty eq 'arbitraryPropertyData'",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty eq ****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c",
                     "https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c")]
@@ -187,8 +190,8 @@ namespace Telemetry.Test
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='Meghan'",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search=****")]
 
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='5555551212'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search=****")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/me/messages?$search='5555551212'",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/me/messages?$search=****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples?search='hello world'",
                     "https://graphexplorerapi.azurewebsites.net/samples?search='hello world'")]

--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -180,13 +180,13 @@ namespace Telemetry.Test
                     "https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='displayName:Meghan'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='****'")]
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search=****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='Meghan'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='****'")]
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search=****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='5555551212'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search='****'")]
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$search=****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples?search='hello world'",
                     "https://graphexplorerapi.azurewebsites.net/samples?search='hello world'")]

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -179,7 +179,7 @@ namespace TelemetryService
         /// <returns>The string content with all PII in the query option sanitized.</returns>
         private static string SanitizeODataQueryOptions(string content)
         {
-            string sanitizedContent = content;
+            var sanitizedContent = content;
 
             if (sanitizedContent.Contains(ODataFilterOperator))
             {

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -201,7 +201,7 @@ namespace TelemetryService
         /// <returns>The string content with all filterable values redacted.</returns>
         private static string RedactFilterableValues(string content)
         {
-            if (!(bool)(content?.Contains(ODataFilterOperator)))
+            if (!(content?.Contains(ODataFilterOperator) ?? false))
             {
                 return content;
             }

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -208,7 +208,7 @@ namespace TelemetryService
 
             var contents = content.Split(ODataFilterOperator);
 
-            if (!(bool)contents?.Any())
+            if (!(contents?.Any() ?? false))
             {
                 return content;
             }

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -246,7 +246,7 @@ namespace TelemetryService
         {
             var contents = content.Split(ODataSearchOperator);
 
-            if (!(bool)contents?.Any())
+            if (!(contents?.Any() ?? false))
             {
                 return content;
             }

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -258,7 +258,7 @@ namespace TelemetryService
             // e.g /openapi?url=/users?$search='displayName:Meghan' --> 'displayName:Meghan'
             var searchableContent = contents[1];
 
-            searchableContent = searchableContent.Replace(searchableContent, "'****'");
+            searchableContent = searchableContent.Replace(searchableContent, "****");
 
             return contents[0] + ODataSearchOperator + searchableContent;
         }

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -223,8 +223,8 @@ namespace TelemetryService
 
             foreach (var option in _odataFilterOptions)
             {
-                var pattern_1 = @$"(?<=\b{option}\s*)('(.*?)')"; // will match ex: /Products?$filter=Name eq 'Milk'
-                var pattern_2 = @$"(?<=\b{option}\s*)(\((.*?)\))"; // will match ex: /Products?$filter=Name in ('Milk', 'Cheese')
+                var pattern_1 = @$"(?<=\b{option}\s*)('(.*?)')"; // will match 'Milk' in example: /Products?$filter=Name eq 'Milk'
+                var pattern_2 = @$"(?<=\b{option}\s*)(\((.*?)\))"; // will match ('Milk', 'Cheese') in example: /Products?$filter=Name in ('Milk', 'Cheese')
                 var regex_1 = new Regex(pattern_1);
                 var regex_2 = new Regex(pattern_2);
 


### PR DESCRIPTION
This PR proposes:
- Adding option for sanitizing trace events. Trace events will soon start being captured in an upcoming feature. Includes tests to validate this.
-  Refactors code by modularizing similar functionalities and renaming a few variables/methods for ease of maintenance and to promote consistency.
- Addresses a couple of extra OData `$filter` cases that need to be sanitized. Tests have been updated to validate this.
- Sanitizing all `$search` and `$filter` property values for `/users` and `/people`
- Fixes a few bugs and updates the relevant tests where the below example request urls were not being sanitized properly:
 1. `/permissions?requesturl=/users/9f376303-1936-44a9-b4fd-7271483525bb/drives&method=GET`, 
2. `/permissions?requesturl=/users/20463493-79c2-4116-b87b-a20d06242e6a/drives&method=GET`. 

This was because the `_employeeIdRegex` `[0-9]{7}` was sanitizing the above GUIDs on the original value even after the `_guidRegex` already made a pass. Hence, 

1. would be: `/permissions?requesturl=/users/9f376303-1936-44a9-b4fd-****525bb/drives&method=GET`, and
2.  would be: `/permissions?requesturl=/users/****3-79c2-4116-b87b-a20d06242e6a/drives&method=GET`

Also, the event telemetry `RequestPath` and `RenderedMessage` values were skipped being sanitized for presence of OData `$search` options.