### PR TITLE
Fix: Ignore casing when resolving regex for $filter sanitizations

### DIFF
--- a/TelemetryService.Test/CustomPIIFilterShould.cs
+++ b/TelemetryService.Test/CustomPIIFilterShould.cs
@@ -148,14 +148,14 @@ namespace Telemetry.Test
         }
 
         [Theory]
-        [InlineData("https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users?$filter(displayName eq 'Megan Bowen')",
-                    "https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users?$filter(displayName eq ****)")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users?$filter(displayName eQ 'Megan Bowen')",
+                    "https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/users?$filter(displayName eQ ****)")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=displayName%20eq%20%27Meghan%27",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=displayName eq ****")]
 
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=firstName eq 'Megan'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=firstName eq ****")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=firstName Eq 'Megan'",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=firstName Eq ****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=emailAddress eq 'MiriamG@M365x214355.onmicrosoft.com'",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=emailAddress eq ****")]
@@ -172,14 +172,14 @@ namespace Telemetry.Test
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=givenName in ('Adele', 'Alex')",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=givenName in ****")]
 
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith(givenName,'Alex')",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith****")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=StartsWith(givenName,'Alex')",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=StartsWith****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=startswith(displayName, 'a')&$count=true&$top=1&$orderby=displayName",
                     "https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=startswith****&$count=true&$top=1&$orderby=displayName")]
 
-        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty eq 'arbitraryPropertyData'",
-                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty eq ****")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty EQ 'arbitraryPropertyData'",
+                    "https://graphexplorerapi.azurewebsites.net/openapi?url=/groups?$filter=testProperty EQ ****")]
 
         [InlineData("https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c",
                     "https://graphexplorerapi.azurewebsites.net/samples/0277cf48-fd30-45fa-b2a7-a845f4f4e36c")]

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -225,10 +225,10 @@ namespace TelemetryService
             foreach (var option in _odataFilterOptions)
             {
                 // Matches 'Milk' in example: /Products?$filter=Name eq 'Milk'
-                var regex_1 = new Regex(@$"(?<=\b{option}\s*)('(.*?)')");
+                var regex_1 = new Regex(@$"(?<=\b{option}\s*)('(.*?)')", RegexOptions.IgnoreCase);
 
                 // Matches ('Milk', 'Cheese') in example: /Products?$filter=Name in ('Milk', 'Cheese')
-                var regex_2 = new Regex(@$"(?<=\b{option}\s*)(\((.*?)\))");
+                var regex_2 = new Regex(@$"(?<=\b{option}\s*)(\((.*?)\))", RegexOptions.IgnoreCase);
 
                 if (regex_1.IsMatch(filterableContent))
                 {


### PR DESCRIPTION
Fixes instances of strings with varying cases that are to be matched by a given regex. For example, given this regex string:
`(?<=\bstartswith\s*)(\((.*?)\))` constructed from this list of all lower-cased values:
https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/2619a3c7ca2f2abe917355338981c04d780bd9f4/TelemetryService/CustomPIIFilter.cs#L44-L60 
The above specified regex matches this url: 
`https://graphexplorerapi-staging.azurewebsites.net/openapi?url=/users?$filter=startswith(displayName,'John Doe')&style=GEAutocomplete`, 

but not this: 

`https://graphexplorerapi-staging.azurewebsites.net/openapi?url=/users?$filter=startsWith(displayName,'John Doe')&style=GEAutocomplete`  

(note the **startswith** and **startsWith** casing in the two urls' `$filter` options respectively). 

- Using `RegexOptions.IgnoreCase` resolves this. 
- Tests have been updated to validate this.

This is only applicable to the `$filter` option regex checks. 

