### PR TITLE
Creates utility library and bump projects to net5.0

### DIFF
--- a/FileService/FileService.csproj
+++ b/FileService/FileService.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
+++ b/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\FileService\FileService.csproj" />
     <ProjectReference Include="..\UriMatchService\UriMatchingService.csproj" />
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
+++ b/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -17,6 +17,7 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UriMatchingService;
+using UtilityService;
 
 namespace GraphExplorerPermissionsService
 {
@@ -319,7 +320,7 @@ namespace GraphExplorerPermissionsService
                         throw new ArgumentNullException(nameof(method), "The HTTP method value cannot be null or empty.");
                     }
 
-                    requestUrl = Regex.Replace(requestUrl, @"\?.*", string.Empty); // remove any query params
+                    requestUrl = requestUrl.BaseUriPath(); // remove any query params
                     requestUrl = Regex.Replace(requestUrl, @"\(.*?\)", string.Empty); // remove any '(...)' resource modifiers
 
                     // Check if requestUrl is contained in our Url Template table

--- a/GraphExplorerSamplesService/GraphExplorerSamplesService.csproj
+++ b/GraphExplorerSamplesService/GraphExplorerSamplesService.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -37,7 +37,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChangesService.Test", "Chan
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TelemetryService.Test", "TelemetryService.Test\TelemetryService.Test.csproj", "{3F86F0DF-82CA-4EC2-8FC7-00B7B62A3A0B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelemetryService", "TelemetryService\TelemetryService.csproj", "{F0BA9165-34C0-4A76-B42E-0FC274357AF0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TelemetryService", "TelemetryService\TelemetryService.csproj", "{F0BA9165-34C0-4A76-B42E-0FC274357AF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UtilityService", "UtilityService\UtilityService.csproj", "{C3241050-9B95-49B9-B223-5FACF59F0052}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UtilityService.Test", "UtilityService.Test\UtilityService.Test.csproj", "{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -117,6 +121,14 @@ Global
 		{F0BA9165-34C0-4A76-B42E-0FC274357AF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0BA9165-34C0-4A76-B42E-0FC274357AF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0BA9165-34C0-4A76-B42E-0FC274357AF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3241050-9B95-49B9-B223-5FACF59F0052}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3241050-9B95-49B9-B223-5FACF59F0052}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3241050-9B95-49B9-B223-5FACF59F0052}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3241050-9B95-49B9-B223-5FACF59F0052}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -169,7 +169,7 @@ namespace OpenAPIService.Test
         }
 
         [Theory]
-        [InlineData(null, null, "/users")]
+        [InlineData(null, null, "/users?$filter=startswith(displayName,'John Doe')")]
         [InlineData(null, "users.user", null)]
         [InlineData("users.user.ListUser", null, null)]
         public void ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UriMatchService\UriMatchingService.csproj" />
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -21,6 +21,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using OpenAPIService.Common;
 using UriMatchingService;
+using UtilityService;
 
 namespace OpenAPIService
 {
@@ -168,7 +169,8 @@ namespace OpenAPIService
                     await PopulateReferenceTablesAync(source);
                 }
 
-                url = url.Replace('-', '_');
+                url = url.BaseUriPath()
+                         .Replace('-', '_');
 
                 TemplateMatch resultMatch = _uriTemplateTable.Match(new Uri(url.ToLower(), UriKind.RelativeOrAbsolute));
 

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -122,7 +122,7 @@ namespace PermissionsService.Test
             /* Act */
 
             List<ScopeInformation> result1 =
-                _permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/users/{id}/calendars/{id}", method: "GET").GetAwaiter().GetResult(); // permission in ver1 doc.
+                _permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/users/{id}/calendars/{id}?$orderby=CreatedDate desc", method: "GET").GetAwaiter().GetResult(); // permission in ver1 doc.
             List<ScopeInformation> result2 =
                 _permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/anonymousipriskevents/{id}", method: "GET").GetAwaiter().GetResult(); // permission in ver2 doc.
             List<ScopeInformation> result3 =

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Web;
+using UtilityService;
 
 namespace TelemetryService
 
@@ -141,16 +142,15 @@ namespace TelemetryService
         /// <returns>The string url with PII sanitized from its query path.</returns>
         private string SanitizeUrlQueryPath(string url)
         {
-            var queryIndex = url?.IndexOf('?') ?? -1;
+            var queryPath = url?.Query();
 
-            if (queryIndex is < 0)
+            if (string.IsNullOrEmpty(queryPath))
             {
                 return url;
             }
 
-            var queryPath = url[queryIndex..];
             queryPath = SanitizeContent(queryPath);
-            return url[0..queryIndex] + queryPath;
+            return $"{url.BaseUriPath()}?{queryPath}";
         }
 
         /// <summary>

--- a/TelemetryService/TelemetryService.csproj
+++ b/TelemetryService/TelemetryService.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/UtilityService.Test/UtilityService.Test.csproj
+++ b/UtilityService.Test/UtilityService.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UtilityService.Test/UtilityServiceExtensionsShould.cs
+++ b/UtilityService.Test/UtilityServiceExtensionsShould.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace UtilityService.Test
 {
-    public class UtilityServiceShould
+    public class UtilityServiceExtensionsShould
     {
         [Theory]
         [InlineData("", "")]

--- a/UtilityService.Test/UtilityServiceShould.cs
+++ b/UtilityService.Test/UtilityServiceShould.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace UtilityService.Test
+{
+    public class UtilityServiceShould
+    {
+        [Theory]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        [InlineData("/openapi", "/openapi")]
+        [InlineData("/openapi?url=/me/messages", "/openapi")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith(displayName,'John Doe')",
+                    "https://graphexplorerapi.azurewebsites.net/openapi")]
+        public void GetBaseUriPath(string targetUri, string expectedBasePath)
+        {
+            // Arrange and Act
+            var actualBasePath = targetUri.BaseUriPath();
+
+            // Assert
+            Assert.Equal(expectedBasePath, actualBasePath);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        [InlineData("/openapi", "")]
+        [InlineData("/openapi?url=/me/messages", "url=/me/messages")]
+        [InlineData("https://graphexplorerapi.azurewebsites.net/openapi?url=/users?$filter=startswith(displayName,'John Doe')",
+                    "url=/users?$filter=startswith(displayName,'John Doe')")]
+        public void GetUriQuery(string targetUri, string expectedQuery)
+        {
+            // Arrange and Act
+            var actualQuery = targetUri.Query();
+
+            // Assert
+            Assert.Equal(expectedQuery, actualQuery);
+        }
+    }
+}

--- a/UtilityService/Extensions.cs
+++ b/UtilityService/Extensions.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace UtilityService
+{
+    /// <summary>
+    /// Provides common utility functions.
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Strips out the query path from a uri string.
+        /// </summary>
+        /// <param name="uri">The target uri string.</param>
+        /// <returns>The uri string without the query path.</returns>
+        public static string BaseUriPath(this string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                return uri;
+            }
+
+            var regex = new Regex(@"^[^?]+");
+            return regex.Match(uri).Value;
+        }
+
+        /// <summary>
+        /// Gets the query component from a uri string.
+        /// </summary>
+        /// <param name="uri">The target uri string.</param>
+        /// <returns>The query component from a uri string without the '?'.</returns>
+        public static string Query(this string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                return uri;
+            }
+
+            var regex = new Regex(@"(?<=\?)(.*)");
+            return regex.Match(uri).Value;
+        }
+    }
+}

--- a/UtilityService/UtilityService.csproj
+++ b/UtilityService/UtilityService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR proposes: 
- Bumping up the remainder of the projects to `net5.0`
- Creating a utility library that exposes an extensions class with:
  - An extension method that strips out the query path from a uri string.
  - An extension method that strips out the base path and get the query path from a uri string.

The above is useful in the `OpenApiService`, `Permissions` and `TelemetryService` libraries for stripping out a uri string and making use of either the query path or the base uri path. For `OpenApiService` and `Permissions` we need to strip out the query path to effectively match incoming request urls to our `UrlTemplate` dictionary. In the `TelemetryService`, we are only sanitizing the query path contents. 
This example request currently fails to fetch the appropriate OpenAPI doc.
`https://graphexplorerapi-staging.azurewebsites.net/openapi?url=/users?$filter=startswith(displayName,'John Doe')&style=GEAutocomplete`. 
We use the `url` query param value to match against values defined in the `UrlTemplate` dictionary.
Stripping out the query param from the `url` query param however works (`/users`).

- Tests have been updated in the `OpenApiService` and `Permissions` test libraries to validate this.
- Tests have been created to validate the `Extension.cs` class in the `UtilityService` project.