### PR TITLE
Remove $value and $ref from urls when matching permissions

### DIFF
--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -374,13 +374,17 @@ namespace GraphExplorerPermissionsService
                     return scopesList;
                 }
             }
-            catch (ArgumentNullException exception)
+            catch (ArgumentNullException)
             {
-                throw exception;
+                throw;
             }
             catch (ArgumentException)
             {
-                return null; // equivalent to no match for the given requestUrl
+                /* Equivalent to 'No match for the given requestUrl.'
+                 * This is the exception thrown by a regex match error
+                 * from the UriTemplateMatcher class.
+                */
+                return null;
             }
         }
 

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -67,6 +67,8 @@ namespace GraphWebApi.Controllers
             }
             catch (Exception exception)
             {
+                // Any 'InvalidOperationException' will also be caught here - these are classified as error 500
+
                 return new JsonResult(exception.Message) { StatusCode = StatusCodes.Status500InternalServerError };
             }
         }

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -59,11 +59,7 @@ namespace GraphWebApi.Controllers
                                                                     method: method);
                 }
 
-                return result == null ? NotFound() : (IActionResult)Ok(result);
-            }
-            catch (InvalidOperationException invalidOpsException)
-            {
-                return new JsonResult(invalidOpsException.Message) { StatusCode = StatusCodes.Status500InternalServerError };
+                return result == null ? NotFound() : Ok(result);
             }
             catch (ArgumentNullException argNullException)
             {

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -113,6 +113,8 @@ namespace PermissionsService.Test
                 _permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/anonymousipriskevents/{id}", method: "GET").GetAwaiter().GetResult(); // permission in ver2 doc.
             List<ScopeInformation> result3 =
                 _permissionsStore.GetScopesAsync(scopeType: "Application", requestUrl: "/security/alerts/{id}", method: "PATCH").GetAwaiter().GetResult(); // permission in ver1 doc.
+            List<ScopeInformation> result4 =
+                _permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/me/photo/$value", method: "PATCH").GetAwaiter().GetResult(); // permission in ver1 doc.
 
             /* Assert */
 
@@ -141,6 +143,22 @@ namespace PermissionsService.Test
                   Assert.Equal("Read and update your organization's security events", item.DisplayName);
                   Assert.Equal("Allows the app to read your organization's security events without a signed-in user. Also allows the app to update editable properties in security events.", item.Description);
                   Assert.False(item.IsAdmin);
+              });
+
+            Assert.Collection(result4,
+              item =>
+              {
+                  Assert.Equal("User.ReadWrite", item.ScopeName);
+                  Assert.Equal("Read and update your profile", item.DisplayName);
+                  Assert.Equal("Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.", item.Description);
+                  Assert.False(item.IsAdmin);
+              },
+              item =>
+              {
+                  Assert.Equal("User.ReadWrite.All", item.ScopeName);
+                  Assert.Equal("Read and write all users' full profiles", item.DisplayName);
+                  Assert.Equal("Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.", item.Description);
+                  Assert.True(item.IsAdmin);
               });
         }
 

--- a/PermissionsService.Test/TestFiles/permissions-test-file-v1.0_ver1.json
+++ b/PermissionsService.Test/TestFiles/permissions-test-file-v1.0_ver1.json
@@ -1,286 +1,330 @@
 {
-    "ApiPermissions": {
-        "/security/alerts/{id}": [
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "SecurityEvents.Read.All",
-                "SecurityEvents.ReadWrite.All"
-              ],
-              "DelegatedPersonal": [],
-              "Application": [
-                "SecurityEvents.Read.All",
-                "SecurityEvents.ReadWrite.All"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "SecurityEvents.ReadWrite.All"
-              ],
-              "DelegatedPersonal": [],
-              "Application": [
-                "SecurityEvents.ReadWrite.All"
-              ]
-            }
-          ],
-        "/security/alerts": [
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "SecurityEvents.Read.All",
-                "SecurityEvents.ReadWrite.All"
-              ],
-              "DelegatedPersonal": [],
-              "Application": [
-                "SecurityEvents.Read.All",
-                "SecurityEvents.ReadWrite.All"
-              ]
-            }
-          ],
-        "/me/calendars/{id}": [
-            {
-              "HttpVerb": "DELETE",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            },
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/users/{id}/calendars/{id}": [
-            {
-              "HttpVerb": "DELETE",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            },
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/me/calendars/{id}": [
-            {
-              "HttpVerb": "DELETE",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            },
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/me/calendargroup/calendars/{id}": [
-            {
-              "HttpVerb": "DELETE",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            },
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/users/{id}/calendargroup/calendars": [
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "POST",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/me/calendargroup/calendars/{id}": [
-            {
-              "HttpVerb": "DELETE",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            },
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Calendars.Read"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.Read"
-              ],
-              "Application": [
-                "Calendars.Read"
-              ]
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Calendars.ReadWrite"
-              ],
-              "DelegatedPersonal": [
-                "Calendars.ReadWrite"
-              ],
-              "Application": [
-                "Calendars.ReadWrite"
-              ]
-            }
-          ],
-        "/workbook/worksheets/{id}/charts/{id}": [
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Files.ReadWrite"
-              ],
-              "DelegatedPersonal": [],
-              "Application": []
-            },
-            {
-              "HttpVerb": "PATCH",
-              "DelegatedWork": [
-                "Files.ReadWrite"
-              ],
-              "DelegatedPersonal": [],
-              "Application": []
-            }
-          ],
-        "/workbook/worksheets/{id}/charts/{id}/image(width=640)": [
-            {
-              "HttpVerb": "GET",
-              "DelegatedWork": [
-                "Files.ReadWrite"
-              ],
-              "DelegatedPersonal": [],
-              "Application": []
-            }
-          ]
-    }
+  "ApiPermissions": {
+    "/security/alerts/{id}": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "SecurityEvents.Read.All",
+          "SecurityEvents.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [],
+        "Application": [
+          "SecurityEvents.Read.All",
+          "SecurityEvents.ReadWrite.All"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "SecurityEvents.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [],
+        "Application": [
+          "SecurityEvents.ReadWrite.All"
+        ]
+      }
+    ],
+    "/security/alerts": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "SecurityEvents.Read.All",
+          "SecurityEvents.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [],
+        "Application": [
+          "SecurityEvents.Read.All",
+          "SecurityEvents.ReadWrite.All"
+        ]
+      }
+    ],
+    "/me/calendars/{id}": [
+      {
+        "HttpVerb": "DELETE",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      },
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/users/{id}/calendars/{id}": [
+      {
+        "HttpVerb": "DELETE",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      },
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/me/calendars/{id}": [
+      {
+        "HttpVerb": "DELETE",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      },
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/me/calendargroup/calendars/{id}": [
+      {
+        "HttpVerb": "DELETE",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      },
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/users/{id}/calendargroup/calendars": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "POST",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/me/calendargroup/calendars/{id}": [
+      {
+        "HttpVerb": "DELETE",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      },
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Calendars.Read"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.Read"
+        ],
+        "Application": [
+          "Calendars.Read"
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Calendars.ReadWrite"
+        ],
+        "DelegatedPersonal": [
+          "Calendars.ReadWrite"
+        ],
+        "Application": [
+          "Calendars.ReadWrite"
+        ]
+      }
+    ],
+    "/workbook/worksheets/{id}/charts/{id}": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Files.ReadWrite"
+        ],
+        "DelegatedPersonal": [],
+        "Application": []
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "Files.ReadWrite"
+        ],
+        "DelegatedPersonal": [],
+        "Application": []
+      }
+    ],
+    "/workbook/worksheets/{id}/charts/{id}/image(width=640)": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "Files.ReadWrite"
+        ],
+        "DelegatedPersonal": [],
+        "Application": []
+      }
+    ],
+    "/me/photo": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "User.ReadBasic.All",
+          "User.Read",
+          "User.ReadWrite",
+          "User.Read.All",
+          "User.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [
+          "Not supported."
+        ],
+        "Application": [
+          "Not supported."
+        ]
+      },
+      {
+        "HttpVerb": "PATCH",
+        "DelegatedWork": [
+          "User.ReadWrite",
+          "User.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [
+          "Not supported."
+        ],
+        "Application": [
+          "Not supported."
+        ]
+      },
+      {
+        "HttpVerb": "PUT",
+        "DelegatedWork": [
+          "User.ReadWrite",
+          "User.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [
+          "Not supported."
+        ],
+        "Application": [
+          "Not supported."
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/584

This PR:
- Removes `/${value}` segments from urls for permissions requests in `PermissionsStore.cs`. The JSON permissions mappings don't include the ${values}, ex: `/me/photo/$value` should be resolved to `/me/photo` to be able to match with what is in the permissions mapping doc.. Also paths with `$refs` will be resolved, ex: `/applications/{application-id}/owners/$ref` will be resolved to `/applications/{application-id}/owners`
- Defines a private method `CleanRequestUrl()` in `PermissionsStore.cs` that abstracts out the formatting of the incoming request url to the expected output.
- Updates tests to validate the above.
- Removes `Argument` and `ArgumentNullException` exceptions handling in `PermissionsStore.cs`. We want to capture all argument exceptions in the Permissions controller because:
  - `ArgumentNullException` already gets captured in the controller. 
  - `ArgumentException` needs to be captured as a server error in the controller because this is caused by a Regex-related issue in the UriTemplateMatcher url matching process. The issue is usually caused by an improperly escaped special character in the regex pattern.
- Removes `InvalidOperationException` block in the controller - because it throws error 500 - _server error_, we can combine this with the global `Exception` block which throws the same error. This will be able to capture all `InvalidOperationException`s

NB: Because of deleting the `try... catch` statements in the `GetScopesAsync()` method in `PermissionsStore.cs`, the diff. might appear as though there have been line changes within the remaining code block.