### PR TITLE
Replaces UriTemplateMatcher with OpenApiUrlTreeNode in OpenAPIService

### DIFF
--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -315,7 +315,7 @@ namespace GraphExplorerPermissionsService
                     }
 
                     requestUrl = requestUrl.BaseUriPath() // remove any query params
-                                           .UriTemplatePathFormat();
+                                           .UriTemplatePathFormat(true);
 
                     // Check if requestUrl is contained in our Url Template table
                     TemplateMatch resultMatch = _urlTemplateMatcher.Match(new Uri(requestUrl.ToLowerInvariant(), UriKind.RelativeOrAbsolute));

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -422,7 +422,7 @@ namespace GraphExplorerPermissionsService
             }
 
             requestUrl = requestUrl.BaseUriPath() // remove any query params
-                                   .UriTemplatePathFormat();
+                                   .UriTemplatePathFormat(true);
 
             /* Remove ${value} segments from paths,
              * ex: /me/photo/$value --> $value or /applications/{application-id}/owners/$ref --> $ref

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -57,7 +57,12 @@ namespace GraphWebApi.Controllers
 
                 OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
 
-                var predicate = await OpenApiService.CreatePredicate(operationIds, tags, url, source, forceRefresh);
+                var predicate = await OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                                     tags: tags,
+                                                                     url: url,
+                                                                     source: source,
+                                                                     graphVersion: styleOptions.GraphVersion,
+                                                                     forceRefresh: forceRefresh);
 
                 var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 
@@ -105,16 +110,14 @@ namespace GraphWebApi.Controllers
             {
                 OpenApiStyleOptions styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
-                string graphUri = GetVersionUri(styleOptions.GraphVersion);
-
-                if (graphUri == null)
-                {
-                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
-                }
-
                 OpenApiDocument source = await OpenApiService.ConvertCsdlToOpenApiAsync(Request.Body);
 
-                var predicate = await OpenApiService.CreatePredicate(operationIds, tags, url, source, forceRefresh);
+                var predicate = await OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                                     tags: tags,
+                                                                     url: url,
+                                                                     source: source,
+                                                                     graphVersion: styleOptions.GraphVersion,
+                                                                     forceRefresh: forceRefresh);
 
                 var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -57,7 +57,7 @@ namespace GraphWebApi.Controllers
 
                 OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
 
-                var predicate = await OpenApiService.CreatePredicate(operationIds: operationIds,
+                var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
                                                                      tags: tags,
                                                                      url: url,
                                                                      source: source,
@@ -112,7 +112,7 @@ namespace GraphWebApi.Controllers
 
                 OpenApiDocument source = await OpenApiService.ConvertCsdlToOpenApiAsync(Request.Body);
 
-                var predicate = await OpenApiService.CreatePredicate(operationIds: operationIds,
+                var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
                                                                      tags: tags,
                                                                      url: url,
                                                                      source: source,

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -1,10 +1,12 @@
 openapi: 3.0.3
 info:
   title: "DevX API"
-  version: "20210415.1"
+  version: "20210528.1"
 servers:
   - url: https://graphexplorerapi.azurewebsites.net/
     description: Main server
+  - url: https://graphexplorerapi-staging.azurewebsites.net/
+    description: Staging server
   - url: https://localhost:44399/
     description: Local test server
   - url: https://localhost:5001/

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -323,6 +323,55 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
+                    ["/users/{user-id}/messages/{message-id}"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        {
+                                            new OpenApiTag()
+                                            {
+                                                Name = "users.message"
+                                            }
+                                        }
+                                    },
+                                    OperationId = "users.GetMessages",
+                                    Summary = "Get messages from users",
+                                    Description = "The messages in a mailbox or folder. Read-only. Nullable.",
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200", new OpenApiResponse()
+                                            {
+                                                Description = "Retrieved navigation property",
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    {
+                                                        applicationJsonMediaType,
+                                                        new OpenApiMediaType
+                                                        {
+                                                            Schema = new OpenApiSchema
+                                                            {
+                                                                Reference = new OpenApiReference
+                                                                {
+                                                                    Type = ReferenceType.Schema,
+                                                                    Id = "microsoft.graph.message"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     ["/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore"] = new OpenApiPathItem()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -106,7 +106,8 @@ namespace OpenAPIService.Test
             var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null,
                                                                                                 tags: null,
                                                                                                 url: "/foo",
-                                                                                                source: source)
+                                                                                                source: source,
+                                                                                                graphVersion: GraphVersion)
                                                                                                 .GetAwaiter().GetResult()).Message;
             Assert.Equal("The url supplied could not be found.", message);
         }
@@ -120,7 +121,9 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: "/",
-                                                           source: source).GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
+                                                           .GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -161,7 +164,8 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: url,
-                                                           source: source)
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
                                                            .GetAwaiter().GetResult();
 
             // Assert
@@ -181,7 +185,8 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: url,
-                                                           source: source)
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
                                                            .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
@@ -205,7 +210,7 @@ namespace OpenAPIService.Test
 
         [Theory]
         [InlineData(OpenApiStyle.Plain, "/users/{user-id}", OperationType.Get)]
-        [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}", OperationType.Get)]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users/12345/messages", OperationType.Get)]
         [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
         [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post, "administrativeUnits_restore")]
         [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch, "users.user_UpdateUser")]
@@ -222,7 +227,8 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: url,
-                                                           source: source)
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
                                                            .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
@@ -324,7 +330,8 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: "/security/hostSecurityProfiles",
-                                                           source: source)
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
                                                            .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
@@ -349,7 +356,8 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: url,
-                                                           source: source)
+                                                           source: source,
+                                                           graphVersion: GraphVersion)
                                                            .GetAwaiter().GetResult();
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.OpenApi.Models;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace OpenAPIService.Test
@@ -210,7 +211,9 @@ namespace OpenAPIService.Test
 
         [Theory]
         [InlineData(OpenApiStyle.Plain, "/users/{user-id}", OperationType.Get)]
-        [InlineData(OpenApiStyle.GEAutocomplete, "/users/12345/messages", OperationType.Get)]
+        [InlineData(OpenApiStyle.Plain, "/users/12345", OperationType.Get)]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users(user-id)messages(message-id)", OperationType.Get)]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users/12345/messages/abcde", OperationType.Get)]
         [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
         [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post, "administrativeUnits_restore")]
         [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch, "users.user_UpdateUser")]
@@ -238,7 +241,8 @@ namespace OpenAPIService.Test
             // Assert
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
             {
-                var content = subsetOpenApiDocument.Paths[url]
+                var content = subsetOpenApiDocument.Paths
+                                .FirstOrDefault().Value
                                 .Operations[operationType]
                                 .Responses["200"]
                                 .Content;
@@ -258,7 +262,8 @@ namespace OpenAPIService.Test
             {
                 if (operationType == OperationType.Post)
                 {
-                    var anyOf = subsetOpenApiDocument.Paths[url]
+                    var anyOf = subsetOpenApiDocument.Paths
+                                    .FirstOrDefault().Value
                                     .Operations[operationType]
                                     .Responses["200"]
                                     .Content["application/json"]
@@ -272,7 +277,8 @@ namespace OpenAPIService.Test
                 {
                     if (operationType == OperationType.Post)
                     {
-                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                        var newOperationId = subsetOpenApiDocument.Paths
+                                            .FirstOrDefault().Value
                                             .Operations[operationType]
                                             .OperationId;
 
@@ -280,7 +286,8 @@ namespace OpenAPIService.Test
                     }
                     else if (operationType == OperationType.Patch)
                     {
-                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                        var newOperationId = subsetOpenApiDocument.Paths
+                                            .FirstOrDefault().Value
                                             .Operations[operationType]
                                             .OperationId;
 
@@ -288,7 +295,8 @@ namespace OpenAPIService.Test
                     }
                     else if (operationType == OperationType.Put)
                     {
-                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                        var newOperationId = subsetOpenApiDocument.Paths
+                                            .FirstOrDefault().Value
                                             .Operations[operationType]
                                             .OperationId;
 
@@ -362,7 +370,8 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
             subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
-            var operationId = subsetOpenApiDocument.Paths[url]
+            var operationId = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
                               .Operations[operationType]
                               .OperationId;
 

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -32,14 +32,12 @@ namespace OpenAPIService.Test
             var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1,
                                                              tags: null,
                                                              url: null,
-                                                             source: source)
-                                                             .GetAwaiter().GetResult();
+                                                             source: source);
 
             var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2,
                                                              tags: null,
                                                              url: null,
-                                                             source: source)
-                                                             .GetAwaiter().GetResult();
+                                                             source: source);
 
             // Act
             var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
@@ -74,17 +72,20 @@ namespace OpenAPIService.Test
                 string.IsNullOrEmpty(tags) &&
                 string.IsNullOrEmpty(url))
             {
-                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
-                                .GetAwaiter().GetResult()).Message;
+                var message = Assert.Throws<InvalidOperationException>(() => 
+                    OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                   tags: tags,
+                                                   url: url,
+                                                   source: source)).Message;
                 Assert.Equal("Either operationIds, tags or url need to be specified.", message);
             }
             else
             {
-                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds,
-                                                                                                            tags: tags,
-                                                                                                            url: url,
-                                                                                                            source: source)
-                                                                                                            .GetAwaiter().GetResult()).Message;
+                var message = Assert.Throws<InvalidOperationException>(() => 
+                    OpenApiService.CreatePredicate(operationIds: operationIds,
+                                                   tags: tags,
+                                                   url: url,
+                                                   source: source)).Message;
 
                 if (url != null && (operationIds != null || tags != null))
                 {
@@ -108,8 +109,7 @@ namespace OpenAPIService.Test
                                                                                                 tags: null,
                                                                                                 url: "/foo",
                                                                                                 source: source,
-                                                                                                graphVersion: GraphVersion)
-                                                                                                .GetAwaiter().GetResult()).Message;
+                                                                                                graphVersion: GraphVersion)).Message;
             Assert.Equal("The url supplied could not be found.", message);
         }
 
@@ -123,8 +123,7 @@ namespace OpenAPIService.Test
                                                            tags: null,
                                                            url: "/",
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
+                                                           graphVersion: GraphVersion); // root path will be non-existent in a PowerShell styled doc.
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -144,11 +143,12 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: null,
-                                                           source: source)
-                                                           .GetAwaiter().GetResult();
+                                                           source: source);
 
             // Act & Assert
-            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
+            var message = Assert.Throws<ArgumentException>(() =>
+                OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
+
             Assert.Equal("No paths found for the supplied parameters.", message);
         }
 
@@ -166,8 +166,7 @@ namespace OpenAPIService.Test
                                                            tags: tags,
                                                            url: url,
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult();
+                                                           graphVersion: GraphVersion);
 
             // Assert
             Assert.NotNull(predicate);
@@ -187,8 +186,7 @@ namespace OpenAPIService.Test
                                                            tags: tags,
                                                            url: url,
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult();
+                                                           graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -231,8 +229,7 @@ namespace OpenAPIService.Test
                                                            tags: null,
                                                            url: url,
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult();
+                                                           graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -316,8 +313,7 @@ namespace OpenAPIService.Test
             var predicate = OpenApiService.CreatePredicate(operationIds: "*",
                                                            tags: null,
                                                            url: null,
-                                                           source: source)
-                                                           .GetAwaiter().GetResult(); // fetch all paths/operations
+                                                           source: source); // fetch all paths/operations
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
@@ -339,8 +335,7 @@ namespace OpenAPIService.Test
                                                            tags: null,
                                                            url: "/security/hostSecurityProfiles",
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult();
+                                                           graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
             subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
@@ -365,8 +360,7 @@ namespace OpenAPIService.Test
                                                            tags: null,
                                                            url: url,
                                                            source: source,
-                                                           graphVersion: GraphVersion)
-                                                           .GetAwaiter().GetResult();
+                                                           graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
             subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.9.0" />
     <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.8" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -121,7 +121,7 @@ namespace OpenAPIService
         /// <param name="graphVersion">Version of the target Microsoft Graph API.</param>
         /// <param name="forceRefresh">Whether to reload the OpenAPI document from source.</param>
         /// <returns>A predicate.</returns>
-        public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url,
+        public static Func<OpenApiOperation, bool> CreatePredicate(string operationIds, string tags, string url,
             OpenApiDocument source, string graphVersion = "v1.0", bool forceRefresh = false)
         {
             if (url != null && (operationIds != null || tags != null))
@@ -191,7 +191,7 @@ namespace OpenAPIService
                 throw new InvalidOperationException("Either operationIds, tags or url need to be specified.");
             }
 
-            return await Task.FromResult(predicate);
+            return predicate;
         }
 
         /// <summary>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -47,7 +47,6 @@ namespace OpenAPIService
         /// <returns>A partial OpenAPI document.</returns>
         public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, string graphVersion, Func<OpenApiOperation, bool> predicate)
         {
-
             var subset = new OpenApiDocument
             {
                 Info = new OpenApiInfo()

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using System.Collections.Concurrent;
 using System.Text;
 using OpenAPIService.Common;
-using UriMatchingService;
 using UtilityService;
 
 namespace OpenAPIService
@@ -36,12 +35,16 @@ namespace OpenAPIService
     public class OpenApiService
     {
         private static readonly ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<Uri, OpenApiDocument>();
-        private static UriTemplateMatcher _uriTemplateTable = new UriTemplateMatcher();
-        private static IDictionary<int, OpenApiOperation[]> _openApiOperationsTable = new Dictionary<int, OpenApiOperation[]>();
+        private static OpenApiUrlTreeNode _openApiRootNode = OpenApiUrlTreeNode.Create();
 
         /// <summary>
-        /// Create partial document based on provided predicate
+        /// Create partial OpenAPI document based on the provided predicate.
         /// </summary>
+        /// <param name="source">The target <see cref="OpenApiDocument"/>.</param>
+        /// <param name="title">The OpenAPI document title.</param>
+        /// <param name="graphVersion">Version of the target Microsoft Graph API.</param>
+        /// <param name="predicate">A predicate function.</param>
+        /// <returns>A partial OpenAPI document.</returns>
         public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, string graphVersion, Func<OpenApiOperation, bool> predicate)
         {
 
@@ -115,11 +118,12 @@ namespace OpenAPIService
         /// <param name="operationIds">Comma delimited list of operationIds or * for all operations.</param>
         /// <param name="tags">Comma delimited list of tags or a single regex.</param>
         /// <param name="url">Url path to match with Operation Ids.</param>
-        /// <param name="graphVersion">Version of Microsoft Graph.</param>
+        /// <param name="source">The target <see cref="OpenApiDocument"/>.</param>
+        /// <param name="graphVersion">Version of the target Microsoft Graph API.</param>
         /// <param name="forceRefresh">Whether to reload the OpenAPI document from source.</param>
-        /// <returns>A predicate</returns>
+        /// <returns>A predicate.</returns>
         public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url,
-            OpenApiDocument source, bool forceRefresh = false)
+            OpenApiDocument source, string graphVersion = "v1.0", bool forceRefresh = false)
         {
             if (url != null && (operationIds != null || tags != null))
             {
@@ -159,29 +163,24 @@ namespace OpenAPIService
             }
             else if (url != null)
             {
-                /* Extract the respective Operation Id(s) that match the provided url path */
-
-                if (!_openApiOperationsTable.Any() || forceRefresh)
+                if (forceRefresh)
                 {
-                    _uriTemplateTable = new UriTemplateMatcher();
-                    _openApiOperationsTable = new Dictionary<int, OpenApiOperation[]>();
-
-                    await PopulateReferenceTablesAync(source);
+                    _openApiRootNode = CreateOpenApiUrlTreeNode(source, graphVersion);
+                }
+                else if (!_openApiRootNode.PathItems.ContainsKey(graphVersion))
+                {
+                    _openApiRootNode.Attach(source, graphVersion);
                 }
 
-                url = url.BaseUriPath()
-                         .Replace('-', '_');
+               // url = url.RemoveParentheses();
+                OpenApiOperation[] openApiOps = GetOpenApiOperations(_openApiRootNode, url, graphVersion);
 
-                TemplateMatch resultMatch = _uriTemplateTable.Match(new Uri(url.ToLower(), UriKind.RelativeOrAbsolute));
-
-                if (resultMatch == null)
+                if (openApiOps == null)
                 {
                     throw new ArgumentException("The url supplied could not be found.");
                 }
 
-                /* Fetch the corresponding Operations Id(s) for the matched url */
-
-                OpenApiOperation[] openApiOps = _openApiOperationsTable[int.Parse(resultMatch.Key)];
+                // Fetch the corresponding Operations Id(s) for the matched url
                 string[] operationIdsArray = openApiOps.Select(x => x.OperationId).ToArray();
 
                 predicate = (o) => operationIdsArray.Contains(o.OperationId);
@@ -191,37 +190,113 @@ namespace OpenAPIService
                 throw new InvalidOperationException("Either operationIds, tags or url need to be specified.");
             }
 
-            return predicate;
+            return await Task.FromResult(predicate);
         }
 
         /// <summary>
-        /// Populates the _uriTemplateTable with the Graph url paths and the _openApiOperationsTable
-        /// with the respective OpenApiOperations for these urls paths.
+        /// Creates an <see cref="OpenApiUrlTreeNode"/> from an <see cref="OpenApiDocument"/>.
         /// </summary>
-        /// <param name="source">The OpenAPI document.</param>
-        /// <returns>A task.</returns>
-        private static Task PopulateReferenceTablesAync(OpenApiDocument source)
-		{
-			HashSet<string> uniqueUrlsTable = new HashSet<string>(); // to ensure unique url path entries in the UriTemplate table
+        /// <param name="source">The target <see cref="OpenApiDocument"/>.</param>
+        /// <param name="label">Name tag for labelling the nodes in the directory structure.</param>
+        /// <returns>The created <see cref="OpenApiUrlTreeNode"/>.</returns>
+        private static OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(OpenApiDocument source, string label)
+        {
+            return source == null ? null : OpenApiUrlTreeNode.Create(source, label);
+        }
 
-            int count = 0;
+        /// <summary>
+        /// Retrieves an array of <see cref="OpenApiOperation"/> for a given url path from an
+        /// <see cref="OpenApiUrlTreeNode"/>.
+        /// </summary>
+        /// <param name="rootNode">The target <see cref="OpenApiUrlTreeNode"/> root node.</param>
+        /// <param name="relativeUrl">The relative url path to retrieve
+        /// the array of <see cref="OpenApiOperation"/> from.</param>
+        /// <param name="label">The name of the key for the target operations in the node's PathItems dictionary.</param>
+        /// <returns>The array of <see cref="OpenApiOperation"/> for a given url path.</returns>
+        private static OpenApiOperation[] GetOpenApiOperations(OpenApiUrlTreeNode rootNode, string relativeUrl, string label)
+        {
+            Utils.CheckArgumentNull(rootNode, nameof(rootNode));
+            Utils.CheckArgumentNullOrEmpty(relativeUrl, nameof(relativeUrl));
+            Utils.CheckArgumentNullOrEmpty(label, nameof(label));
 
-            foreach (var path in source.Paths)
+            if (relativeUrl.Equals("/", StringComparison.Ordinal))
             {
-                if (uniqueUrlsTable.Add(path.Key))
+                // root path
+                if (rootNode.HasOperations(label))
                 {
-                    count++;
-
-                    string urlPath = path.Key.Replace('-', '_');
-                    _uriTemplateTable.Add(count.ToString(), urlPath.ToLower());
-
-                    OpenApiOperation[] operations = path.Value.Operations.Values.ToArray();
-                    _openApiOperationsTable.Add(count, operations);
+                    return rootNode.PathItems[label].Operations.Values.ToArray();
                 }
             }
 
-			return Task.CompletedTask;
-		}
+            var urlSegments = relativeUrl.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            OpenApiOperation[] operations = null;
+            var targetChild = rootNode;
+
+            /* This will help keep track of whether we've skipped a segment
+             * in the target url due to a possible parameter naming mismatch
+             * with the corresponding OpenApiUrlTreeNode target child segment.
+             */
+            int parameterNameOffset = 0;
+
+            for (int i = 0; i < urlSegments?.Length; i++)
+            {
+                var tempTargetChild = targetChild?.Children
+                                                  .FirstOrDefault(x => x.Key.Equals(urlSegments[i],
+                                                                    StringComparison.OrdinalIgnoreCase)).Value;
+
+                if (tempTargetChild == null)
+                {
+                    if (i == 0)
+                    {
+                        /* If no match and we are at the 1st segment of the relative url,
+                         * exit; no need to continue matching subsequent segments.
+                         */
+                        break;
+                    }
+
+                    /* Attempt to get the parameter segment from the children of the current node:
+                     * We are assuming a failed match because of different parameter namings
+                     * between the relative url segment and the corresponding OpenApiUrlTreeNode segment name
+                     * ex.: matching '/users/12345/messages' with '/users/{user-id}/messages'
+                     */
+                    tempTargetChild = targetChild.Children
+                                                 .FirstOrDefault(x => x.Value.IsParameter == true).Value;
+
+                    /* If no parameter segment exists in the children of the
+                     * current node or we've already skipped a parameter
+                     * segment in the relative url from the last pass,
+                     * then exit; there's no match.
+                     */
+                    if (tempTargetChild == null || parameterNameOffset > 0)
+                    {
+                        break;
+                    }
+
+                    /* To help us know we've skipped a
+                     * corresponding segment in the relative url.
+                     */
+                    parameterNameOffset++;
+                }
+                else
+                {
+                    parameterNameOffset = 0;
+                }
+
+                targetChild = tempTargetChild;
+
+                // We want the operations of the last segment of the path.
+                if (i == urlSegments.Length - 1)
+                {
+                    if (targetChild.HasOperations(label))
+                    {
+                        operations = targetChild.PathItems[label].Operations.Values.ToArray();
+                    }
+                }
+            }
+
+            return operations;
+        }
 
 		/// <summary>
 		/// Create a representation of the OpenApiDocument to return from an API

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -171,7 +171,9 @@ namespace OpenAPIService
                     _openApiRootNode.Attach(source, graphVersion);
                 }
 
-                url = url.UriTemplatePathFormat();
+                url = url.BaseUriPath()
+                         .UriTemplatePathFormat();
+
                 OpenApiOperation[] openApiOps = GetOpenApiOperations(_openApiRootNode, url, graphVersion);
 
                 if (!(openApiOps?.Any() ?? false))
@@ -244,6 +246,7 @@ namespace OpenAPIService
                                                   .FirstOrDefault(x => x.Key.Equals(urlSegments[i],
                                                                     StringComparison.OrdinalIgnoreCase)).Value;
 
+                // Segment name mismatch
                 if (tempTargetChild == null)
                 {
                     if (i == 0)
@@ -282,6 +285,7 @@ namespace OpenAPIService
                     parameterNameOffset = 0;
                 }
 
+                // Move to the next segment
                 targetChild = tempTargetChild;
 
                 // We want the operations of the last segment of the path.

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -175,7 +175,7 @@ namespace OpenAPIService
                // url = url.RemoveParentheses();
                 OpenApiOperation[] openApiOps = GetOpenApiOperations(_openApiRootNode, url, graphVersion);
 
-                if (openApiOps == null)
+                if (!(openApiOps?.Any() ?? false))
                 {
                     throw new ArgumentException("The url supplied could not be found.");
                 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -263,7 +263,7 @@ namespace OpenAPIService
                      * ex.: matching '/users/12345/messages' with '/users/{user-id}/messages'
                      */
                     tempTargetChild = targetChild.Children
-                                                 .FirstOrDefault(x => x.Value.IsParameter == true).Value;
+                                                 .FirstOrDefault(x => x.Value.IsParameter).Value;
 
                     /* If no parameter segment exists in the children of the
                      * current node or we've already skipped a parameter

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -172,7 +172,7 @@ namespace OpenAPIService
                     _openApiRootNode.Attach(source, graphVersion);
                 }
 
-               // url = url.RemoveParentheses();
+                url = url.UriTemplatePathFormat();
                 OpenApiOperation[] openApiOps = GetOpenApiOperations(_openApiRootNode, url, graphVersion);
 
                 if (!(openApiOps?.Any() ?? false))

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -45,9 +45,13 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// The last '.' character of the OperationId value separates the method group from the operation name.
-        /// This is replaced with an '_' to format the OperationId to allow for the creation of logical Powershell cmdlet names
+        /// Visits an <see cref="OpenApiOperation"/>
         /// </summary>
+        /// <remarks>
+        /// The last '.' character of the OperationId value separates the method group from the operation name.
+        /// This is replaced with an '_' to format the OperationId to allow for the creation of logical Powershell cmdlet names.
+        /// </remarks>
+        /// <param name="operation">The target <see cref="OpenApiOperation"/></param>
         public override void Visit(OpenApiOperation operation)
         {
             var operationId = operation.OperationId;
@@ -81,6 +85,10 @@ namespace OpenAPIService
             }
         }
 
+        /// <summary>
+        /// Visits an <see cref="OpenApiSchema"/>
+        /// </summary>
+        /// <param name="schema">The target <see cref="OpenApiSchema"/></param>
         public override void Visit(OpenApiSchema schema)
         {
             if (_schemaLoop.Contains(schema))

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -96,7 +96,7 @@ namespace OpenAPIService
                 return; // loop detected, this schema has already been walked.
             }
 
-            if (schema?.Type == "object")
+            if ("object".Equals(schema?.Type, StringComparison.OrdinalIgnoreCase))
             {
                 schema.AdditionalProperties = new OpenApiSchema() { Type = "object" }; // To make AutoREST happy
 

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -179,7 +179,7 @@ namespace TelemetryService
                     var valueIndex = queryValue.IndexOf('=') + 1;
                     var valueSegment = queryValue[valueIndex..];
                     valueSegment = valueSegment.BaseUriPath()
-                                               .UriTemplatePathFormat();
+                                               .UriTemplatePathFormat(true);
                     var resultMatch = _uriTemplateMatcher?.Match(new Uri(valueSegment.ToLowerInvariant(), UriKind.RelativeOrAbsolute));
 
                     if (resultMatch != null)

--- a/UtilityService.Test/UtilityServiceExtensionsShould.cs
+++ b/UtilityService.Test/UtilityServiceExtensionsShould.cs
@@ -79,6 +79,7 @@ namespace UtilityService.Test
             // Assert
             Assert.Equal(expectedString, actualString);
         }
+
         [Theory]
         [InlineData("/education/schools(id)users/microsoft.graph.delta()",
                     "/education/schools/id/users/microsoft.graph.delta()")]

--- a/UtilityService.Test/UtilityServiceExtensionsShould.cs
+++ b/UtilityService.Test/UtilityServiceExtensionsShould.cs
@@ -71,7 +71,26 @@ namespace UtilityService.Test
                     "/permissions?requesturl=/students/'MeganB@M365x214355.onmicrosoft.com'/classes")]
         [InlineData("/permissions?requesturl=/students/('MeganB@M365x214355.onmicrosoft.com')/classes",
                     "/permissions?requesturl=/students/'MeganB@M365x214355.onmicrosoft.com'/classes")]
-        public void GetUriTemplatePathFormat(string targetString, string expectedString)
+        public void GetUriTemplatePathFormatWithSimplifyNamespaceTrue(string targetString, string expectedString)
+        {
+            // Arrange and Act
+            var actualString = targetString.UriTemplatePathFormat(true);
+
+            // Assert
+            Assert.Equal(expectedString, actualString);
+        }
+        [Theory]
+        [InlineData("/education/schools(id)users/microsoft.graph.delta()",
+                    "/education/schools/id/users/microsoft.graph.delta()")]
+        [InlineData("/users/{user-id}/insights/used(usedInsight-id)resource/microsoft.graph.workbookWorksheet/microsoft.graph.range(address={address})",
+                    "/users/{user-id}/insights/used/usedInsight-id/resource/microsoft.graph.workbookWorksheet/microsoft.graph.range(address={address})")]
+        [InlineData("/groupLifecyclePolicies(groupLifecyclePolicy-id)microsoft.graph.remove",
+                    "/groupLifecyclePolicies/groupLifecyclePolicy-id/microsoft.graph.remove")]
+        [InlineData("worksheets/range/microsoft.graph.range(address={address})",
+                    "worksheets/range/microsoft.graph.range(address={address})")]
+        [InlineData("/drive/list/items(listItem-id)microsoft.graph.getActivitiesByInterval()",
+                    "/drive/list/items/listItem-id/microsoft.graph.getActivitiesByInterval()")]
+        public void GetUriTemplatePathFormatWithSimplifyNamespaceFalse(string targetString, string expectedString)
         {
             // Arrange and Act
             var actualString = targetString.UriTemplatePathFormat();

--- a/UtilityService/Utils.cs
+++ b/UtilityService/Utils.cs
@@ -1,0 +1,34 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace UtilityService
+{
+    public static class Utils
+    {
+        /// <summary>
+        /// Check whether the input argument value is null or not.
+        /// </summary>
+        /// <typeparam name="T">The input value type.</typeparam>
+        /// <param name="value">The input value.</param>
+        /// <param name="parameterName">The input parameter name.</param>
+        /// <returns>The input value.</returns>
+        public static T CheckArgumentNull<T>(T value, string parameterName) where T : class
+        {
+            return value ?? throw new ArgumentNullException(parameterName, $"Value cannot be null: {parameterName}");
+        }
+
+        /// <summary>
+        /// Check whether the input string value is null or empty.
+        /// </summary>
+        /// <param name="value">The input string value.</param>
+        /// <param name="parameterName">The input parameter name.</param>
+        /// <returns>The input value.</returns>
+        public static string CheckArgumentNullOrEmpty(string value, string parameterName)
+        {
+            return string.IsNullOrEmpty(value) ? throw new ArgumentNullException(parameterName, $"Value cannot be null or empty: {parameterName}") : value;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/590

This PR:
- Bumps the `Microsoft.OpenApi.Readers` lib. to `v1.3.0-preview`. This is to get the new `OpenApiUrlTreeNode` data structure.
- Replaces the `UriTemplateMatcher` with the `OpenApiUrlTreeNode` for matching urls. The latter provides an easier, efficient and faster matching experience compared to the former, which uses regexes. This should actualize faster response times for the Graph Explorer autocomplete feature or any client requesting a subset OpenAPI doc using a url, ex: `/openapi?url=/users/{user-id}`.
- Because we need to provide a label for each `OpenApiDocument` that gets appended to the `OpenApiUrlTreeNode` data structure, the method `CreatePredicate()` adds a new parameter `graphVersion` with a default value: `v1.0`. Consequently, the `OpenApiController` has been updated to provide this new argument when calling the aforementioned method. Respective tests have also been updated to account for the new parameter (where applicable). This param is defaulted because only calls to the `CreatePredicate()` method with a `url` value need only supply a value for the `graphVersion` param.
- Besides others, `OpenApiService.cs` adds a new `private` method  `GetOpenApiOperations()` that is responsible for matching a url string value to the children segments of the `OpenApiUrlTreeNode` data structure and pulling out the `OpenApiOperations` under the path.
- Unless a `forceRefresh` is requested, the `OpenApiUrlTreeNode` will persist paths and operations for `v1.0` and `beta` in the same data structure.
- Adds a new `Utils.cs` class in the `Extensions` library. This contains common utility functions `CheckArgumentNull()` and `CheckArgumentNullOrEmpty()` that can be used across the solution for a standardized way of checking for nullability of params. In `OpenApiService.cs`, its use has been employed in the method `GetOpenApiOperations()` 
- Updates the `UriTemplatePathFormat()` method: adds a new `bool` param - `simplifyNamespace` that provides an option on whether to simplify `action`/`functions` namespaces in path values. In the `OpenApiUrlTreeNode` data structure matching we don't necessarily want to simplify the namespace; however, in the `PermissionsStore.cs` and `CustomPIIFilter.cs` matching, we do need to simplify the namespace - because for the latter two they use the JSON permissions doc. urls as their source of templates for matching; and these don't expose the fully qualified names for `actions`/`functions` in their values. 
- `Extensions.cs` tests for the above updated feature has been added for validation.
- In the `Visit(OpenApiSchema schema)` method in the `PowershellFormatter.cs` class, we now have to account for the fact that `AdditionalProperties` in schemas are now being _walked_. To avoid endlessly creating and walking the `AdditionalProperties` schemas in an infinite recursion, we are using a `Stack` to keep track of the schemas already visited.
- Update the _OpenApi.yaml_ file version and server values.
- Updates some XML documentations.