### PR TITLE
Update the sources of the Graph metadata

### DIFF
--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -16,8 +16,8 @@
   },
   "AllowedHosts": "*",
   "GraphMetadata": {
-    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml",
-    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml"
+    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsv1.0.xml",
+    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsAndAnnotationsbeta.xml"
   },
   "BlobStorage": {
     "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/602
New sources contains updated `Org.OData.Capabilities.V1` annotations.

example: 

Original cleanMetadataWithDescriptions
![image](https://user-images.githubusercontent.com/40403681/122018794-dc1ee700-cdcb-11eb-8f3b-136ed6b2be21.png)

New cleanMetadataWithDescriptionsAndAnnotations
![image](https://user-images.githubusercontent.com/40403681/122019046-14262a00-cdcc-11eb-8886-07a5eddd5f03.png)
