### PR TITLE
Initialize telemetry client

### DIFF
--- a/ChangesService.Test/ChangeLogRecordsModelShould.cs
+++ b/ChangesService.Test/ChangeLogRecordsModelShould.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using ChangesService.Interfaces;
 using ChangesService.Models;
 using Xunit;
 
@@ -10,6 +11,13 @@ namespace ChangesService.Test
 {
     public class ChangeLogRecordsModelShould
     {
+        private readonly IChangesService _changesService;
+
+        public ChangeLogRecordsModelShould()
+        {
+            _changesService = new Services.ChangesService();
+        }
+
         [Fact]
         public void UpdateTotalItemsOnChangeLogsPropertySetter()
         {
@@ -92,7 +100,7 @@ namespace ChangesService.Test
         /// <param name="variableDate">Optional. CreatedDateTime value for Reports
         /// workload.</param>
         /// <returns>Sample <see cref="ChangeLogRecords"/></returns>
-        public static ChangeLogRecords GetChangeLogRecords(string variableDate = "2020-12-31T00:00:00.000Z")
+        public ChangeLogRecords GetChangeLogRecords(string variableDate = "2020-12-31T00:00:00.000Z")
         {
             // variableDate param will be used for specifying custom CreatedDateTime
             // value for Reports workload
@@ -158,7 +166,7 @@ namespace ChangesService.Test
 
             changeLogRecords = changeLogRecords.Replace("variableDate", variableDate);
 
-            return Services.ChangesService.DeserializeChangeLogRecords(changeLogRecords);
+            return _changesService.DeserializeChangeLogRecords(changeLogRecords);
         }
     }
 }

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using ChangesService.Interfaces;
 using ChangesService.Models;
 using System;
 using Xunit;
@@ -11,6 +12,14 @@ namespace ChangesService.Test
     public class ChangesServiceShould
     {
         private readonly MicrosoftGraphProxyConfigs _graphProxyConfigs = new MicrosoftGraphProxyConfigs();
+        private readonly IChangesService _changesService;
+        private readonly ChangeLogRecordsModelShould _changeLogRecordsModelShould;
+
+        public ChangesServiceShould()
+        {
+            _changesService = new Services.ChangesService();
+            _changeLogRecordsModelShould = new ChangeLogRecordsModelShould();
+        }
 
         [Fact]
         public void ThrowArgumentNullExceptionOnDeserializeChangeLogRecordsIfJsonStringArgumentIsNull()
@@ -20,7 +29,7 @@ namespace ChangesService.Test
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() =>
-                Services.ChangesService.DeserializeChangeLogRecords(nullArgument));
+                _changesService.DeserializeChangeLogRecords(nullArgument));
         }
 
         [Fact]
@@ -28,7 +37,7 @@ namespace ChangesService.Test
         {
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() =>
-                Services.ChangesService.FilterChangeLogRecords(null, new ChangeLogSearchOptions(), new MicrosoftGraphProxyConfigs()));
+                _changesService.FilterChangeLogRecords(null, new ChangeLogSearchOptions(), new MicrosoftGraphProxyConfigs()));
         }
 
         [Fact]
@@ -36,7 +45,7 @@ namespace ChangesService.Test
         {
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() =>
-                Services.ChangesService.FilterChangeLogRecords(new ChangeLogRecords(), null, new MicrosoftGraphProxyConfigs()));
+                _changesService.FilterChangeLogRecords(new ChangeLogRecords(), null, new MicrosoftGraphProxyConfigs()));
         }
 
         [Fact]
@@ -44,7 +53,7 @@ namespace ChangesService.Test
         {
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() =>
-                Services.ChangesService.FilterChangeLogRecords(new ChangeLogRecords(), new ChangeLogSearchOptions(), null));
+                _changesService.FilterChangeLogRecords(new ChangeLogRecords(), new ChangeLogSearchOptions(), null));
         }
 
         [Fact]
@@ -53,13 +62,13 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
 
             var searchOptions = new ChangeLogSearchOptions(workload: "Compliance");
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert
             Assert.NotNull(changeLog);
@@ -87,14 +96,14 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
             var startDate = DateTime.Parse("2020-01-01");
             var endDate = DateTime.Parse("2020-10-01");
             var searchOptions = new ChangeLogSearchOptions(startDate: startDate, endDate: endDate);
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert
             Assert.NotNull(changeLog);
@@ -139,13 +148,13 @@ namespace ChangesService.Test
             DateTime varDate = DateTime.Today.AddDays(-30);
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords(varDate.ToString("yyyy-MM-ddTHH:mm:ss")).ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords(varDate.ToString("yyyy-MM-ddTHH:mm:ss")).ChangeLogs
             };
 
             var searchOptions = new ChangeLogSearchOptions(daysRange: 60);
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert
             Assert.NotNull(changeLog);
@@ -174,14 +183,14 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
             var startDate = DateTime.Parse("2020-06-01");
 
             var searchOptions = new ChangeLogSearchOptions(startDate: startDate, daysRange: 120);
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert
             Assert.NotNull(changeLog);
@@ -224,14 +233,14 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
             var endDate = DateTime.Parse("2021-01-01");
 
             var searchOptions = new ChangeLogSearchOptions(endDate: endDate, daysRange: 30);
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert
             Assert.NotNull(changeLog);
@@ -259,7 +268,7 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
 
             var searchOptions = new ChangeLogSearchOptions
@@ -269,7 +278,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert -- fetch first two items from the changelog sample
             Assert.NotNull(changeLog);
@@ -312,7 +321,7 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
 
             var searchOptions = new ChangeLogSearchOptions
@@ -322,7 +331,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert -- fetch middle item from the changelog sample
             Assert.NotNull(changeLog);
@@ -350,7 +359,7 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = new ChangeLogRecords
             {
-                ChangeLogs = ChangeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
+                ChangeLogs = _changeLogRecordsModelShould.GetChangeLogRecords().ChangeLogs
             };
 
             var searchOptions = new ChangeLogSearchOptions
@@ -360,7 +369,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var changeLog = Services.ChangesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
+            var changeLog = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs);
 
             // Assert -- fetch last item from the changelog sample
             Assert.NotNull(changeLog);

--- a/ChangesService.Test/ChangesStoreShould.cs
+++ b/ChangesService.Test/ChangesStoreShould.cs
@@ -24,9 +24,11 @@ namespace ChangesService.Test
         private readonly IHttpClientUtility _httpClientUtility;
         private readonly IMemoryCache _changesCache;
         private IChangesStore _changesStore;
+        private readonly IChangesService _changesService;
 
         public ChangesStoreShould()
         {
+            _changesService = new Services.ChangesService();
             _httpClientUtility = new FileUtilityMock();
             _changesCache = Create.MockedMemoryCache();
             _configuration = new ConfigurationBuilder()
@@ -39,16 +41,17 @@ namespace ChangesService.Test
         {
             /* Act and Assert */
 
-            Assert.Throws<ArgumentNullException>(() => new ChangesStore(null, _changesCache, _httpClientUtility)); // null configuration
-            Assert.Throws<ArgumentNullException>(() => new ChangesStore(_configuration, null, _httpClientUtility)); // null changesCache
-            Assert.Throws<ArgumentNullException>(() => new ChangesStore(_configuration, _changesCache, null)); // null httpClientUtility
+            Assert.Throws<ArgumentNullException>(() => new ChangesStore(null, _changesCache, _changesService, _httpClientUtility)); // null configuration
+            Assert.Throws<ArgumentNullException>(() => new ChangesStore(_configuration, null, _changesService, _httpClientUtility)); // null changesCache
+            Assert.Throws<ArgumentNullException>(() => new ChangesStore(_configuration, _changesCache, null, _httpClientUtility)); // null changesService
+            Assert.Throws<ArgumentNullException>(() => new ChangesStore(_configuration, _changesCache, _changesService, null)); // null httpClientUtility
         }
 
         [Fact]
         public async Task CorrectlySeedLocaleCachesOfChangeLogRecordsWhenMultipleRequestsMultipleLocaleReceived()
         {
             // Arrange
-            _changesStore = new ChangesStore(_configuration, _changesCache, _httpClientUtility);
+            _changesStore = new ChangesStore(_configuration, _changesCache, _changesService, _httpClientUtility);
 
             /* Act */
 
@@ -80,7 +83,7 @@ namespace ChangesService.Test
         public async Task CorrectlySeedLocaleCachesOfChangeLogRecordsWhenMultipleRequestsSingleLocaleReceived()
         {
             // Arrange
-            _changesStore = new ChangesStore(_configuration, _changesCache, _httpClientUtility);
+            _changesStore = new ChangesStore(_configuration, _changesCache, _changesService, _httpClientUtility);
 
             /* Act */
 
@@ -114,7 +117,7 @@ namespace ChangesService.Test
         public async Task SetDefaultLocaleInFetchChangeLogRecords(string locale)
         {
             // Arrange
-            _changesStore = new ChangesStore(_configuration, _changesCache, _httpClientUtility);
+            _changesStore = new ChangesStore(_configuration, _changesCache, _changesService, _httpClientUtility);
 
             /* Act */
 

--- a/ChangesService/Interfaces/IChangesService.cs
+++ b/ChangesService/Interfaces/IChangesService.cs
@@ -2,9 +2,18 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using ChangesService.Models;
+using FileService.Interfaces;
+
 namespace ChangesService.Interfaces
 {
     public interface IChangesService
     {
+        ChangeLogRecords DeserializeChangeLogRecords(string jsonString);
+
+        ChangeLogRecords FilterChangeLogRecords(ChangeLogRecords changeLogRecords,
+                                                ChangeLogSearchOptions searchOptions,
+                                                MicrosoftGraphProxyConfigs graphProxyConfigs,
+                                                IHttpClientUtility httpClientUtility = null);
     }
 }

--- a/ChangesService/Interfaces/IChangesService.cs
+++ b/ChangesService/Interfaces/IChangesService.cs
@@ -1,0 +1,10 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace ChangesService.Interfaces
+{
+    public interface IChangesService
+    {
+    }
+}

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -29,7 +29,7 @@ namespace ChangesService.Services
         private static readonly Dictionary<string, string> _urlWorkloadDict = new();
         private static readonly Dictionary<string, string> _changesTraceProperties =
                         new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesService" } };
-        private static TelemetryClient _telemetryClient;
+        private readonly TelemetryClient _telemetryClient;
 
         public ChangesService(TelemetryClient telemetryClient = null)
         {
@@ -41,7 +41,7 @@ namespace ChangesService.Services
         /// </summary>
         /// <param name="jsonString">The json string to deserialize</param>
         /// <returns>The deserialized <see cref="ChangeLogRecords"/>.</returns>
-        public static ChangeLogRecords DeserializeChangeLogRecords(string jsonString)
+        public ChangeLogRecords DeserializeChangeLogRecords(string jsonString)
         {
             if (string.IsNullOrEmpty(jsonString))
             {
@@ -64,9 +64,8 @@ namespace ChangesService.Services
         /// <param name="graphProxyConfigs">Configuration settings for connecting to the Microsoft Graph Proxy.</param>
         /// <param name="httpClientUtility">Optional. An implementation instance of <see cref="IHttpClientUtility"/>.</param>
         /// <returns><see cref="ChangeLogRecords"/> containing the filtered and/or paginated
-        /// <see cref="ChangeLog"/> entries.</returns>
-        public static ChangeLogRecords FilterChangeLogRecords(ChangeLogRecords changeLogRecords,
-                                                              ChangeLogSearchOptions searchOptions,
+        /// <see cref="ChangeLog"/> entries.</returns>        public ChangeLogRecords FilterChangeLogRecords(ChangeLogRecords changeLogRecords,
+        ChangeLogSearchOptions searchOptions,
                                                               MicrosoftGraphProxyConfigs graphProxyConfigs,
                                                               IHttpClientUtility httpClientUtility = null)
         {
@@ -252,7 +251,7 @@ namespace ChangesService.Services
         /// <param name="graphProxy">Configuration settings for connecting to the Microsoft Graph Proxy.</param>
         /// <param name="httpClientUtility">An implementation instance of <see cref="IFileUtility"/>.</param>
         /// <returns>The workload name for the target request url.</returns>
-        private static async Task<string> RetrieveWorkloadNameFromRequestUrl(ChangeLogSearchOptions searchOptions,
+        private async Task<string> RetrieveWorkloadNameFromRequestUrl(ChangeLogSearchOptions searchOptions,
                                                                              MicrosoftGraphProxyConfigs graphProxy,
                                                                              IHttpClientUtility httpClientUtility)
         {

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -64,7 +64,8 @@ namespace ChangesService.Services
         /// <param name="graphProxyConfigs">Configuration settings for connecting to the Microsoft Graph Proxy.</param>
         /// <param name="httpClientUtility">Optional. An implementation instance of <see cref="IHttpClientUtility"/>.</param>
         /// <returns><see cref="ChangeLogRecords"/> containing the filtered and/or paginated
-        /// <see cref="ChangeLog"/> entries.</returns>        public ChangeLogRecords FilterChangeLogRecords(ChangeLogRecords changeLogRecords,
+        /// <see cref="ChangeLog"/> entries.</returns>
+        public ChangeLogRecords FilterChangeLogRecords(ChangeLogRecords changeLogRecords,
         ChangeLogSearchOptions searchOptions,
                                                               MicrosoftGraphProxyConfigs graphProxyConfigs,
                                                               IHttpClientUtility httpClientUtility = null)

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using ChangesService.Common;
+using ChangesService.Interfaces;
 using ChangesService.Models;
 using FileService.Common;
 using FileService.Interfaces;
@@ -21,7 +22,7 @@ namespace ChangesService.Services
     /// <summary>
     /// Utility functions for transforming and filtering <see cref="ChangeLogRecords"/> and <see cref="ChangeLog"/> objects.
     /// </summary>
-    public class ChangesService
+    public class ChangesService : IChangesService
     {
         // Field to hold key-value pairs of url and workload names
         private static readonly Dictionary<string, string> _urlWorkloadDict = new();

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using UtilityService;
 
 namespace ChangesService.Services
 {
@@ -26,7 +27,8 @@ namespace ChangesService.Services
     {
         // Field to hold key-value pairs of url and workload names
         private static readonly Dictionary<string, string> _urlWorkloadDict = new();
-        private static readonly Dictionary<string, string> _changesTraceProperties = new() { { "Changes", "ChangesService" } };
+        private static readonly Dictionary<string, string> _changesTraceProperties =
+                        new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesService" } };
         private static TelemetryClient _telemetryClient;
 
         public ChangesService(TelemetryClient telemetryClient = null)

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -28,7 +28,7 @@ namespace ChangesService.Services
         // Field to hold key-value pairs of url and workload names
         private static readonly Dictionary<string, string> _urlWorkloadDict = new();
         private static readonly Dictionary<string, string> _changesTraceProperties =
-                        new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesService" } };
+                        new() { { UtilityConstants.TelemetryPropertyKey_Changes, nameof(ChangesService)} };
         private readonly TelemetryClient _telemetryClient;
 
         public ChangesService(TelemetryClient telemetryClient = null)

--- a/ChangesService/Services/ChangesStore.cs
+++ b/ChangesService/Services/ChangesStore.cs
@@ -31,7 +31,7 @@ namespace ChangesService.Services
         private readonly IMemoryCache _changeLogCache;
         private readonly IConfiguration _configuration;
         private readonly Dictionary<string, string> _changesTraceProperties =
-                        new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesStore" } };
+                        new() { { UtilityConstants.TelemetryPropertyKey_Changes, nameof(ChangesStore) } };
         private readonly string _changeLogRelativeUrl;
         private readonly int _defaultRefreshTimeInHours;
         private readonly TelemetryClient _telemetryClient;

--- a/ChangesService/Services/ChangesStore.cs
+++ b/ChangesService/Services/ChangesStore.cs
@@ -35,11 +35,14 @@ namespace ChangesService.Services
         private readonly string _changeLogRelativeUrl;
         private readonly int _defaultRefreshTimeInHours;
         private readonly TelemetryClient _telemetryClient;
+        private readonly IChangesService _changesService;
 
-        public ChangesStore(IConfiguration configuration, IMemoryCache changeLogCache,
+        public ChangesStore(IConfiguration configuration, IMemoryCache changeLogCache, IChangesService changesService,
                             IHttpClientUtility httpClientUtility, TelemetryClient telemetryClient = null)
         {
             _telemetryClient = telemetryClient;
+            _changesService = changesService ?? throw new ArgumentNullException(nameof(changesService),
+                $"{ ChangesServiceConstants.ValueNullError }: { nameof(changesService) }"); ;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration),
                 $"{ ChangesServiceConstants.ValueNullError }: { nameof(configuration) }");
             _changeLogCache = changeLogCache ?? throw new ArgumentNullException(nameof(changeLogCache),
@@ -118,7 +121,7 @@ namespace ChangesService.Services
                                                  _changesTraceProperties);
 
                     // Return the changelog records from the file contents
-                    return Task.FromResult(ChangesService.DeserializeChangeLogRecords(jsonFileContents));
+                    return Task.FromResult(_changesService.DeserializeChangeLogRecords(jsonFileContents));
                 }
             });
 

--- a/CodeSnippetsReflection/CodeSnippetsReflection.csproj
+++ b/CodeSnippetsReflection/CodeSnippetsReflection.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -8,6 +8,7 @@ using CodeSnippetsReflection.LanguageGenerators;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights;
+using UtilityService;
 
 namespace CodeSnippetsReflection
 {
@@ -17,7 +18,8 @@ namespace CodeSnippetsReflection
     public class SnippetsGenerator : ISnippetsGenerator
     {
         private readonly TelemetryClient _telemetryClient;
-        private readonly IDictionary<string, string> _snippetsTraceProperties = new Dictionary<string, string> { { "Snippets", "SnippetsGenerator" } };
+        private readonly Dictionary<string, string> _snippetsTraceProperties =
+                    new() { { UtilityConstants.TelemetryPropertyKey_Snippets, "SnippetsGenerator" } };
         public static HashSet<string> SupportedLanguages = new HashSet<string>
         {
             "c#",

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -19,7 +19,7 @@ namespace CodeSnippetsReflection
     {
         private readonly TelemetryClient _telemetryClient;
         private readonly Dictionary<string, string> _snippetsTraceProperties =
-                    new() { { UtilityConstants.TelemetryPropertyKey_Snippets, "SnippetsGenerator" } };
+                    new() { { UtilityConstants.TelemetryPropertyKey_Snippets, nameof(SnippetsGenerator) } };
         public static HashSet<string> SupportedLanguages = new HashSet<string>
         {
             "c#",

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -280,6 +280,7 @@ namespace GraphExplorerPermissionsService
                 _applicationScopesInfoTable.Add(applicationScopeInfo.ScopeName, applicationScopeInfo);
             }
 
+            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsCount");
             _telemetryClient?.TrackTrace("Finished creating the scopes information tables. " +
                                          $"Delegated scopes count: {_delegatedScopesInfoTable.Count}. " +
                                          $"Application scopes count: {_applicationScopesInfoTable.Count}",

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -86,9 +86,11 @@ namespace GraphExplorerPermissionsService
 
             foreach (string permissionFilePath in _permissionsBlobNames)
             {
+                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsStore");
                 _telemetryClient?.TrackTrace($"Seeding permissions table from file source '{permissionFilePath}'",
                                              SeverityLevel.Information,
                                              _permissionsTraceProperties);
+                _permissionsTraceProperties.Remove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore);
 
                 string relativePermissionPath = FileServiceHelper.GetLocalizedFilePathSource(_permissionsContainerName, permissionFilePath);
                 string jsonString = _fileUtility.ReadFromFile(relativePermissionPath).GetAwaiter().GetResult();

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -282,12 +282,13 @@ namespace GraphExplorerPermissionsService
                 _applicationScopesInfoTable.Add(applicationScopeInfo.ScopeName, applicationScopeInfo);
             }
 
-            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsCount");
+            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsStore");
             _telemetryClient?.TrackTrace("Finished creating the scopes information tables. " +
                                          $"Delegated scopes count: {_delegatedScopesInfoTable.Count}. " +
                                          $"Application scopes count: {_applicationScopesInfoTable.Count}",
                                          SeverityLevel.Information,
                                          _permissionsTraceProperties);
+            _permissionsTraceProperties.Remove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore);
 
             return new Dictionary<string, IDictionary<string, ScopeInformation>>
             {

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -33,7 +33,7 @@ namespace GraphExplorerPermissionsService
         private readonly IConfiguration _configuration;
         private readonly TelemetryClient _telemetryClient;
         private readonly Dictionary<string, string> _permissionsTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, "PermissionsStore" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, nameof(PermissionsStore)} };
         private readonly string _permissionsContainerName;
         private readonly List<string> _permissionsBlobNames;
         private readonly string _scopesInformation;
@@ -86,7 +86,7 @@ namespace GraphExplorerPermissionsService
 
             foreach (string permissionFilePath in _permissionsBlobNames)
             {
-                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsStore");
+                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(PermissionsStore));
                 _telemetryClient?.TrackTrace($"Seeding permissions table from file source '{permissionFilePath}'",
                                              SeverityLevel.Information,
                                              _permissionsTraceProperties);
@@ -282,7 +282,7 @@ namespace GraphExplorerPermissionsService
                 _applicationScopesInfoTable.Add(applicationScopeInfo.ScopeName, applicationScopeInfo);
             }
 
-            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsStore");
+            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(PermissionsStore));
             _telemetryClient?.TrackTrace("Finished creating the scopes information tables. " +
                                          $"Delegated scopes count: {_delegatedScopesInfoTable.Count}. " +
                                          $"Application scopes count: {_applicationScopesInfoTable.Count}",

--- a/GraphExplorerSamplesService/Services/SamplesStore.cs
+++ b/GraphExplorerSamplesService/Services/SamplesStore.cs
@@ -29,7 +29,7 @@ namespace GraphExplorerSamplesService.Services
         private readonly IMemoryCache _samplesCache;
         private readonly IConfiguration _configuration;
         private readonly Dictionary<string, string> SamplesTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Samples, "SamplesStore" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Samples, nameof(SamplesStore)} };
         private readonly string _sampleQueriesContainerName;
         private readonly string _sampleQueriesBlobName;
         private readonly int _defaultRefreshTimeInHours;

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -27,7 +27,7 @@ namespace GraphWebApi.Controllers
         private readonly IConfiguration _configuration;
         private readonly IHttpClientUtility _httpClientUtility;
         private readonly Dictionary<string, string> _changesTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesController" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Changes, nameof(ChangesController) } };
         private readonly TelemetryClient _telemetryClient;
         private readonly IChangesService _changesService;
 
@@ -107,7 +107,7 @@ namespace GraphWebApi.Controllers
                     // Filtered items yielded no result
                     return NotFound();
                 }
-                _changesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "ChangesCount");
+                _changesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(ChangesController));
                 _telemetryClient?.TrackTrace($"Fetched {changeLog.CurrentItems} changes",
                                              SeverityLevel.Information,
                                              _changesTraceProperties);

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -29,14 +29,16 @@ namespace GraphWebApi.Controllers
         private readonly Dictionary<string, string> _changesTraceProperties =
             new() { { UtilityConstants.TelemetryPropertyKey_Changes, "ChangesController" } };
         private readonly TelemetryClient _telemetryClient;
+        private readonly IChangesService _changesService;
 
-        public ChangesController(IChangesStore changesStore, IConfiguration configuration,
+        public ChangesController(IChangesStore changesStore, IConfiguration configuration, IChangesService changesService,
                                  IHttpClientUtility httpClientUtility, TelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient;
             _changesStore = changesStore;
             _configuration = configuration;
             _httpClientUtility = httpClientUtility;
+            _changesService = changesService;
         }
 
         // Gets the changelog records
@@ -89,8 +91,7 @@ namespace GraphWebApi.Controllers
                         GraphVersion = graphVersion
                     };
 
-                    changeLog = ChangesService.Services.ChangesService
-                                    .FilterChangeLogRecords(changeLog, searchOptions, graphProxyConfigs, _httpClientUtility);
+                    changeLog = _changesService.FilterChangeLogRecords(changeLog, searchOptions, graphProxyConfigs, _httpClientUtility);
                 }
                 else
                 {

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -106,7 +106,7 @@ namespace GraphWebApi.Controllers
                     // Filtered items yielded no result
                     return NotFound();
                 }
-                _changesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_Count, "ChangesCount");
+                _changesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "ChangesCount");
                 _telemetryClient?.TrackTrace($"Fetched {changeLog.CurrentItems} changes",
                                              SeverityLevel.Information,
                                              _changesTraceProperties);

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -69,7 +69,7 @@ namespace GraphWebApi.Controllers
                                                                     method: method);
                 }
 
-                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_Count, "PermissionsCount");
+                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsCount");
                 _telemetryClient?.TrackTrace($"Fetched {result.Count} permissions",
                                              SeverityLevel.Information,
                                              _permissionsTraceProperties);

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -23,7 +23,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IPermissionsStore _permissionsStore;
         private readonly Dictionary<string, string> _permissionsTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, "PermissionsController" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, nameof(GraphExplorerPermissionsController) } };
         private readonly TelemetryClient _telemetryClient;
 
         public GraphExplorerPermissionsController(IPermissionsStore permissionsStore, TelemetryClient telemetryClient)
@@ -69,7 +69,7 @@ namespace GraphWebApi.Controllers
                                                                     method: method);
                 }
 
-                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "PermissionsCount");
+                _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(GraphExplorerPermissionsController));
                 _telemetryClient?.TrackTrace($"Fetched {result.Count} permissions",
                                              SeverityLevel.Information,
                                              _permissionsTraceProperties);

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -25,7 +25,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly ISamplesStore _samplesStore;
         private readonly Dictionary<string, string> _samplesTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Samples, "SamplesController" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Samples, nameof(GraphExplorerSamplesController)} };
         private readonly TelemetryClient _telemetryClient;
 
         public GraphExplorerSamplesController(ISamplesStore samplesStore, TelemetryClient telemetryClient)
@@ -71,7 +71,7 @@ namespace GraphWebApi.Controllers
                     return NotFound();
                 }
 
-                _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "SamplesCount");
+                _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(GraphExplorerSamplesController));
                 _telemetryClient?.TrackTrace($"{filteredSampleQueries.Count} sample queries found from search value '{search}'",
                                              SeverityLevel.Information,
                                              _samplesTraceProperties);
@@ -352,7 +352,7 @@ namespace GraphWebApi.Controllers
                 sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale);
             }
 
-            _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "SamplesCount");
+            _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(GraphExplorerSamplesController));
             _telemetryClient?.TrackTrace($"Fetched {sampleQueriesList?.SampleQueries.Count} samples",
                                          SeverityLevel.Information,
                                          _samplesTraceProperties);

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -71,7 +71,7 @@ namespace GraphWebApi.Controllers
                     return NotFound();
                 }
 
-                _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_Count, "SamplesCount");
+                _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "SamplesCount");
                 _telemetryClient?.TrackTrace($"{filteredSampleQueries.Count} sample queries found from search value '{search}'",
                                              SeverityLevel.Information,
                                              _samplesTraceProperties);
@@ -352,7 +352,7 @@ namespace GraphWebApi.Controllers
                 sampleQueriesList = await _samplesStore.FetchSampleQueriesListAsync(locale);
             }
 
-            _samplesTraceProperties.Add("Count", "SamplesCount");
+            _samplesTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "SamplesCount");
             _telemetryClient?.TrackTrace($"Fetched {sampleQueriesList?.SampleQueries.Count} samples",
                                          SeverityLevel.Information,
                                          _samplesTraceProperties);

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -20,7 +20,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly ISnippetsGenerator _snippetGenerator;
         private readonly Dictionary<string, string> _snippetsTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Snippets, "SnippetsController" } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Snippets, nameof(GraphExplorerSnippetsController) } };
         private readonly TelemetryClient _telemetryClient;
 
         public GraphExplorerSnippetsController(ISnippetsGenerator snippetGenerator, TelemetryClient telemetryClient)

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights;
+using UtilityService;
 
 namespace GraphWebApi.Controllers
 {
@@ -18,7 +19,8 @@ namespace GraphWebApi.Controllers
     public class GraphExplorerSnippetsController : ControllerBase
     {
         private readonly ISnippetsGenerator _snippetGenerator;
-        private readonly IDictionary<string, string> _snippetsTraceProperties = new Dictionary<string, string> { { "Snippets", "SnippetsController" } };
+        private readonly Dictionary<string, string> _snippetsTraceProperties =
+            new() { { UtilityConstants.TelemetryPropertyKey_Snippets, "SnippetsController" } };
         private readonly TelemetryClient _telemetryClient;
 
         public GraphExplorerSnippetsController(ISnippetsGenerator snippetGenerator, TelemetryClient telemetryClient)

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -29,7 +29,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IConfiguration _configuration;
         private static readonly Dictionary<string, string> _openApiTraceProperties =
-                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, "OpenApiController" } };
+                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiController)} };
         private readonly TelemetryClient _telemetryClient;
         private readonly IOpenApiService _openApiService;
 

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+using UtilityService;
 
 namespace GraphWebApi.Controllers
 {
@@ -26,7 +27,8 @@ namespace GraphWebApi.Controllers
     public class OpenApiController : ControllerBase
     {
         private readonly IConfiguration _configuration;
-        private static readonly Dictionary<string, string> _openApiTraceProperties = new() { { "OpenApi", "OpenApiController" } };
+        private static readonly Dictionary<string, string> _openApiTraceProperties =
+                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, "OpenApiController" } };
         private readonly TelemetryClient _telemetryClient;
 
         public OpenApiController(IConfiguration configuration, TelemetryClient telemetryClient)

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -84,7 +84,6 @@ namespace GraphWebApi
             #endregion
 
             services.AddMemoryCache();
-            
             services.AddSingleton<ISnippetsGenerator, SnippetsGenerator>();
             services.AddSingleton<IFileUtility, AzureBlobStorageUtility>();
             services.AddSingleton<IPermissionsStore, PermissionsStore>();
@@ -139,9 +138,9 @@ namespace GraphWebApi
             // Localization
             var localizationOptions = app.ApplicationServices.GetService<IOptions<RequestLocalizationOptions>>().Value;
             app.UseRequestLocalization(localizationOptions);
+
             app.ApplicationServices.GetRequiredService<IChangesService>();
             app.ApplicationServices.GetRequiredService<IOpenApiService>();
-
 
             app.UseEndpoints(endpoints =>
             {

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -25,6 +25,8 @@ using System.Globalization;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Options;
 using TelemetrySanitizerService;
+using OpenAPIService.Interfaces;
+using OpenAPIService;
 
 namespace GraphWebApi
 {
@@ -87,7 +89,9 @@ namespace GraphWebApi
             services.AddSingleton<IFileUtility, AzureBlobStorageUtility>();
             services.AddSingleton<IPermissionsStore, PermissionsStore>();
             services.AddSingleton<ISamplesStore, SamplesStore>();
+            services.AddSingleton<IChangesService, ChangesService.Services.ChangesService>();
             services.AddSingleton<IChangesStore, ChangesStore>();
+            services.AddSingleton<IOpenApiService, OpenApiService>();
             services.AddHttpClient<IHttpClientUtility, HttpClientUtility>();
             services.AddControllers().AddNewtonsoftJson();
             services.Configure<SamplesAdministrators>(Configuration);
@@ -135,6 +139,8 @@ namespace GraphWebApi
             // Localization
             var localizationOptions = app.ApplicationServices.GetService<IOptions<RequestLocalizationOptions>>().Value;
             app.UseRequestLocalization(localizationOptions);
+            app.ApplicationServices.GetRequiredService<IChangesService>();
+            app.ApplicationServices.GetRequiredService<IOpenApiService>();
 
 
             app.UseEndpoints(endpoints =>

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -5,6 +5,7 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using OpenAPIService.Interfaces;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -13,9 +14,15 @@ namespace OpenAPIService.Test
     /// <summary>
     /// Mock class that creates a sample OpenAPI document.
     /// </summary>
-    public static class OpenAPIDocumentCreatorMock
+    public class OpenAPIDocumentCreatorMock
     {
         private static readonly ConcurrentDictionary<string, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<string, OpenApiDocument>();
+        private readonly IOpenApiService _openApiService;
+
+        public OpenAPIDocumentCreatorMock(IOpenApiService openApiService)
+        {
+            _openApiService = openApiService;
+        }
 
         /// <summary>
         /// Gets an OpenAPI document of Microsoft Graph
@@ -24,7 +31,7 @@ namespace OpenAPIService.Test
         /// <param name="key">The key for the OpenAPI document dictionary.</param>
         /// <param name="forceRefresh">Whether to reload the OpenAPI document from source.</param>
         /// <returns>Instance of an OpenApiDocument</returns>
-        public static OpenApiDocument GetGraphOpenApiDocument(string key, bool forceRefresh)
+        public OpenApiDocument GetGraphOpenApiDocument(string key, bool forceRefresh)
         {
             if (!forceRefresh && _OpenApiDocuments.TryGetValue(key, out OpenApiDocument doc))
             {
@@ -40,7 +47,7 @@ namespace OpenAPIService.Test
         /// Creates an OpenAPI document.
         /// </summary>
         /// <returns>Instance of an OpenApi document</returns>
-        private static OpenApiDocument CreateOpenApiDocument()
+        private OpenApiDocument CreateOpenApiDocument()
         {
             string applicationJsonMediaType = "application/json";
 
@@ -715,7 +722,7 @@ namespace OpenAPIService.Test
                 }
             };
 
-            return OpenApiService.FixReferences(document);
+            return _openApiService.FixReferences(document);
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using OpenAPIService.Interfaces;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -18,10 +19,12 @@ namespace OpenAPIService.Test
     {
         private static readonly ConcurrentDictionary<string, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<string, OpenApiDocument>();
         private readonly IOpenApiService _openApiService;
+        private const string NullValueError = "Value cannot be null";
 
         public OpenAPIDocumentCreatorMock(IOpenApiService openApiService)
         {
-            _openApiService = openApiService;
+            _openApiService = openApiService
+                ?? throw new ArgumentNullException(nameof(openApiService), $"{ NullValueError }: { nameof(openApiService) }");
         }
 
         /// <summary>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.OpenApi.Models;
+using OpenAPIService.Interfaces;
 using System;
 using System.Linq;
 using Xunit;
@@ -14,11 +15,16 @@ namespace OpenAPIService.Test
         private const string Title = "Partial Graph API";
         private const string GraphVersion = "beta";
         private readonly OpenApiDocument _graphBetaSource = null;
+        private readonly IOpenApiService _openApiService;
+        private readonly OpenAPIDocumentCreatorMock _openAPIDocumentCreatorMock;
 
         public OpenAPIServiceShould()
         {
+            _openApiService = new OpenApiService();
+            _openAPIDocumentCreatorMock = new OpenAPIDocumentCreatorMock(_openApiService);
+
             // Create OpenAPI document with default OpenApiStyle = Plain
-            _graphBetaSource = OpenAPIDocumentCreatorMock.GetGraphOpenApiDocument("Beta", false);
+            _graphBetaSource = _openAPIDocumentCreatorMock.GetGraphOpenApiDocument("Beta", false);
         }
 
         [Fact]
@@ -29,19 +35,19 @@ namespace OpenAPIService.Test
             string operationId_2 = "reports.getTeamsUserActivityUserDetail-a3f1";
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1,
+            var predicate_1 = _openApiService.CreatePredicate(operationIds: operationId_1,
                                                              tags: null,
                                                              url: null,
                                                              source: source);
 
-            var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2,
+            var predicate_2 = _openApiService.CreatePredicate(operationIds: operationId_2,
                                                              tags: null,
                                                              url: null,
                                                              source: source);
 
             // Act
-            var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
-            var subsetOpenApiDocument_2 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_2);
+            var subsetOpenApiDocument_1 = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
+            var subsetOpenApiDocument_2 = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_2);
 
             // Assert
             Assert.Collection(subsetOpenApiDocument_1.Paths,
@@ -73,7 +79,7 @@ namespace OpenAPIService.Test
                 string.IsNullOrEmpty(url))
             {
                 var message = Assert.Throws<InvalidOperationException>(() =>
-                    OpenApiService.CreatePredicate(operationIds: operationIds,
+                    _openApiService.CreatePredicate(operationIds: operationIds,
                                                    tags: tags,
                                                    url: url,
                                                    source: source)).Message;
@@ -82,7 +88,7 @@ namespace OpenAPIService.Test
             else
             {
                 var message = Assert.Throws<InvalidOperationException>(() =>
-                    OpenApiService.CreatePredicate(operationIds: operationIds,
+                    _openApiService.CreatePredicate(operationIds: operationIds,
                                                    tags: tags,
                                                    url: url,
                                                    source: source)).Message;
@@ -105,7 +111,7 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act and Assert
-            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null,
+            var message = Assert.Throws<ArgumentException>(() => _openApiService.CreatePredicate(operationIds: null,
                                                                                                 tags: null,
                                                                                                 url: "/foo",
                                                                                                 source: source,
@@ -119,16 +125,16 @@ namespace OpenAPIService.Test
             // Arrange
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: "/",
                                                            source: source,
                                                            graphVersion: GraphVersion); // root path will be non-existent in a PowerShell styled doc.
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
             // Act & Assert
-            var message = Assert.Throws<ArgumentException>(() => OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument)).Message;
+            var message = Assert.Throws<ArgumentException>(() => _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument)).Message;
             Assert.Equal("No paths found for the supplied parameters.", message);
         }
 
@@ -140,14 +146,14 @@ namespace OpenAPIService.Test
             // Arrange
             OpenApiDocument source = _graphBetaSource;
 
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+            var predicate = _openApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: null,
                                                            source: source);
 
             // Act & Assert
             var message = Assert.Throws<ArgumentException>(() =>
-                OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
+                _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
 
             Assert.Equal("No paths found for the supplied parameters.", message);
         }
@@ -162,7 +168,7 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+            var predicate = _openApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: url,
                                                            source: source,
@@ -182,13 +188,13 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds,
+            var predicate = _openApiService.CreatePredicate(operationIds: operationIds,
                                                            tags: tags,
                                                            url: url,
                                                            source: source,
                                                            graphVersion: GraphVersion);
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
             // Assert
             Assert.NotNull(subsetOpenApiDocument);
@@ -225,15 +231,15 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: url,
                                                            source: source,
                                                            graphVersion: GraphVersion);
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = OpenApiService.ApplyStyle(style, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
 
             // Assert
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
@@ -310,14 +316,14 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: "*",
+            var predicate = _openApiService.CreatePredicate(operationIds: "*",
                                                            tags: null,
                                                            url: null,
                                                            source: source); // fetch all paths/operations
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
 
             // Assert
             Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
@@ -331,14 +337,14 @@ namespace OpenAPIService.Test
             var expectedDescription = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <#/>, etc.).";
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: "/security/hostSecurityProfiles",
                                                            source: source,
                                                            graphVersion: GraphVersion);
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
 
             var parentSchema = subsetOpenApiDocument.Components.Schemas["microsoft.graph.networkInterface"];
             var descriptionSchema = parentSchema.Properties["description"];
@@ -356,14 +362,14 @@ namespace OpenAPIService.Test
             OpenApiDocument source = _graphBetaSource;
 
             // Act
-            var predicate = OpenApiService.CreatePredicate(operationIds: null,
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
                                                            url: url,
                                                            source: source,
                                                            graphVersion: GraphVersion);
 
-            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
             var operationId = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[operationType]

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -1,0 +1,10 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace OpenAPIService.Interfaces
+{
+    public interface IOpenApiService
+    {
+    }
+}

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -2,9 +2,29 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.OpenApi.Models;
+using OpenAPIService.Common;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
 namespace OpenAPIService.Interfaces
 {
     public interface IOpenApiService
     {
+        OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, string graphVersion, Func<OpenApiOperation, bool> predicate);
+
+        Func<OpenApiOperation, bool> CreatePredicate(string operationIds, string tags, string url,
+            OpenApiDocument source, string graphVersion = "v1.0", bool forceRefresh = false);
+
+        MemoryStream SerializeOpenApiDocument(OpenApiDocument subset, OpenApiStyleOptions styleOptions);
+
+        Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh);
+
+        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument);
+
+        Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
+
+        OpenApiDocument FixReferences(OpenApiDocument document);
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -39,7 +39,8 @@ namespace OpenAPIService
     {
         private static readonly ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new();
         private static OpenApiUrlTreeNode _openApiRootNode = OpenApiUrlTreeNode.Create();
-        private static readonly Dictionary<string, string> _openApiTraceProperties = new() { { "OpenApi", "OpenApiService" } };
+        private static readonly Dictionary<string, string> _openApiTraceProperties =
+                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, "OpenApiService" } };
         private static TelemetryClient _telemetryClient;
 
         public OpenApiService(TelemetryClient telemetryClient = null)

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -203,7 +203,7 @@ namespace OpenAPIService
                 }
                 else if (!_openApiRootNode.PathItems.ContainsKey(graphVersion))
                 {
-                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "GraphVersion");
+                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
                     _telemetryClient?.TrackTrace($"Attaching '{graphVersion}' source document to the OpenApiUrlTreeNode",
                                                  SeverityLevel.Information,
                                                  _openApiTraceProperties);
@@ -211,7 +211,7 @@ namespace OpenAPIService
 
                     _openApiRootNode.Attach(source, graphVersion);
 
-                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "GraphVersion");
+                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
                     _telemetryClient?.TrackTrace($"Finished attaching '{graphVersion}' source document to the OpenApiUrlTreeNode",
                                                  SeverityLevel.Information,
                                                  _openApiTraceProperties);

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -450,9 +450,11 @@ namespace OpenAPIService
                 return doc;
             }
 
+            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
             _telemetryClient?.TrackTrace($"Fetch the OpenApi document from the source: {graphUri}",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
+            _openApiTraceProperties.Remove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore);
 
             OpenApiDocument source = await CreateOpenApiDocumentAsync(csdlHref);
             _OpenApiDocuments[csdlHref] = source;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -40,7 +40,7 @@ namespace OpenAPIService
         private static readonly ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new();
         private static OpenApiUrlTreeNode _openApiRootNode = OpenApiUrlTreeNode.Create();
         private static readonly Dictionary<string, string> _openApiTraceProperties =
-                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, "OpenApiService" } };
+                        new() { { UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService)} };
         private readonly TelemetryClient _telemetryClient;
 
         public OpenApiService(TelemetryClient telemetryClient = null)
@@ -203,7 +203,7 @@ namespace OpenAPIService
                 }
                 else if (!_openApiRootNode.PathItems.ContainsKey(graphVersion))
                 {
-                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
+                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
                     _telemetryClient?.TrackTrace($"Attaching '{graphVersion}' source document to the OpenApiUrlTreeNode",
                                                  SeverityLevel.Information,
                                                  _openApiTraceProperties);
@@ -211,7 +211,7 @@ namespace OpenAPIService
 
                     _openApiRootNode.Attach(source, graphVersion);
 
-                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
+                    _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
                     _telemetryClient?.TrackTrace($"Finished attaching '{graphVersion}' source document to the OpenApiUrlTreeNode",
                                                  SeverityLevel.Information,
                                                  _openApiTraceProperties);
@@ -455,7 +455,7 @@ namespace OpenAPIService
                 return doc;
             }
 
-            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, "OpenApiService");
+            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
             _telemetryClient?.TrackTrace($"Fetch the OpenApi document from the source: {graphUri}",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -23,6 +23,7 @@ using OpenAPIService.Common;
 using UtilityService;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights;
+using OpenAPIService.Interfaces;
 
 namespace OpenAPIService
 {
@@ -34,7 +35,7 @@ namespace OpenAPIService
         GEAutocomplete
     }
 
-    public class OpenApiService
+    public class OpenApiService : IOpenApiService
     {
         private static readonly ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new();
         private static OpenApiUrlTreeNode _openApiRootNode = OpenApiUrlTreeNode.Create();

--- a/TelemetryService/CustomPIIFilter.cs
+++ b/TelemetryService/CustomPIIFilter.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Web;
-using UriMatchingService;
 using UtilityService;
 
 namespace TelemetrySanitizerService
@@ -102,7 +101,7 @@ namespace TelemetrySanitizerService
                  * numerical telemetry not required to
                  * be sanitized.
                  */
-                if (!trace.Properties.ContainsKey(UtilityConstants.TelemetryPropertyKey_Count))
+                if (!trace.Properties.ContainsKey(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore))
                 {
                     SanitizeTelemetry(trace: trace);
                 }
@@ -158,7 +157,7 @@ namespace TelemetrySanitizerService
             // use the service provider to lazily get an IPermissionsStore instance
             var permissionsStore = _serviceProvider.GetRequiredService<IPermissionsStore>();
             var uriTemplateMatcher = permissionsStore.GetUriTemplateMatcher();
-            
+
             const char QueryValSeparator = '&';
             var queryPath = url?.Query();
 

--- a/UtilityService/UtilityConstants.cs
+++ b/UtilityService/UtilityConstants.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.ApplicationInsights;
+using System.Collections.Generic;
 
 namespace UtilityService
 {
@@ -11,10 +12,12 @@ namespace UtilityService
     /// </summary>
     public static class UtilityConstants
     {
-        public const string TelemetryPropertyKey_Count = "Count";
+        public const string TelemetryPropertyKey_SanitizeIgnore = "SanitizeIgnore";
         public const string TelemetryPropertyKey_Permissions = "Permissions";
         public const string TelemetryPropertyKey_Samples = "Samples";
         public const string TelemetryPropertyKey_Changes = "Changes";
         public const string TelemetryPropertyKey_OpenApi = "OpenApi";
+        public const string TelemetryPropertyKey_Snippets = "Snippets";
     }
 }
+ 

--- a/UtilityService/UtilityConstants.cs
+++ b/UtilityService/UtilityConstants.cs
@@ -14,6 +14,7 @@ namespace UtilityService
         public const string TelemetryPropertyKey_Count = "Count";
         public const string TelemetryPropertyKey_Permissions = "Permissions";
         public const string TelemetryPropertyKey_Samples = "Samples";
-        public const string TelemetryPropertyKey_Changes = "Changes";      
+        public const string TelemetryPropertyKey_Changes = "Changes";
+        public const string TelemetryPropertyKey_OpenApi = "OpenApi";
     }
 }


### PR DESCRIPTION
Previously, the ` _telemetryClient` field in the `OpenApiService` and `ChangesService` classes weren't being initialized correctly.
To resolve this, I've created interfaces for both services and registered them in Startup as singletons.