### PR TITLE
Fix: Revert metadata source

### DIFF
--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -16,8 +16,8 @@
   },
   "AllowedHosts": "*",
   "GraphMetadata": {
-    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsv1.0.xml",
-    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsAndAnnotationsbeta.xml"
+    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml",
+    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml"
   },
   "BlobStorage": {
     "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",


### PR DESCRIPTION
The new metadata with annotations has some annotation discrepancies that need to be looked into before being accepted back into prod. This is especially affecting PowerShell cmdlet generation. This PR reverts the metadata sources back to the original files.