### PR TITLE
Update snippets url

### DIFF
--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -17,14 +17,14 @@ namespace GraphWebApi.Controllers
     [Route("api/[controller]")]
     [Route("permissions")]
     [ApiController]
-    public class GraphExplorerPermissionsController : ControllerBase
+    public class PermissionsController : ControllerBase
     {
         private readonly IPermissionsStore _permissionsStore;
         private readonly Dictionary<string, string> _permissionsTraceProperties =
-            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, nameof(GraphExplorerPermissionsController) } };
+            new() { { UtilityConstants.TelemetryPropertyKey_Permissions, nameof(PermissionsController) } };
         private readonly TelemetryClient _telemetryClient;
 
-        public GraphExplorerPermissionsController(IPermissionsStore permissionsStore, TelemetryClient telemetryClient)
+        public PermissionsController(IPermissionsStore permissionsStore, TelemetryClient telemetryClient)
         {
             UtilityFunctions.CheckArgumentNull(telemetryClient, nameof(telemetryClient));
             UtilityFunctions.CheckArgumentNull(permissionsStore, nameof(permissionsStore));
@@ -67,7 +67,7 @@ namespace GraphWebApi.Controllers
                                                                 method: method);
             }
 
-            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(GraphExplorerPermissionsController));
+            _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(PermissionsController));
             _telemetryClient?.TrackTrace($"Fetched {result?.Count ?? 0} permissions",
                                             SeverityLevel.Information,
                                             _permissionsTraceProperties);

--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -15,7 +15,8 @@ using UtilityService;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
-    [Route("graphexplorerpermissions")]
+    [Route("api/graphexplorerpermissions")]
+    [Route("permissions")]
     [ApiController]
     public class PermissionsController : ControllerBase
     {

--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -15,7 +15,7 @@ using UtilityService;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
-    [Route("permissions")]
+    [Route("graphexplorerpermissions")]
     [ApiController]
     public class PermissionsController : ControllerBase
     {

--- a/GraphWebApi/Controllers/SamplesController.cs
+++ b/GraphWebApi/Controllers/SamplesController.cs
@@ -34,7 +34,8 @@ namespace GraphWebApi.Controllers
 
         // Gets the list of all sample queries
         [Route("api/[controller]")]
-        [Route("graphexplorersamples")]
+        [Route("api/graphexplorersamples")]
+        [Route("samples")]
         [Produces("application/json")]
         [HttpGet]
         public async Task<IActionResult> GetSampleQueriesListAsync(string search, string org, string branchName)
@@ -72,7 +73,8 @@ namespace GraphWebApi.Controllers
 
        // Gets a sample query from the list of sample queries by its id
        [Route("api/[controller]/{id}")]
-       [Route("graphexplorersamples/{id}")]
+       [Route("api/graphexplorersamples/{id}")]
+       [Route("samples/{id}")]
        [Produces("application/json")]
        [HttpGet]
         public async Task<IActionResult> GetSampleQueryByIdAsync(string id, string org, string branchName)

--- a/GraphWebApi/Controllers/SamplesController.cs
+++ b/GraphWebApi/Controllers/SamplesController.cs
@@ -34,7 +34,7 @@ namespace GraphWebApi.Controllers
 
         // Gets the list of all sample queries
         [Route("api/[controller]")]
-        [Route("samples")]
+        [Route("graphexplorersamples")]
         [Produces("application/json")]
         [HttpGet]
         public async Task<IActionResult> GetSampleQueriesListAsync(string search, string org, string branchName)
@@ -72,7 +72,7 @@ namespace GraphWebApi.Controllers
 
        // Gets a sample query from the list of sample queries by its id
        [Route("api/[controller]/{id}")]
-       [Route("samples/{id}")]
+       [Route("graphexplorersamples/{id}")]
        [Produces("application/json")]
        [HttpGet]
         public async Task<IActionResult> GetSampleQueryByIdAsync(string id, string org, string branchName)

--- a/GraphWebApi/Controllers/SnippetsController.cs
+++ b/GraphWebApi/Controllers/SnippetsController.cs
@@ -20,7 +20,8 @@ using System;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
-    [Route("snippetgenerator")]
+    [Route("snippets")]
+    [Route("api/graphexplorersnippets")]
     [ApiController]
     public class SnippetsController : ControllerBase
     {

--- a/GraphWebApi/Controllers/SnippetsController.cs
+++ b/GraphWebApi/Controllers/SnippetsController.cs
@@ -20,8 +20,8 @@ using System;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
-    [Route("snippetgenerator")]
     [Route("api/graphexplorersnippets")]
+    [Route("snippetgenerator")]
     [ApiController]
     public class SnippetsController : ControllerBase
     {

--- a/GraphWebApi/Controllers/SnippetsController.cs
+++ b/GraphWebApi/Controllers/SnippetsController.cs
@@ -20,7 +20,7 @@ using System;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
-    [Route("snippets")]
+    [Route("snippetgenerator")]
     [Route("api/graphexplorersnippets")]
     [ApiController]
     public class SnippetsController : ControllerBase


### PR DESCRIPTION
Following the recent project renaming, the `/graphexplorersnippets` endpoint on Graph Explorer was failing.
This PR adds a `/graphexplorersnippets` route to the controller to fix this issue