### PR TITLE
Revert Serilog.Sinks.Console lib. version from 4.0.0 to 3.1.1

### DIFF
--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The latest version of `Serilog.Sinks.Console` `v4.0.0` breaks the AzDo build pipeline.

See the below snapshot of the logged build failure:
![image](https://user-images.githubusercontent.com/40403681/132491642-5edecb5d-4f08-411a-905b-2efc5c6424c9.png)

Full log details can be found here: https://o365exchange.visualstudio.com/2f15a0d3-3217-4778-8334-4e61181c4029/_apis/build/builds/6269887/logs/20