### PR TITLE
[New feature bug fix] Avoids caching OpenAPIUrlTreeNode document

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -160,7 +160,7 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi/tree")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery] string graphVersions,
+        public async Task<IActionResult> Get([FromQuery] string graphVersions = "*",
                                              [FromQuery] bool forceRefresh = false)
         {
             graphVersions = string.IsNullOrEmpty(graphVersions) ? "*" : graphVersions.ToLower();

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -163,6 +163,11 @@ namespace GraphWebApi.Controllers
         public async Task<IActionResult> Get([FromQuery] string graphVersions = "*",
                                              [FromQuery] bool forceRefresh = false)
         {
+            if (string.IsNullOrEmpty(graphVersions))
+            {
+                throw new InvalidOperationException($"{nameof(graphVersions)} parameter has an invalid value.");
+            }
+
             HashSet<string> graphVersionsList = new();
             if (graphVersions == "*")
             {

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -173,7 +173,7 @@ namespace GraphWebApi.Controllers
             }
             else
             {
-                graphVersionsList.Add(graphVersions);
+                graphVersionsList.Add(graphVersions.ToLower());
             }
 
             var sources = new Dictionary<string, OpenApiDocument>();

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -163,7 +163,6 @@ namespace GraphWebApi.Controllers
         public async Task<IActionResult> Get([FromQuery] string graphVersions = "*",
                                              [FromQuery] bool forceRefresh = false)
         {
-            graphVersions = string.IsNullOrEmpty(graphVersions) ? "*" : graphVersions.ToLower();
             HashSet<string> graphVersionsList = new();
             if (graphVersions == "*")
             {

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -164,7 +164,7 @@ namespace GraphWebApi.Controllers
                                              [FromQuery] bool forceRefresh = false)
         {
             graphVersions = string.IsNullOrEmpty(graphVersions) ? "*" : graphVersions.ToLower();
-            List<string> graphVersionsList = new();
+            HashSet<string> graphVersionsList = new();
             if (graphVersions == "*")
             {
                 // Use both v1.0 and beta

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -16,7 +16,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UtilityService;
@@ -161,11 +160,11 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi/tree")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery] string graphVersions = Constants.OpenApiConstants.GraphVersion_V1,
+        public async Task<IActionResult> Get([FromQuery] string graphVersions,
                                              [FromQuery] bool forceRefresh = false)
         {
+            graphVersions = string.IsNullOrEmpty(graphVersions) ? "*" : graphVersions.ToLower();
             List<string> graphVersionsList = new();
-
             if (graphVersions == "*")
             {
                 // Use both v1.0 and beta
@@ -181,7 +180,6 @@ namespace GraphWebApi.Controllers
             foreach (var graphVersion in graphVersionsList)
             {
                 var graphUri = GetVersionUri(graphVersion);
-
                 if (graphUri == null)
                 {
                     throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
@@ -191,7 +189,6 @@ namespace GraphWebApi.Controllers
             }
 
             var rootNode = _openApiService.GetOrCreateOpenApiUrlTreeNode(sources, graphVersions, forceRefresh);
-
             using MemoryStream stream = new();
             _openApiService.ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
             return Content(Encoding.ASCII.GetString(stream.ToArray()), "application/json");

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -188,7 +188,7 @@ namespace GraphWebApi.Controllers
                 sources.Add(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
             }
 
-            var rootNode = _openApiService.GetOrCreateOpenApiUrlTreeNode(sources, graphVersions, forceRefresh);
+            var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
             using MemoryStream stream = new();
             _openApiService.ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
             return Content(Encoding.ASCII.GetString(stream.ToArray()), "application/json");

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -626,14 +626,14 @@ paths:
             type: string
             default: v1.0
           required: false
-          description: Comma separated list of the target Microsoft Graph API versions. # Ex: graphVersions=v1.0 / graphVersions=beta / graphVersions=v1.0,beta or graphVersions=* (for both)
+          description: The target Microsoft Graph API version. # Ex: ?graphVersions=v1.0 / ?graphVersions=beta / or ?graphVersions=* (for both)
         - name: forceRefresh
           in: query
           schema:
             type: boolean
             default: false
           required: false
-          description: Reload the OpenAPI document(s).
+          description: Reload the OpenAPI document(s) and the OpenApiUrlTreeNode document.
       responses:
         "200":
           description: Simplified OpenAPI document(s) rendered as an OpenApiUrlTreeNode document.

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -633,7 +633,7 @@ paths:
             type: boolean
             default: false
           required: false
-          description: Reload the OpenAPI document(s) and the OpenApiUrlTreeNode document.
+          description: Reload the OpenAPI document(s).
       responses:
         "200":
           description: Simplified OpenAPI document(s) rendered as an OpenApiUrlTreeNode document.

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -624,7 +624,7 @@ paths:
           in: query
           schema:
             type: string
-            default: v1.0
+            default: v1.0 and beta
           required: false
           description: The target Microsoft Graph API version. # Ex: ?graphVersions=v1.0 / ?graphVersions=beta / or ?graphVersions=* (for both)
         - name: forceRefresh

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -401,16 +401,14 @@ namespace OpenAPIService.Test
             Assert.Equal("applications_GetCreatedOnBehalfOfByRef", operationId);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetOpenApiTreeNode(bool forceRefresh)
+        [Fact]
+        public void GetOpenApiTreeNode()
         {
             // Arrange
             var sources = new Dictionary<string, OpenApiDocument>() { { GraphVersion, _graphMockSource } };
 
             // Act
-            var rootNode = _openApiService.GetOrCreateOpenApiUrlTreeNode(sources, GraphVersion, forceRefresh);
+            var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
             using MemoryStream stream = new();
             ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
 

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -405,10 +406,13 @@ namespace OpenAPIService.Test
         [InlineData(false)]
         public void GetOpenApiTreeNode(bool forceRefresh)
         {
-            // Arrange & Act
-            _openApiService.GetOrCreateOpenApiUrlTreeNode(_graphMockSource, GraphVersion, forceRefresh);
+            // Arrange
+            var sources = new Dictionary<string, OpenApiDocument>() { { GraphVersion, _graphMockSource } };
+
+            // Act
+            var rootNode = _openApiService.GetOrCreateOpenApiUrlTreeNode(sources, GraphVersion, forceRefresh);
             using MemoryStream stream = new();
-            ConvertOpenApiUrlTreeNodeToJson(OpenApiService.RootNode, stream);
+            ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
 
             // Assert
             var jsonPayload = Encoding.ASCII.GetString(stream.ToArray());

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -23,7 +23,7 @@ namespace OpenAPIService.Interfaces
 
         Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh);
 
-        OpenApiUrlTreeNode GetOrCreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources, string graphVersionKey, bool forceRefresh = false);
+        OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources);
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Common;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -22,7 +23,7 @@ namespace OpenAPIService.Interfaces
 
         Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh);
 
-        OpenApiUrlTreeNode GetOrCreateOpenApiUrlTreeNode(OpenApiDocument source, string graphVersion, bool forceRefresh = false);
+        OpenApiUrlTreeNode GetOrCreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources, string graphVersionKey, bool forceRefresh = false);
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 


### PR DESCRIPTION
This PR:

- Attempts to fix a bug that was surfaced during staging tests of the new Resource Explorer endpoint feature. The `OpenApiService` was not correctly returning the expected `OpenApiUrlTreeNode` data for a requested version/label, e.g. 
  - These calls: 
  https://graphexplorerapi-staging.azurewebsites.net/openapi/tree?graphVersions=v1.0 or 
  https://graphexplorerapi-staging.azurewebsites.net/openapi/tree?graphVersions=beta 
fetches the `OpenApiUrlTreeNode` document for both `v1.0` and `beta` versions instead of the specific requested version, `v1.0` or `beta`. This is because, according to the implementation logic, we were improperly caching the `OpenApiUrlTreeNode` document that gets created. 
  - The proposed implementation in this PR is that the  `OpenApiUrlTreeNode` gets created every time it is requested, without storing it in a cache. The `CreateOpenApiUrlTreeNode` method accepts a `Collection` of `OpenApiDocument` and simply creates an `OpenApiUrlTreeNode` without caching the result. This will help in ensuring that the tree nodes do not go stale over time. Instead, the tree nodes will always be a representation of the cached versions of the `OpenApiDocument`.
- Actions user feedback that proposes calling the path `/openapi/tree` without providing any query params should default to fetching the `OpenApiUrlTreeNode` containing both `v1.0` and `beta` paths, and not the initial default `v1.0` paths.

Related to: https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/709