### PR TITLE
Fix typo in ReferenceRequestBody snippets

### DIFF
--- a/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
@@ -99,7 +99,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
                             {
                                 snippetModel.ResponseVariableName += "Reference"; // append suffix
                                 snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = new ReferenceRequestBody\n{{\n");
-                                snippetBuilder.Append($"\tOdataId = \"{odataId}\"\n}};\n\n");
+                                snippetBuilder.Append($"\tODataId = \"{odataId}\"\n}};\n\n");
                                 snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\r\n\t.AddAsync({snippetModel.ResponseVariableName});"));
                             }
                             break;


### PR DESCRIPTION
This PR fixes a typo in snippets invlolving the `ReferenceRequestBody` object.

It fixes the naming of the `ODataId` property from `ODataId` to match the property name [here](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/3c83c2d85b8b9f34e3ab695a6b5e4bf1d6516594/src/Microsoft.Graph.Core/Models/ReferenceRequestBody.cs#L19).