### PR TITLE
Fixes binary encoding in dotnet snippets

### DIFF
--- a/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
@@ -940,7 +940,7 @@ namespace CodeSnippetsReflection.Test
             const string expectedSnippet = "var attachment = new FileAttachment\r\n" + // Use the FileAttachment class rather than the Attachment superclass from metadata
                                            "{\r\n" +
                                            "\tName = \"smile\",\r\n" +
-                                           "\tContentBytes = Encoding.ASCII.GetBytes(\"R0lGODdhEAYEAA7\")\r\n" +
+                                           "\tContentBytes = Convert.FromBase64String(\"R0lGODdhEAYEAA7\")\r\n" +
                                            "};\r\n" +
 
                                            "\r\nawait graphClient.Me.Messages[\"AAMkpsDRVK\"].Attachments\r\n" +

--- a/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
@@ -726,7 +726,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
                         return $"new Duration({specialClassString})";
 
                     case "Binary":
-                        return $"Encoding.ASCII.GetBytes({specialClassString})";
+                        return $"Convert.FromBase64String({specialClassString})";
 
                     case "Double":
                         return $"(double){stringParameter}";

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -138,7 +138,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("Encoding.ASCII.GetBytes", result);
+            Assert.Contains("Convert.FromBase64String", result);
         }
         [Fact]
         public async Task GeneratesADateTimeOffsetPayload() {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -161,7 +161,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
 			switch (value.ValueKind) {
 				case JsonValueKind.String:
 					if(propSchema?.Format?.Equals("base64url", StringComparison.OrdinalIgnoreCase) ?? false)
-						payloadSB.AppendLine($"{propertyAssignment}Encoding.ASCII.GetBytes(\"{value.GetString()}\"){propertySuffix},");
+						payloadSB.AppendLine($"{propertyAssignment}Convert.FromBase64String(\"{value.GetString()}\"){propertySuffix},");
 					else if (propSchema?.Format?.Equals("date-time", StringComparison.OrdinalIgnoreCase) ?? false)
 						payloadSB.AppendLine($"{propertyAssignment}DateTimeOffset.Parse(\"{value.GetString()}\"){propertySuffix},");
 					else


### PR DESCRIPTION
This PR closes #751 

It involves changing the reading of binary properties to use `Convert.FromBase64String` as http examples use Base64 encoded data in the examples and using `Encoding.ASCII.GetBytes` causes data corruption due to the how the function work.

Snippet diff can be viewed at https://github.com/microsoftgraph/microsoft-graph-docs/commit/d4a4886a57c85a8ff4363bc28a5696c6acf8a2b5


Related 
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1164