### PR TITLE
Fixes release pipeline build failure

### DIFF
--- a/ChangesService.Test/ChangeLogRecordsModelShould.cs
+++ b/ChangesService.Test/ChangeLogRecordsModelShould.cs
@@ -28,8 +28,8 @@ namespace ChangesService.Test
             };
 
             // 1st Assert
-            Assert.Equal(3, changeLogRecords.TotalItems);
-            Assert.Equal(3, changeLogRecords.ChangeLogs.Count());
+            Assert.Equal(8, changeLogRecords.TotalItems);
+            Assert.Equal(8, changeLogRecords.ChangeLogs.Count());
 
             /* Take only first two changelog items from list,
              * e.g. in a pagination scenario.
@@ -39,7 +39,7 @@ namespace ChangesService.Test
                                        .ToList();
 
             // 2nd Assert - TotalItems value should not change
-            Assert.Equal(3, changeLogRecords.TotalItems);
+            Assert.Equal(8, changeLogRecords.TotalItems);
             Assert.Equal(2, changeLogRecords.ChangeLogs.Count());
         }
 
@@ -55,7 +55,7 @@ namespace ChangesService.Test
             /* 1st Assert - CurrentItems should always be equal
              * to the current count of changelog items in list.
             */
-            Assert.Equal(3, changeLogRecords.CurrentItems);
+            Assert.Equal(8, changeLogRecords.CurrentItems);
             Assert.Equal(changeLogRecords.CurrentItems, changeLogRecords.ChangeLogs.Count());
 
             /* Take only first two changelog items from list,
@@ -85,13 +85,13 @@ namespace ChangesService.Test
             changeLogRecords.PageLimit = 1;
 
             // Assert
-            Assert.Equal(3, changeLogRecords.TotalPages);
+            Assert.Equal(8, changeLogRecords.TotalPages);
 
             // Act
             changeLogRecords.PageLimit = 2;
 
             // Assert
-            Assert.Equal(2, changeLogRecords.TotalPages);
+            Assert.Equal(4, changeLogRecords.TotalPages);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace ChangesService.Test
                    ""Id"": ""2d94636a-2d78-44d6-8b08-ff2a9121214b"",
                    ""Cloud"": ""prd"",
                    ""Version"": ""v1.0"",
-                   ""CreatedDateTime"": ""2020-09-15T00:00:00.000Z"",
+                   ""CreatedDateTime"": ""2020-08-15T00:00:00.000Z"",
                    ""WorkloadArea"": ""Extensions"",
                    ""SubArea"": ""Schema extensions""
                  },
@@ -160,9 +160,123 @@ namespace ChangesService.Test
                    ""CreatedDateTime"": ""variableDate"",
                    ""WorkloadArea"": ""Reports"",
                    ""SubArea"": ""Identity and access reports""
-                 }
-               ]
-            }";
+                 },
+                 {
+                  ""ChangeList"": [
+                     {
+                        ""Id"": ""937000e6-2cab-4a40-a5ea-58e20dab9fbb"",
+                        ""ApiChange"": ""Resource"",
+                        ""ChangedApiName"": ""Scoping application permissions to specific Exchange Online mailboxes"",
+                        ""ChangeType"": ""Ajout"",
+                        ""Description"": ""Added the capability for administrators to limit app access to only specific mailboxes, even when an app has been granted application permissions to mail, mailbox settings, calendars, or contacts. For more details, see [Scoping application permissions to specific Exchange Online mailboxes](auth-limit-mailbox-access.md)."",
+                        ""Target"": ""Scoping application permissions to specific Exchange Online mailboxes""
+                     }
+                    ],
+                    ""Id"": ""937000e6-2cab-4a40-a5ea-58e20dab9fbb"",
+                    ""Cloud"": ""prd"",
+                    ""Version"": ""v1.0"",
+                    ""CreatedDateTime"": ""2019-11-01T00:00:00.000Z"",
+                    ""WorkloadArea"": ""Calendar, mail, personal contacts"",
+                    ""SubArea"": """"
+                 },
+                 {
+                      ""ChangeList"": [
+                         {
+                            ""Id"": ""656072a4-9a39-4731-8322-13932419895a"",
+                            ""ApiChange"": ""Property"",
+                            ""ChangedApiName"": ""transactionId"",
+                            ""ChangeType"": ""Addition"",
+                            ""Description"": ""Added the **transactionId** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) entity."",
+                            ""Target"": ""events""
+                          }
+                         ],
+                        ""Id"": ""656072a4-9a39-4731-8322-13932419895a"",
+                        ""Cloud"": ""prd"",
+                        ""Version"": ""v1.0"",
+                        ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                        ""WorkloadArea"": ""Calendar"",
+                        ""SubArea"": """"
+                        },
+                    {
+                      ""ChangeList"": [
+                        {
+                          ""Id"": ""8a32aa94-ac63-42d3-b323-5312bfc80a9d"",
+                          ""ApiChange"": ""Property"",
+                          ""ChangedApiName"": ""cancelledOccurrences,exceptionOccurrences,occurrenceId"",
+                          ""ChangeType"": ""Addition"",
+                          ""Description"": ""Added the **cancelledOccurrences**, **exceptionOccurrences**, and **occurrenceId** properties to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-beta) entity."",
+                          ""Target"": ""event""
+                        }
+                      ],
+                      ""Id"": ""8a32aa94-ac63-42d3-b323-5312bfc80a9d"",
+                      ""Cloud"": ""prd"",
+                      ""Version"": ""beta"",
+                      ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                      ""WorkloadArea"": ""Calendar"",
+                      ""SubArea"": """"
+                    },
+                    {
+                          ""ChangeList"": [
+                            {
+                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                              ""ApiChange"": ""Property"",
+                              ""ChangedApiName"": ""allowNewTimeProposals"",
+                              ""ChangeType"": ""Addition"",
+                              ""Description"": ""Added the **allowNewTimeProposals** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) and [eventMessageRequest](https://docs.microsoft.com/en-us/graph/api/resources/eventmessagerequest?view=graph-rest-1.0) entities."",
+                              ""Target"": ""event,eventMessageRequest""
+                            },
+                            {
+                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                              ""ApiChange"": ""Parameter"",
+                              ""ChangedApiName"": ""proposedNewTime,event"",
+                              ""ChangeType"": ""Addition"",
+                              ""Description"": ""Added the **proposedNewTime** optional parameter to the [tentativelyAccept](https://docs.microsoft.com/en-us/graph/api/event-tentativelyaccept?view=graph-rest-1.0) and [decline](https://docs.microsoft.com/en-us/graph/api/event-decline?view=graph-rest-1.0) methods of **event**."",
+                              ""Target"": ""tentativelyAccept,decline""
+                            },
+                            {
+                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                              ""ApiChange"": ""Property"",
+                              ""ChangedApiName"": ""proposedNewTime,responseType"",
+                              ""ChangeType"": ""Addition"",
+                              ""Description"": ""Added the [eventMessageResponse](https://docs.microsoft.com/en-us/graph/api/resources/eventmessageresponse?view=graph-rest-1.0) entity that is based on [eventMessage](https://docs.microsoft.com/en-us/graph/api/resources/eventmessage?view=graph-rest-1.0), and in addition, includes the **proposedNewTime** and **responseType** properties."",
+                              ""Target"": ""eventMessageResponse,eventMessage""
+                            },
+                            {
+                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                              ""ApiChange"": ""Property"",
+                              ""ChangedApiName"": ""proposedNewTime"",
+                              ""ChangeType"": ""Addition"",
+                              ""Description"": ""Added the **proposedNewTime** property to the [attendee](https://docs.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0) complex type."",
+                              ""Target"": ""calendar""
+                            }
+                          ],
+                          ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                          ""Cloud"": ""prd"",
+                          ""Version"": ""v1.0"",
+                          ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                          ""WorkloadArea"": ""Calendar"",
+                          ""SubArea"": """"
+                        },
+                        {
+                          ""ChangeList"": [
+                            {
+                              ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
+                              ""ApiChange"": ""Resource"",
+                              ""ChangedApiName"": ""delta"",
+                              ""ChangeType"": ""Addition"",
+                              ""Description"": ""The [delta](https://docs.microsoft.com/en-us/graph/api/event-delta?view=graph-rest-beta) function supports an additional scenario to get incremental changes (new, updated, or removed) of events in a user calendar without necessarily being bounded by a date range."",
+                              ""Target"": ""delta""
+                            }
+                          ],
+                          ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
+                          ""Cloud"": ""prd"",
+                          ""Version"": ""beta"",
+                          ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                          ""WorkloadArea"": ""Calendar"",
+                          ""SubArea"": """"
+                       }
+                     ]
+                   }";
 
             changeLogRecords = changeLogRecords.Replace("variableDate", variableDate);
 

--- a/ChangesService.Test/ChangeLogRecordsModelShould.cs
+++ b/ChangesService.Test/ChangeLogRecordsModelShould.cs
@@ -92,6 +92,12 @@ namespace ChangesService.Test
 
             // Assert
             Assert.Equal(4, changeLogRecords.TotalPages);
+
+            // Act
+            changeLogRecords.PageLimit = 3;
+
+            // Assert
+            Assert.Equal(3, changeLogRecords.TotalPages);
         }
 
         /// <summary>
@@ -180,24 +186,24 @@ namespace ChangesService.Test
                     ""SubArea"": """"
                  },
                  {
-                      ""ChangeList"": [
-                         {
-                            ""Id"": ""656072a4-9a39-4731-8322-13932419895a"",
-                            ""ApiChange"": ""Property"",
-                            ""ChangedApiName"": ""transactionId"",
-                            ""ChangeType"": ""Addition"",
-                            ""Description"": ""Added the **transactionId** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) entity."",
-                            ""Target"": ""events""
-                          }
-                         ],
+                    ""ChangeList"": [
+                        {
                         ""Id"": ""656072a4-9a39-4731-8322-13932419895a"",
-                        ""Cloud"": ""prd"",
-                        ""Version"": ""v1.0"",
-                        ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
-                        ""WorkloadArea"": ""Calendar"",
-                        ""SubArea"": """"
-                        },
-                    {
+                        ""ApiChange"": ""Property"",
+                        ""ChangedApiName"": ""transactionId"",
+                        ""ChangeType"": ""Addition"",
+                        ""Description"": ""Added the **transactionId** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) entity."",
+                        ""Target"": ""events""
+                        }
+                        ],
+                    ""Id"": ""656072a4-9a39-4731-8322-13932419895a"",
+                    ""Cloud"": ""prd"",
+                    ""Version"": ""v1.0"",
+                    ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                    ""WorkloadArea"": ""Calendar"",
+                    ""SubArea"": """"
+                   },
+                   {
                       ""ChangeList"": [
                         {
                           ""Id"": ""8a32aa94-ac63-42d3-b323-5312bfc80a9d"",
@@ -214,69 +220,69 @@ namespace ChangesService.Test
                       ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
                       ""WorkloadArea"": ""Calendar"",
                       ""SubArea"": """"
-                    },
-                    {
-                          ""ChangeList"": [
-                            {
-                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
-                              ""ApiChange"": ""Property"",
-                              ""ChangedApiName"": ""allowNewTimeProposals"",
-                              ""ChangeType"": ""Addition"",
-                              ""Description"": ""Added the **allowNewTimeProposals** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) and [eventMessageRequest](https://docs.microsoft.com/en-us/graph/api/resources/eventmessagerequest?view=graph-rest-1.0) entities."",
-                              ""Target"": ""event,eventMessageRequest""
-                            },
-                            {
-                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
-                              ""ApiChange"": ""Parameter"",
-                              ""ChangedApiName"": ""proposedNewTime,event"",
-                              ""ChangeType"": ""Addition"",
-                              ""Description"": ""Added the **proposedNewTime** optional parameter to the [tentativelyAccept](https://docs.microsoft.com/en-us/graph/api/event-tentativelyaccept?view=graph-rest-1.0) and [decline](https://docs.microsoft.com/en-us/graph/api/event-decline?view=graph-rest-1.0) methods of **event**."",
-                              ""Target"": ""tentativelyAccept,decline""
-                            },
-                            {
-                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
-                              ""ApiChange"": ""Property"",
-                              ""ChangedApiName"": ""proposedNewTime,responseType"",
-                              ""ChangeType"": ""Addition"",
-                              ""Description"": ""Added the [eventMessageResponse](https://docs.microsoft.com/en-us/graph/api/resources/eventmessageresponse?view=graph-rest-1.0) entity that is based on [eventMessage](https://docs.microsoft.com/en-us/graph/api/resources/eventmessage?view=graph-rest-1.0), and in addition, includes the **proposedNewTime** and **responseType** properties."",
-                              ""Target"": ""eventMessageResponse,eventMessage""
-                            },
-                            {
-                                    ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
-                              ""ApiChange"": ""Property"",
-                              ""ChangedApiName"": ""proposedNewTime"",
-                              ""ChangeType"": ""Addition"",
-                              ""Description"": ""Added the **proposedNewTime** property to the [attendee](https://docs.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0) complex type."",
-                              ""Target"": ""calendar""
-                            }
-                          ],
-                          ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
-                          ""Cloud"": ""prd"",
-                          ""Version"": ""v1.0"",
-                          ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
-                          ""WorkloadArea"": ""Calendar"",
-                          ""SubArea"": """"
-                        },
-                        {
-                          ""ChangeList"": [
-                            {
-                              ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
-                              ""ApiChange"": ""Resource"",
-                              ""ChangedApiName"": ""delta"",
-                              ""ChangeType"": ""Addition"",
-                              ""Description"": ""The [delta](https://docs.microsoft.com/en-us/graph/api/event-delta?view=graph-rest-beta) function supports an additional scenario to get incremental changes (new, updated, or removed) of events in a user calendar without necessarily being bounded by a date range."",
-                              ""Target"": ""delta""
-                            }
-                          ],
-                          ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
-                          ""Cloud"": ""prd"",
-                          ""Version"": ""beta"",
-                          ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
-                          ""WorkloadArea"": ""Calendar"",
-                          ""SubArea"": """"
-                       }
-                     ]
-                   }";
+                   },
+                   {
+                       ""ChangeList"": [
+                         {
+                            ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                            ""ApiChange"": ""Property"",
+                            ""ChangedApiName"": ""allowNewTimeProposals"",
+                            ""ChangeType"": ""Addition"",
+                            ""Description"": ""Added the **allowNewTimeProposals** property to the [event](https://docs.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0) and [eventMessageRequest](https://docs.microsoft.com/en-us/graph/api/resources/eventmessagerequest?view=graph-rest-1.0) entities."",
+                            ""Target"": ""event,eventMessageRequest""
+                         },
+                         {
+                            ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                            ""ApiChange"": ""Parameter"",
+                            ""ChangedApiName"": ""proposedNewTime,event"",
+                            ""ChangeType"": ""Addition"",
+                            ""Description"": ""Added the **proposedNewTime** optional parameter to the [tentativelyAccept](https://docs.microsoft.com/en-us/graph/api/event-tentativelyaccept?view=graph-rest-1.0) and [decline](https://docs.microsoft.com/en-us/graph/api/event-decline?view=graph-rest-1.0) methods of **event**."",
+                            ""Target"": ""tentativelyAccept,decline""
+                         },
+                         {
+                            ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                            ""ApiChange"": ""Property"",
+                            ""ChangedApiName"": ""proposedNewTime,responseType"",
+                            ""ChangeType"": ""Addition"",
+                            ""Description"": ""Added the [eventMessageResponse](https://docs.microsoft.com/en-us/graph/api/resources/eventmessageresponse?view=graph-rest-1.0) entity that is based on [eventMessage](https://docs.microsoft.com/en-us/graph/api/resources/eventmessage?view=graph-rest-1.0), and in addition, includes the **proposedNewTime** and **responseType** properties."",
+                            ""Target"": ""eventMessageResponse,eventMessage""
+                         },
+                         {
+                            ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                            ""ApiChange"": ""Property"",
+                            ""ChangedApiName"": ""proposedNewTime"",
+                            ""ChangeType"": ""Addition"",
+                            ""Description"": ""Added the **proposedNewTime** property to the [attendee](https://docs.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0) complex type."",
+                            ""Target"": ""calendar""
+                         }
+                        ],
+                        ""Id"": ""f5824007-1349-4ab9-b1c3-1b294d2c5bd4"",
+                        ""Cloud"": ""prd"",
+                        ""Version"": ""v1.0"",
+                        ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                        ""WorkloadArea"": ""Calendar"",
+                        ""SubArea"": """"
+                     },
+                     {
+                        ""ChangeList"": [
+                          {
+                             ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
+                             ""ApiChange"": ""Resource"",
+                             ""ChangedApiName"": ""delta"",
+                             ""ChangeType"": ""Addition"",
+                             ""Description"": ""The [delta](https://docs.microsoft.com/en-us/graph/api/event-delta?view=graph-rest-beta) function supports an additional scenario to get incremental changes (new, updated, or removed) of events in a user calendar without necessarily being bounded by a date range."",
+                             ""Target"": ""delta""
+                           }
+                        ],
+                        ""Id"": ""13064a4f-262d-40eb-ac18-5c6396974ed7"",
+                        ""Cloud"": ""prd"",
+                        ""Version"": ""beta"",
+                        ""CreatedDateTime"": ""2020-10-01T00:00:00.000Z"",
+                        ""WorkloadArea"": ""Calendar"",
+                        ""SubArea"": """"
+                     }
+                 ]
+            }";
 
             changeLogRecords = changeLogRecords.Replace("variableDate", variableDate);
 

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -117,10 +117,10 @@ namespace ChangesService.Test
             // Arrange
             var changeLogRecords = await _changesStore.FetchChangeLogRecordsAsync(new CultureInfo("en-US"));
 
-            var searchOptions = new ChangeLogSearchOptions(requestUrl: "/me/calendar", graphVersion: "v1.0");
+            var searchOptions = new ChangeLogSearchOptions(requestUrl: "/me/calendar/events", graphVersion: "v1.0");
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -128,7 +128,7 @@ namespace ChangesService.Test
             Assert.Collection(filteredChangeLogRecords.ChangeLogs,
                 item =>
                 {
-                    Assert.Equal(4, item.ChangeList.Count());
+                    Assert.Single(item.ChangeList);
                 },
                 item =>
                 {
@@ -137,15 +137,13 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public async Task FilterChangeLogRecordsByRequestUrlReturnsNoChangeLogsForNonExistingChanges()
+        public void FilterChangeLogRecordsByRequestUrlReturnsNoChangeLogsForNonExistingChanges()
         {
             // Arrange
-            var changeLogRecords = await _changesStore.FetchChangeLogRecordsAsync(new CultureInfo("en-US"));
-
             var searchOptions = new ChangeLogSearchOptions(requestUrl: "/me/messages", graphVersion: "v1.0");
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -154,29 +152,25 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public async Task ThrowExceptionWhenServiceNameIsNotFoundForReturnedWorkloadId()
+        public void ThrowExceptionWhenServiceNameIsNotFoundForReturnedWorkloadId()
         {
             // Arrange
-            var changeLogRecords = await _changesStore.FetchChangeLogRecordsAsync(new CultureInfo("en-US"));
-
             var searchOptions = new ChangeLogSearchOptions(requestUrl: "/appCatalogs/teamsApps", graphVersion: "v1.0");
 
             // Act and Assert
             Assert.Throws<Exception>(() =>
-            _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility));
+            _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility));
         }
 
         [Fact]
-        public async Task ThrowInvalidOperationExceptionWhenFetchWorkloadInfoFromGraphReturnsError()
+        public void ThrowInvalidOperationExceptionWhenFetchWorkloadInfoFromGraphReturnsError()
         {
             // Arrange
-            var changeLogRecords = await _changesStore.FetchChangeLogRecordsAsync(new CultureInfo("en-US"));
-
             var searchOptions = new ChangeLogSearchOptions(requestUrl: "/admin/windows/updates", graphVersion: "v1.0");
 
             // Act and Assert
             Assert.Throws<InvalidOperationException>(() =>
-            _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility));
+            _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility));
         }
 
         [Fact]
@@ -184,7 +178,7 @@ namespace ChangesService.Test
         {
             // Arrange
             var startDate = DateTime.Parse("2020-01-01");
-            var endDate = DateTime.Parse("2020-10-01");
+            var endDate = DateTime.Parse("2020-09-01");
             var searchOptions = new ChangeLogSearchOptions(startDate: startDate, endDate: endDate);
 
             // Act
@@ -423,8 +417,8 @@ namespace ChangesService.Test
             // Arrange
             var searchOptions = new ChangeLogSearchOptions
             {
-                Page = 2,
-                PageLimit = 2
+                Page = 8,
+                PageLimit = 1
             };
 
             // Act
@@ -435,17 +429,16 @@ namespace ChangesService.Test
             Assert.Collection(filteredChangeLogRecords.ChangeLogs,
                 item =>
                 {
-                    Assert.Equal("dca6467b-d026-4316-8353-2c6c02598af3", item.Id);
-                    Assert.Equal("Reports", item.WorkloadArea);
-                    Assert.Equal("Identity and access reports", item.SubArea);
+                    Assert.Equal("13064a4f-262d-40eb-ac18-5c6396974ed7", item.Id);
+                    Assert.Equal("Calendar", item.WorkloadArea);
                     Assert.Collection(item.ChangeList,
                         item =>
                         {
-                            Assert.Equal("dca6467b-d026-4316-8353-2c6c02598af3", item.Id);
+                            Assert.Equal("13064a4f-262d-40eb-ac18-5c6396974ed7", item.Id);
                             Assert.Equal("Resource", item.ApiChange);
-                            Assert.Equal("relyingPartyDetailedSummary,listing", item.ChangedApiName);
+                            Assert.Equal("delta", item.ChangedApiName);
                             Assert.Equal("Addition", item.ChangeType);
-                            Assert.Equal("relyingPartyDetailedSummary,listing", item.Target);
+                            Assert.Equal("delta", item.Target);
                         });
                 });
         }

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -9,10 +9,8 @@ using FileService.Services;
 using MockTestUtility;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace ChangesService.Test
@@ -438,6 +436,20 @@ namespace ChangesService.Test
                             Assert.Equal("delta", item.Target);
                         });
                 });
+
+            // Arrange
+            searchOptions = new ChangeLogSearchOptions
+            {
+                Page = 3,
+                PageLimit = 3
+            };
+
+            // Act
+            filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+
+            // Assert
+            Assert.NotNull(filteredChangeLogRecords);
+            Assert.Equal(2, filteredChangeLogRecords.ChangeLogs.Count());
         }
 
         private static Dictionary<string, string> GetWorkloadServiceMappingsFile()

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -22,7 +22,6 @@ namespace ChangesService.Test
         private readonly MicrosoftGraphProxyConfigs _graphProxyConfigs;
         private readonly IChangesService _changesService;
         private readonly ChangeLogRecordsModelShould _changeLogRecordsModel = new();
-        private readonly ChangesStoreShould _changesStore = new();
         private readonly Dictionary<string, string> _workloadServiceMappings = GetWorkloadServiceMappingsFile();
         private readonly HttpClient _httpClientMock;
         private readonly IHttpClientUtility _httpClientUtility;
@@ -112,11 +111,9 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public async Task FilterChangeLogRecordsByRequestUrlReturnsRecordsForExistingChanges()
+        public void FilterChangeLogRecordsByRequestUrlReturnsRecordsForExistingChanges()
         {
             // Arrange
-            var changeLogRecords = await _changesStore.FetchChangeLogRecordsAsync(new CultureInfo("en-US"));
-
             var searchOptions = new ChangeLogSearchOptions(requestUrl: "/me/calendar/events", graphVersion: "v1.0");
 
             // Act

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -147,13 +147,13 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public void ThrowExceptionWhenServiceNameIsNotFoundForReturnedWorkloadId()
+        public void ThrowArgumentOutOfRangeExceptionWhenServiceNameIsNotFoundForReturnedWorkloadId()
         {
             // Arrange
             var searchOptions = new ChangeLogSearchOptions(requestUrl: "/appCatalogs/teamsApps", graphVersion: "v1.0");
 
             // Act and Assert
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings, _httpClientUtility));
         }
 

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -21,23 +21,22 @@ namespace ChangesService.Test
     {
         private readonly MicrosoftGraphProxyConfigs _graphProxyConfigs;
         private readonly IChangesService _changesService;
-        private readonly ChangeLogRecordsModelShould _changeLogRecordsModel;
-        private readonly ChangesStoreShould _changesStore;
-        private readonly Dictionary<string, string> _workloadServiceMappings = new();
+        private readonly ChangeLogRecordsModelShould _changeLogRecordsModel = new();
+        private readonly ChangesStoreShould _changesStore = new();
+        private readonly Dictionary<string, string> _workloadServiceMappings = GetWorkloadServiceMappingsFile();
         private readonly HttpClient _httpClientMock;
         private readonly IHttpClientUtility _httpClientUtility;
+        private readonly ChangeLogRecords _changeLogRecords = new();
 
 
         public ChangesServiceShould()
         {
             _changesService = new Services.ChangesService();
-            _changeLogRecordsModel = new ChangeLogRecordsModelShould();
-            _changesStore = new ChangesStoreShould();
-            _workloadServiceMappings = _changesStore.GetWorkloadServiceMappingsFile().GetAwaiter().GetResult();
             _httpClientMock = new HttpClient(new MockHttpMessageHandler());
             _httpClientUtility = new HttpClientUtility(_httpClientMock);
             var graphProxyConfigsInitializer = new MicrosoftGraphProxyConfigTestInitializer("v1.0");
             _graphProxyConfigs = graphProxyConfigsInitializer.GraphProxyConfigs;
+            _changeLogRecords.ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs;
         }
 
         [Fact]
@@ -87,15 +86,10 @@ namespace ChangesService.Test
         public void FilterChangeLogRecordsByWorkload()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
-
             var searchOptions = new ChangeLogSearchOptions(service: "Compliance", graphVersion: "beta");
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -189,16 +183,12 @@ namespace ChangesService.Test
         public void FilterChangeLogRecordsByDates()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
             var startDate = DateTime.Parse("2020-01-01");
             var endDate = DateTime.Parse("2020-10-01");
             var searchOptions = new ChangeLogSearchOptions(startDate: startDate, endDate: endDate);
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -239,7 +229,6 @@ namespace ChangesService.Test
         public void FilterChangeLogRecordsByDaysRange()
         {
             // Arrange
-
             DateTime varDate = DateTime.Today.AddDays(-30);
             var changeLogRecords = new ChangeLogRecords
             {
@@ -276,16 +265,11 @@ namespace ChangesService.Test
         public void FilterChangeLogRecordsByStartDateAndDaysRange()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
             var startDate = DateTime.Parse("2020-06-01");
-
             var searchOptions = new ChangeLogSearchOptions(startDate: startDate, daysRange: 120);
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -326,16 +310,11 @@ namespace ChangesService.Test
         public void FilterChangeLogRecordsByEndDateAndDaysRange()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
             var endDate = DateTime.Parse("2021-01-01");
-
             var searchOptions = new ChangeLogSearchOptions(endDate: endDate, daysRange: 30);
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert
             Assert.NotNull(filteredChangeLogRecords);
@@ -361,11 +340,6 @@ namespace ChangesService.Test
         public void PaginateChangeLogRecordsFirstPage()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
-
             var searchOptions = new ChangeLogSearchOptions
             {
                 Page = 1,
@@ -373,7 +347,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert -- fetch first two items from the changelog sample
             Assert.NotNull(filteredChangeLogRecords);
@@ -414,11 +388,6 @@ namespace ChangesService.Test
         public void PaginateChangeLogRecordsMiddlePage()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
-
             var searchOptions = new ChangeLogSearchOptions
             {
                 Page = 2,
@@ -426,7 +395,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert -- fetch middle item from the changelog sample
             Assert.NotNull(filteredChangeLogRecords);
@@ -452,11 +421,6 @@ namespace ChangesService.Test
         public void PaginateChangeLogRecordsLastPage()
         {
             // Arrange
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = _changeLogRecordsModel.GetChangeLogRecords().ChangeLogs
-            };
-
             var searchOptions = new ChangeLogSearchOptions
             {
                 Page = 2,
@@ -464,7 +428,7 @@ namespace ChangesService.Test
             };
 
             // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
 
             // Assert -- fetch last item from the changelog sample
             Assert.NotNull(filteredChangeLogRecords);
@@ -484,6 +448,15 @@ namespace ChangesService.Test
                             Assert.Equal("relyingPartyDetailedSummary,listing", item.Target);
                         });
                 });
+        }
+
+        private static Dictionary<string, string> GetWorkloadServiceMappingsFile()
+        {
+            return new Dictionary<string, string>
+            {
+                {"Microsoft.Exchange.Places", "Calendar" },
+                {"Microsoft.Exchange", "Calendar, mail, personal contacts" }
+            };
         }
     }
 }

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -213,6 +213,10 @@ namespace ChangesService.Services
                     changeLogRecords.Page = changeLogRecords.TotalPages;
 
                     int lastItems = changeLogRecords.ChangeLogs.Count() % searchOptions.PageLimit.Value;
+                    if (lastItems == 0)
+                    {
+                        lastItems = 1;
+                    }
                     enumerableChangeLogs = changeLogRecords.ChangeLogs
                                                             .TakeLast(lastItems);
                 }

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -343,7 +343,7 @@ namespace ChangesService.Services
             }
             else
             {
-                throw new Exception($"Service name not found for the WorkloadId: {targetWorkloadId}");
+                throw new ArgumentOutOfRangeException($"Service name not found for the WorkloadId: {targetWorkloadId}");
             }
         }
     }

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -215,8 +215,9 @@ namespace ChangesService.Services
                     int lastItems = changeLogRecords.ChangeLogs.Count() % searchOptions.PageLimit.Value;
                     if (lastItems == 0)
                     {
-                        lastItems = 1;
+                        lastItems = searchOptions.PageLimit.Value;
                     }
+
                     enumerableChangeLogs = changeLogRecords.ChangeLogs
                                                             .TakeLast(lastItems);
                 }

--- a/MockTestUtility/MockHttpConstants.cs
+++ b/MockTestUtility/MockHttpConstants.cs
@@ -22,7 +22,7 @@ namespace MockTestUtility
                 "\"https://graph.office.net/en-us/graph/api/proxy\""
             },
             {
-                "https://graph.office.net/en-us/graph/api/proxy?url=https://graph.microsoft.com/v1.0/me/calendar?$whatif",
+                "https://graph.office.net/en-us/graph/api/proxy?url=https://graph.microsoft.com/v1.0/me/calendar/events?$whatif",
                 @"{
    ""Description"":""Runs main request and in case of NotFound, discovers the uri and runs the request again."",
    ""Uri"":""https://outlook.office365.com/api/gv1.0/Users('48d31887-5fad-4d73-a9f5-3c356e68a038%40dcd219dd-bc68-4b9b-bf0b-4a33a796be35')/messages?$whatif"",


### PR DESCRIPTION
**Issue:**
When attempting to run the [release pipeline](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/results?buildId=6810581&view=results) for the DevX API for the master branch, the job times out on the **Run Tests** task after 60 minutes. From the emitted [logs](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/results?buildId=6810581&view=logs&j=23363795-6e69-57d1-331b-529ba9db22f1&t=6d9dff71-3f87-5860-de7e-22e84ded2812) however, it is not immediately clear why this times out:

![image](https://user-images.githubusercontent.com/40403681/141678502-e5d6f119-0366-4ddc-9b87-83cf8a2ac66e.png)

It is worth noting that this also caused the SonarCloud [build ](https://github.com/microsoftgraph/microsoft-graph-devx-api/runs/4156986673?check_suite_focus=true) job to time out during this [PR](https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/747).

These tests do pass in the local setup of DevX API and did also pass in the last build job for the [DevX API Validate PR](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=58757&view=results) pipeline. 
From face value however, indications pointed to something to do with the `ChangesService.Test` project. Upon further rigorous and pain-staking investigations, the cause for this was found to be these calls made from the `ChangesServiceShould.cs` class to the `ChangesStoreShould.cs` class.

1. Call 1:
![image](https://user-images.githubusercontent.com/40403681/141698392-46ac3e6d-16d2-42fa-98d5-fd368adc453b.png)
https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/95dcaadf6deaa79b724f9fe334b110d8244bf848/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L36

2. Call 2 (and other similar subsequent calls):
![image](https://user-images.githubusercontent.com/40403681/141698433-368368f4-bf10-493c-b0e2-eadf0e43df5f.png)
https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/95dcaadf6deaa79b724f9fe334b110d8244bf848/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L149

**Fixes done in this PR to resolve the above includes**:
- Replacing the calls from the test class `ChangesServiceShould.cs` to the test class `ChangesStoreShould.cs` with calls that return static values, e.g.,

The [first call](https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/95dcaadf6deaa79b724f9fe334b110d8244bf848/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L36) has been replaced with a call to the static method:

![image](https://user-images.githubusercontent.com/40403681/141699036-faadd4dd-ac2b-436d-8ede-a6367f20885c.png)
https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/4157029e2adf21754b0a0f88048ee2f91ae7ddb4/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L455-L462

The [2nd call](https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/95dcaadf6deaa79b724f9fe334b110d8244bf848/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L149) (and similar subsequent calls) have been replaced with:

![image](https://user-images.githubusercontent.com/40403681/141699138-84c178c5-b234-4d49-a380-ebc486228b83.png)
https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/4157029e2adf21754b0a0f88048ee2f91ae7ddb4/ChangesService.Test/ChangesServiceShould.cs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L36

Both updated calls now get static data returned. This helps resolve the build time-out issue experienced in the release pipeline. It is still unclear why this actually caused an issue in the build pipeline.

**Other PR updates:**
- Adding new test sample data.
- Updating some of the tests.
- Updating the pagination logic (for retrieving last pages)