### PR TITLE
Removes hash suffix values from the operationIds of function paths

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -705,6 +705,72 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
+                    ["/reports/microsoft.graph.getSharePointSiteUsageDetail(period={period})"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        new OpenApiTag()
+                                        {
+                                            Name = "reports.Functions"
+                                        }
+                                    },
+                                    OperationId = "reports.getSharePointSiteUsageDetail-204b",
+                                    Summary = "Invoke function getSharePointSiteUsageDetail",
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        new OpenApiParameter()
+                                        {
+                                            Name = "period",
+                                            In = ParameterLocation.Path,
+                                            Description = "Usage: period={period}",
+                                            Required = true,
+                                            Schema = new OpenApiSchema()
+                                            {
+                                                Type = "string"
+                                            }
+                                        }
+                                    },
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200", new OpenApiResponse()
+                                            {
+                                                Description = "Success",
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    {
+                                                        applicationJsonMediaType,
+                                                        new OpenApiMediaType
+                                                        {
+                                                            Schema = new OpenApiSchema
+                                                            {
+                                                                Reference = new OpenApiReference
+                                                                {
+                                                                    Type = ReferenceType.Schema,
+                                                                    Id = "microsoft.graph.report"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("function")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     ["/applications/{application-id}/createdOnBehalfOf/$ref"] = new OpenApiPathItem()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -334,6 +334,7 @@ namespace OpenAPIService.Test
         [Theory]
         [InlineData("/communications/calls/{call-id}/microsoft.graph.keepAlive", OperationType.Post, "communications.calls_keepAlive")]
         [InlineData("/groups/{group-id}/events/{event-id}/calendar/events/microsoft.graph.delta", OperationType.Get, "groups.events.calendar.events_delta")]
+        [InlineData("/reports/microsoft.graph.getSharePointSiteUsageDetail(period={period})", OperationType.Get, "reports_getSharePointSiteUsageDetail")]
         public void ResolveActionFunctionOperationIdsForPowerShellStyle(string url, OperationType operationType, string expectedOperationId)
         {
 

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -150,7 +150,7 @@ namespace OpenAPIService
 
             var updatedOperationId = string.Join(".", segments);
 
-            // Remove hash suffix values from OperationIds of functions.
+            // Remove hash suffix values from OperationIds of function paths.
             // For example,
             // Default OperationId --> reports_getEmailActivityUserDetail-fe32
             // Resolved OperationId --> reports_getEmailActivityUserDetail


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/728

This PR:
- Uses regex to remove hash suffix values from the `operationId`s of certain _function_ paths for the `PowerShell` `style` option.
- Adds a mock _function_ path and a test to validate the above.