### PR TITLE
Fix Typescript Code Generation

### DIFF
--- a/CodeSnippetsReflection.App/Program.cs
+++ b/CodeSnippetsReflection.App/Program.cs
@@ -93,7 +93,7 @@ namespace CodeSnippetsReflection.App
 
             Parallel.ForEach(supportedLanguages, language =>
             {
-                if(language.Equals("go", StringComparison.OrdinalIgnoreCase))
+                if(language.Equals("go", StringComparison.OrdinalIgnoreCase) || language.Equals("typescript", StringComparison.OrdinalIgnoreCase))
                     generation = "openapi";
                 else
                     generation = originalGeneration;

--- a/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
@@ -50,7 +50,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("const graphClient = new GraphClient(requestAdapter)", result);
+            Assert.Contains("const graphServiceClient = new GraphServiceClient(requestAdapter)", result);
         }
         [Fact]
         public async Task GeneratesTheGetMethodCall()

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
@@ -20,8 +20,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         /// <returns>String of the snippet in Javascript code</returns>
         /// 
 
-        private const string clientVarName = "graphClient";
-        private const string clientVarType = "GraphClient";
+        private const string clientVarName = "graphServiceClient";
+        private const string clientVarType = "GraphServiceClient";
         private const string httpCoreVarName = "requestAdapter";
 
         public string GenerateCodeSnippet(SnippetModel snippetModel)
@@ -46,7 +46,11 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             // add parameters
             var parametersList = GetActionParametersList(payloadVarName, queryParamsVarName, requestHeadersVarName);
             var methodName = snippetModel.Method.ToString().ToLower();
-            snippetBuilder.AppendLine($"{responseAssignment}await {clientVarName}.{GetFluentApiPath(snippetModel.PathNodes)}.{methodName}({parametersList});");
+            snippetBuilder.AppendLine($"{responseAssignment}async () => {{");
+            indentManager.Indent();
+            snippetBuilder.AppendLine($"{indentManager.GetIndent()}await {clientVarName}.{GetFluentApiPath(snippetModel.PathNodes)}.{methodName}({parametersList});");
+            indentManager.Unindent();
+            snippetBuilder.AppendLine($"}}");
 
             return snippetBuilder.ToString();
         }


### PR DESCRIPTION
Renames typescript client name, enables of typescript to es5 and add typescript to snippet generation logic


## Overview

Allows generation of typescript with ES5 compatible syntax of Await.
Renames typescript default client name.
Adds typescript to code generation pipeline


## Testing Instructions

* All changes are covered in automated tests