### PR TITLE
[Feature]: Support regex-based filtering on operationIds query parameter

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -199,6 +199,28 @@ namespace OpenAPIService.Test
         }
 
         [Theory]
+        [InlineData("^users.", null, 3)]
+        [InlineData("users.user*", null, 2)]
+        [InlineData("^users.|^applications.", null, 5)]
+        [InlineData(null, "^users.", 3)]
+        [InlineData(null, "users.user*", 2)]
+        [InlineData(null, "^users.|^applications.", 5)]
+        public void SupportFilteringOpenApiDocumentByRegexOnOperationIdsAndTags(string operationIds, string tags, int pathCount)
+        {
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: operationIds,
+                                                          tags: tags,
+                                                          url: null,
+                                                          source: _graphMockSource,
+                                                          graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+
+            // Assert
+            Assert.Equal(pathCount, subsetOpenApiDocument.Paths.Count);
+        }
+
+        [Theory]
         [InlineData(OpenApiStyle.Plain, "/users/{user-id}", OperationType.Get)]
         [InlineData(OpenApiStyle.Plain, "/users/12345", OperationType.Get)]
         [InlineData(OpenApiStyle.GEAutocomplete, "/users(user-id)messages(message-id)", OperationType.Get)]

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -160,13 +160,18 @@ namespace OpenAPIService
             Func<OpenApiOperation, bool> predicate;
             if (operationIds != null)
             {
-                if (operationIds == "*")
+                var operationIdsArray = operationIds.Split(',');
+                if (operationIds == "*") // Note: string literal "*" is not valid regex, so we are handling it separately
                 {
                     predicate = (o) => true;  // All operations
                 }
+                else if (operationIdsArray.Length == 1)
+                {
+                    var regex = new Regex(operationIdsArray[0]);
+                    predicate = (o) => regex.IsMatch(o.OperationId);
+                }
                 else
                 {
-                    var operationIdsArray = operationIds.Split(',');
                     predicate = (o) => operationIdsArray.Contains(o.OperationId);
                 }
 


### PR DESCRIPTION
## Overview
Issue: https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/441

This PR adds the support for filtering Open API by operationIds query parameter.
 For example: GET `https://graphexplorerapi.azurewebsites.net/openapi?operationIds=deviceManagement.reports*`

### Demo
<img width="349" alt="filter-by-operation-ids" src="https://user-images.githubusercontent.com/6814355/143445969-28fbc336-f306-4ab7-a2bd-1d57ca788b82.PNG">