### PR TITLE
- switches to feed for api doctor instead of local build

### DIFF
--- a/ApiDoctorRef/ApiDoctorRef.csproj
+++ b/ApiDoctorRef/ApiDoctorRef.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ApiDoctor" Version="1.2.2106.31" />
+  </ItemGroup>
+
+</Project>

--- a/ApiDoctorRef/Program.cs
+++ b/ApiDoctorRef/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace ApiDoctorRef
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -61,6 +61,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TourStepsService", "TourSte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TourStepsService.Test", "TourStepsService.Test\TourStepsService.Test.csproj", "{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiDoctorRef", "ApiDoctorRef\ApiDoctorRef.csproj", "{05CA8E2C-842F-4F31-8C18-751F9B58A64C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,10 @@ Global
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05CA8E2C-842F-4F31-8C18-751F9B58A64C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05CA8E2C-842F-4F31-8C18-751F9B58A64C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05CA8E2C-842F-4F31-8C18-751F9B58A64C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05CA8E2C-842F-4F31-8C18-751F9B58A64C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -20,19 +20,12 @@ resources:
      endpoint: microsoftgraph
      name: microsoftgraph/microsoft-graph-docs
      ref: main
-   - repository: apidoctor
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/apidoctor
-     ref: master
 
 pool:
   vmImage: 'ubuntu-latest'
 
 variables:
   buildConfiguration: 'Release'
-  apidoctorPath: 'apidoctor'
-  apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
   snippetLanguages: 'C#,JavaScript,Objective-C,Java,Go'
 
 steps:
@@ -44,12 +37,6 @@ steps:
 - checkout: microsoft-graph-docs
   displayName: checkout docs
   fetchDepth: 1
-  persistCredentials: true
-
-- checkout: apidoctor
-  displayName: checkout apidoctor
-  fetchDepth: 1
-  submodules: recursive
   persistCredentials: true
 
 - template: templates/git-config.yml
@@ -66,25 +53,14 @@ steps:
     projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Restore packages for APIDoctor'
-  inputs:
-    command: 'restore'
-    projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
-
-- task: DotNetCoreCLI@2
-  displayName: 'Build APIDoctor'
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
-    arguments: '--configuration $(buildConfiguration)'
+- pwsh: scripts/downloadApiDoctor.ps1
 
 - pwsh: |
     # release folder can change based on .NET core version, so search recursively in bin folder
     $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
     Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
-    $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
+    $apidoctorPath = (Get-ChildItem $env:ApiDoctorPath/tools apidoc.exe -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
     . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -22,7 +22,7 @@ resources:
      ref: main
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -64,7 +64,7 @@ steps:
 
 - pwsh: |
     # release folder can change based on .NET core version, so search recursively in bin folder
-    $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
+    $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App.exe -Recurse).FullName
     Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
     $apidoctorPath = (Get-ChildItem (Join-Path "$(ApiDoctorPath)" "tools" "apidoc.exe") -Recurse).FullName

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -58,6 +58,7 @@ steps:
     targetType: 'filePath'
     filePath: microsoft-graph-devx-api/scripts/downloadApiDoctor.ps1
     pwsh: true
+    workingDirectory: microsoft-graph-devx-api
 
 - pwsh: |
     # release folder can change based on .NET core version, so search recursively in bin folder

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -27,6 +27,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   snippetLanguages: 'C#,JavaScript,Objective-C,Java,Go'
+  ApiDoctorPath: ''
 
 steps:
 - checkout: self
@@ -66,7 +67,7 @@ steps:
     $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
     Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
-    $apidoctorPath = (Get-ChildItem $env:ApiDoctorPath/tools apidoc.exe -Recurse).FullName
+    $apidoctorPath = (Get-ChildItem (Join-Path $env:ApiDoctorPath "tools" "apidoc.exe") -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
     . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -27,7 +27,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   snippetLanguages: 'C#,JavaScript,Objective-C,Java,Go'
-  ApiDoctorPath: ''
+  ApiDoctorPath: $(Agent.TempDirectory)/ApiDoctor
 
 steps:
 - checkout: self
@@ -67,7 +67,7 @@ steps:
     $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
     Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
-    $apidoctorPath = (Get-ChildItem (Join-Path $env:ApiDoctorPath "tools" "apidoc.exe") -Recurse).FullName
+    $apidoctorPath = (Get-ChildItem (Join-Path "$(ApiDoctorPath)" "tools" "apidoc.exe") -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
     . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -54,6 +54,7 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 - task: PowerShell@2
+  displayName: 'Download API doctor'
   inputs:
     targetType: 'filePath'
     filePath: microsoft-graph-devx-api/scripts/downloadApiDoctor.ps1

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -53,7 +53,11 @@ steps:
     projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
-- pwsh: scripts/downloadApiDoctor.ps1
+- task: PowerShell@2
+  inputs:
+    targetType: 'filePath'
+    filePath: scripts/downloadApiDoctor.ps1
+    pwsh: true
 
 - pwsh: |
     # release folder can change based on .NET core version, so search recursively in bin folder

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -56,7 +56,7 @@ steps:
 - task: PowerShell@2
   inputs:
     targetType: 'filePath'
-    filePath: scripts/downloadApiDoctor.ps1
+    filePath: microsoft-graph-devx-api/scripts/downloadApiDoctor.ps1
     pwsh: true
 
 - pwsh: |

--- a/scripts/downloadApiDoctor.ps1
+++ b/scripts/downloadApiDoctor.ps1
@@ -12,7 +12,7 @@ $url = "https://globalcdn.nuget.org/packages/apidoctor.$version.nupkg"
 
 Invoke-WebRequest -Uri $url -OutFile $targetFile
 
-Expand-Archive -Path $targetFile -DestinationPath $targetDirectory
+Expand-Archive -Path $targetFile -DestinationPath $targetDirectory -Verbose
 
-Write-Host "##vso[task.setvariable variable=ApiDoctorPath;]$targetDirectory"
+Write-Host "##vso[task.setvariable variable=ApiDoctorPath]$targetDirectory"
 Write-Host "Set environment variable to ($env:ApiDoctorPath)"

--- a/scripts/downloadApiDoctor.ps1
+++ b/scripts/downloadApiDoctor.ps1
@@ -6,9 +6,10 @@
 $version = $csproj.Project.ItemGroup.PackageReference.Version
 
 $targetFile = [System.IO.Path]::GetTempPath() + "ApiDoctor.zip"
-$targetDirectory = $env:ApiDoctorPath
-if($null -eq $targetDirectory) {
-    Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
+$targetDirectory = $env:APIDOCTORPATH
+if($null -eq $targetDirectory -or $targetDirectory -eq "") {
+    Write-Information "APIDOCTORPATH environment variable is not set. Using default value."
+    $targetDirectory = Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
 }
 
 $url = "https://globalcdn.nuget.org/packages/apidoctor.$version.nupkg"

--- a/scripts/downloadApiDoctor.ps1
+++ b/scripts/downloadApiDoctor.ps1
@@ -6,13 +6,13 @@
 $version = $csproj.Project.ItemGroup.PackageReference.Version
 
 $targetFile = [System.IO.Path]::GetTempPath() + "ApiDoctor.zip"
-$targetDirectory = Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
+$targetDirectory = $env:ApiDoctorPath
+if($null -eq $targetDirectory) {
+    Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
+}
 
 $url = "https://globalcdn.nuget.org/packages/apidoctor.$version.nupkg"
 
 Invoke-WebRequest -Uri $url -OutFile $targetFile
 
 Expand-Archive -Path $targetFile -DestinationPath $targetDirectory -Verbose
-
-Write-Host "##vso[task.setvariable variable=ApiDoctorPath]$targetDirectory"
-Write-Host "Set environment variable to ($env:ApiDoctorPath)"

--- a/scripts/downloadApiDoctor.ps1
+++ b/scripts/downloadApiDoctor.ps1
@@ -8,7 +8,7 @@ $version = $csproj.Project.ItemGroup.PackageReference.Version
 $targetFile = [System.IO.Path]::GetTempPath() + "ApiDoctor.zip"
 $targetDirectory = $env:APIDOCTORPATH
 if($null -eq $targetDirectory -or $targetDirectory -eq "") {
-    Write-Information "APIDOCTORPATH environment variable is not set. Using default value."
+    Write-Warning "APIDOCTORPATH environment variable is not set. Using default value."
     $targetDirectory = Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
 }
 

--- a/scripts/downloadApiDoctor.ps1
+++ b/scripts/downloadApiDoctor.ps1
@@ -1,0 +1,18 @@
+# this script downloads API doctor as it is not published as a tool.
+# it relies on the ApiDoctorRef project to keep tracks of the latest version. (dependbot creates PRs on that project)
+
+[xml]$csproj = Get-Content -Path "./ApiDoctorRef/ApiDoctorRef.csproj"
+
+$version = $csproj.Project.ItemGroup.PackageReference.Version
+
+$targetFile = [System.IO.Path]::GetTempPath() + "ApiDoctor.zip"
+$targetDirectory = Join-path ([System.IO.Path]::GetTempPath()) "ApiDoctor"
+
+$url = "https://globalcdn.nuget.org/packages/apidoctor.$version.nupkg"
+
+Invoke-WebRequest -Uri $url -OutFile $targetFile
+
+Expand-Archive -Path $targetFile -DestinationPath $targetDirectory
+
+Write-Host "##vso[task.setvariable variable=ApiDoctorPath;]$targetDirectory"
+Write-Host "Set environment variable to ($env:ApiDoctorPath)"


### PR DESCRIPTION
This removes the apidoctor resource in the pipeline definition to use the nuget package instead.

A few limitations here because the nuget package is not published as a tool :
- cannot simply install it with `dotnet tool install -g ApiDoctor`, hence the reference project
- is not published for linux, hence the switch to windows

I'll go ahead and create an issue over there to get the teams attention, we can always revert/clean-up some of the changes made here after they unblock those aspects.

Result from the generation from that PR https://github.com/microsoftgraph/microsoft-graph-docs/pull/new/snippet-generation/60352   