### PR TITLE
replaces apidoctor resource by submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "apidoctor"]
+	path = apidoctor
+	url = https://github.com/OneDrive/apidoctor.git

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -20,18 +20,13 @@ resources:
      endpoint: microsoftgraph
      name: microsoftgraph/microsoft-graph-docs
      ref: main
-   - repository: apidoctor
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/apidoctor
-     ref: master
 
 pool:
   vmImage: 'ubuntu-latest'
 
 variables:
   buildConfiguration: 'Release'
-  apidoctorPath: 'apidoctor'
+  apidoctorPath: 'microsoft-graph-devx-api/apidoctor'
   apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
   snippetLanguages: 'C#,JavaScript,Objective-C,Java,Go'
 
@@ -43,11 +38,6 @@ steps:
 
 - checkout: microsoft-graph-docs
   displayName: checkout docs
-  fetchDepth: 1
-  persistCredentials: true
-
-- checkout: apidoctor
-  displayName: checkout apidoctor
   fetchDepth: 1
   submodules: recursive
   persistCredentials: true

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -74,7 +74,7 @@ steps:
     $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
     Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
-    $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
+    $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
     . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -34,12 +34,12 @@ steps:
 - checkout: self
   displayName: checkout GE api
   fetchDepth: 1
+  submodules: recursive
   persistCredentials: true
 
 - checkout: microsoft-graph-docs
   displayName: checkout docs
   fetchDepth: 1
-  submodules: recursive
   persistCredentials: true
 
 - template: templates/git-config.yml


### PR DESCRIPTION

## Overview

Closes #806

We've explored multiple avenues to get rid of our api doctor fork under microsoft graph:

- Updating the resource to the upstream: blocked by a permission issue on the repo
- Relying on the nuget package (806): adds complexity and forces us to revert to windows which has a performance impact

This PR explores another avenue of using a submodule instead.

