### PR TITLE
Upgrade projects to use .NET 6

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,9 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 6.0.x
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: 6.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1.8.2
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
       - name: Set up JDK 11

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,6 +29,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: 6.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,16 +29,19 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Setup .NET 6
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-          with:
-            dotnet-version: 6.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: 11
+      - name: Setup .NET 5 # At the moment the scanner requires dotnet 5 https://www.nuget.org/packages/dotnet-sonarscanner
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: 6.0.x
       - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/ChangesService.Test/ChangesService.Test.csproj
+++ b/ChangesService.Test/ChangesService.Test.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <None Remove="TestFiles\ChangeLogs\workload-mapping.json" />
-  </ItemGroup> 
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="TestFiles\appsettingstest.json">

--- a/ChangesService/ChangesService.csproj
+++ b/ChangesService/ChangesService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj
+++ b/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CodeSnippetsReflection.OData.Test/CodeSnippetsReflection.OData.Test.csproj
+++ b/CodeSnippetsReflection.OData.Test/CodeSnippetsReflection.OData.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CodeSnippetsReflection.OData/CodeSnippetsReflection.OData.csproj
+++ b/CodeSnippetsReflection.OData/CodeSnippetsReflection.OData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CodeSnippetsReflection.OpenAPI.Test/CodeSnippetsReflection.OpenAPI.Test.csproj
+++ b/CodeSnippetsReflection.OpenAPI.Test/CodeSnippetsReflection.OpenAPI.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CodeSnippetsReflection.OpenAPI/CodeSnippetsReflection.OpenAPI.csproj
+++ b/CodeSnippetsReflection.OpenAPI/CodeSnippetsReflection.OpenAPI.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/CodeSnippetsReflection/CodeSnippetsReflection.csproj
+++ b/CodeSnippetsReflection/CodeSnippetsReflection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/ExceptionMiddleware/ExceptionMiddleware.Test.csproj
+++ b/ExceptionMiddleware/ExceptionMiddleware.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/FileService.Test/FileService.Test.csproj
+++ b/FileService.Test/FileService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/FileService/FileService.csproj
+++ b/FileService/FileService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
     <UserSecretsId>2c8c1580-cbe8-4155-ac1a-4304a0632b26</UserSecretsId>
     <ApplicationInsightsResourceId>/subscriptions/68397ef5-9754-46e7-9572-9b15d12367f1/resourceGroups/Graph-Explorer-API/providers/microsoft.insights/components/DevX-API-AppInsights-Testing</ApplicationInsightsResourceId>

--- a/KnownIssuesService.Test/KnownIssuesService.Test.csproj
+++ b/KnownIssuesService.Test/KnownIssuesService.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/KnownIssuesService/KnownIssuesService.csproj
+++ b/KnownIssuesService/KnownIssuesService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MockTestUtility/MockTestUtility.csproj
+++ b/MockTestUtility/MockTestUtility.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenAPIService.Test/OpenAPIService.Test.csproj
+++ b/OpenAPIService.Test/OpenAPIService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PermissionsService.Test/PermissionsService.Test.csproj
+++ b/PermissionsService.Test/PermissionsService.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PermissionsService/PermissionsService.csproj
+++ b/PermissionsService/PermissionsService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SamplesService.Test/SamplesService.Test.csproj
+++ b/SamplesService.Test/SamplesService.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SamplesService/SamplesService.csproj
+++ b/SamplesService/SamplesService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TelemetryService.Test/TelemetrySanitizerService.Test.csproj
+++ b/TelemetryService.Test/TelemetrySanitizerService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TelemetryService/TelemetrySanitizerService.csproj
+++ b/TelemetryService/TelemetrySanitizerService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TourStepsService.Test/TourStepsService.Test.csproj
+++ b/TourStepsService.Test/TourStepsService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TourStepsService/TourStepsService.csproj
+++ b/TourStepsService/TourStepsService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UriMatchService.Test/UriMatchingService.Test.csproj
+++ b/UriMatchService.Test/UriMatchingService.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/UtilityService.Test/UtilityService.Test.csproj
+++ b/UtilityService.Test/UtilityService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/UtilityService/UtilityService.csproj
+++ b/UtilityService/UtilityService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -28,6 +28,13 @@ steps:
   fetchDepth: 1
   submodules: true
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 6.0.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - task: DotNetCoreCLI@2
   displayName: "Restore Nuget Packages"
   inputs:

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -24,7 +24,14 @@ steps:
   clean: true
   fetchDepth: 1
   submodules: true
-  
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 6.0.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - task: DotNetCoreCLI@2
   displayName: "Restore Nuget Packages"
   inputs:


### PR DESCRIPTION
These [Dependabot PRs ](https://github.com/microsoftgraph/microsoft-graph-devx-api/pulls?q=is%3Apr+is%3Aopen+dependabot)seek to upgrade NuGet packages but they mainly target .net6.0.
This PR seeks to bump up the target framework from `.net5.0` to `.net6.0` for all our projects

Fixes #826 