### PR TITLE
Use OData query options for the Changes endpoint

### DIFF
--- a/ChangesService.Test/ChangeLogPaginationModelShould.cs
+++ b/ChangesService.Test/ChangeLogPaginationModelShould.cs
@@ -10,22 +10,21 @@ namespace ChangesService.Test
 {
     public class ChangeLogPaginationModelShould
     {
-        readonly ChangeLogPagination _pagination = new ChangeLogPagination();
+        readonly ChangeLogQueryOptions _pagination = new ChangeLogQueryOptions();
 
         [Fact]
-        public void ThrowArgumentExceptionIfPageValueIsZeroOrNegativeInteger()
+        public void ThrowArgumentExceptionIfSkipValueIsNegativeInteger()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => _pagination.Page = 0);
-            Assert.Throws<ArgumentException>(() => _pagination.Page = -1);
+            Assert.Throws<ArgumentException>(() => _pagination.Skip = -1);
         }
 
         [Fact]
-        public void ThrowArgumentExceptionIfPageLimitValueIsZeroOrNegativeInteger()
+        public void ThrowArgumentExceptionIfTopValueIsZeroOrNegativeInteger()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => _pagination.PageLimit = 0);
-            Assert.Throws<ArgumentException>(() => _pagination.PageLimit = -1);
+            Assert.Throws<ArgumentException>(() => _pagination.Top = 0);
+            Assert.Throws<ArgumentException>(() => _pagination.Top = -1);
         }
     }
 }

--- a/ChangesService.Test/ChangeLogQueryOptionsShould.cs
+++ b/ChangesService.Test/ChangeLogQueryOptionsShould.cs
@@ -25,5 +25,15 @@ namespace ChangesService.Test
             // Act & Assert
             Assert.Throws<ArgumentException>(() => _queryOption.Top = -1);
         }
+
+        [Fact]
+        public void ValidateAndSetDefaultMaximumTopValue()
+        {
+            // Arrange & Act
+            _queryOption.Top = 1000;
+
+            // Assert
+            Assert.Equal(500, _queryOption.Top);
+        }
     }
 }

--- a/ChangesService.Test/ChangeLogQueryOptionsShould.cs
+++ b/ChangesService.Test/ChangeLogQueryOptionsShould.cs
@@ -8,23 +8,22 @@ using Xunit;
 
 namespace ChangesService.Test
 {
-    public class ChangeLogPaginationModelShould
+    public class ChangeLogQueryOptionsShould
     {
-        readonly ChangeLogQueryOptions _pagination = new ChangeLogQueryOptions();
+        readonly ChangeLogQueryOptions _queryOption = new();
 
         [Fact]
         public void ThrowArgumentExceptionIfSkipValueIsNegativeInteger()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => _pagination.Skip = -1);
+            Assert.Throws<ArgumentException>(() => _queryOption.Skip = -1);
         }
 
         [Fact]
-        public void ThrowArgumentExceptionIfTopValueIsZeroOrNegativeInteger()
+        public void ThrowArgumentExceptionIfTopValueIsNegativeInteger()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => _pagination.Top = 0);
-            Assert.Throws<ArgumentException>(() => _pagination.Top = -1);
+            Assert.Throws<ArgumentException>(() => _queryOption.Top = -1);
         }
     }
 }

--- a/ChangesService.Test/ChangeLogRecordsModelShould.cs
+++ b/ChangesService.Test/ChangeLogRecordsModelShould.cs
@@ -82,19 +82,19 @@ namespace ChangesService.Test
             };
 
             // Act
-            changeLogRecords.PageLimit = 1;
+            changeLogRecords.Top = 1;
 
             // Assert
             Assert.Equal(8, changeLogRecords.TotalPages);
 
             // Act
-            changeLogRecords.PageLimit = 2;
+            changeLogRecords.Top = 2;
 
             // Assert
             Assert.Equal(4, changeLogRecords.TotalPages);
 
             // Act
-            changeLogRecords.PageLimit = 3;
+            changeLogRecords.Top = 3;
 
             // Assert
             Assert.Equal(3, changeLogRecords.TotalPages);

--- a/ChangesService.Test/ChangeLogRecordsModelShould.cs
+++ b/ChangesService.Test/ChangeLogRecordsModelShould.cs
@@ -72,34 +72,6 @@ namespace ChangesService.Test
             Assert.Equal(changeLogRecords.CurrentItems, changeLogRecords.ChangeLogs.Count());
         }
 
-        [Fact]
-        public void UpdateTotalPagesOnPageLimitPropertySetter()
-        {
-            // Arrange & Act
-            var changeLogRecords = new ChangeLogRecords
-            {
-                ChangeLogs = GetChangeLogRecords().ChangeLogs
-            };
-
-            // Act
-            changeLogRecords.Top = 1;
-
-            // Assert
-            Assert.Equal(8, changeLogRecords.TotalPages);
-
-            // Act
-            changeLogRecords.Top = 2;
-
-            // Assert
-            Assert.Equal(4, changeLogRecords.TotalPages);
-
-            // Act
-            changeLogRecords.Top = 3;
-
-            // Assert
-            Assert.Equal(3, changeLogRecords.TotalPages);
-        }
-
         /// <summary>
         /// Gets a sample of <see cref="ChangeLogRecords"/>
         /// </summary>

--- a/ChangesService.Test/ChangesServiceShould.cs
+++ b/ChangesService.Test/ChangesServiceShould.cs
@@ -326,13 +326,12 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public void PaginateChangeLogRecordsFirstPage()
+        public void FilterChangeLogRecordswithTop()
         {
             // Arrange
             var searchOptions = new ChangeLogSearchOptions
             {
-                Page = 1,
-                PageLimit = 2
+                Top = 2
             };
 
             // Act
@@ -374,46 +373,12 @@ namespace ChangesService.Test
         }
 
         [Fact]
-        public void PaginateChangeLogRecordsMiddlePage()
+        public void PaginateChangeLogRecordsWithSkip()
         {
             // Arrange
             var searchOptions = new ChangeLogSearchOptions
             {
-                Page = 2,
-                PageLimit = 1
-            };
-
-            // Act
-            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
-
-            // Assert -- fetch middle item from the changelog sample
-            Assert.NotNull(filteredChangeLogRecords);
-            Assert.Collection(filteredChangeLogRecords.ChangeLogs,
-                item =>
-                {
-                    Assert.Equal("2d94636a-2d78-44d6-8b08-ff2a9121214b", item.Id);
-                    Assert.Equal("Extensions", item.WorkloadArea);
-                    Assert.Equal("Schema extensions", item.SubArea);
-                    Assert.Collection(item.ChangeList,
-                        item =>
-                        {
-                            Assert.Equal("2d94636a-2d78-44d6-8b08-ff2a9121214b", item.Id);
-                            Assert.Equal("Resource", item.ApiChange);
-                            Assert.Equal("schema extensions,Microsoft Cloud for US Government.", item.ChangedApiName);
-                            Assert.Equal("Addition", item.ChangeType);
-                            Assert.Equal("schema extensions,Microsoft Cloud for US Government", item.Target);
-                        });
-                });
-        }
-
-        [Fact]
-        public void PaginateChangeLogRecordsLastPage()
-        {
-            // Arrange
-            var searchOptions = new ChangeLogSearchOptions
-            {
-                Page = 8,
-                PageLimit = 1
+                Skip = 7
             };
 
             // Act
@@ -440,8 +405,8 @@ namespace ChangesService.Test
             // Arrange
             searchOptions = new ChangeLogSearchOptions
             {
-                Page = 3,
-                PageLimit = 3
+                Top = 3,
+                Skip = 6
             };
 
             // Act
@@ -451,6 +416,39 @@ namespace ChangesService.Test
             Assert.NotNull(filteredChangeLogRecords);
             Assert.Equal(2, filteredChangeLogRecords.ChangeLogs.Count());
         }
+
+        [Fact]
+        public void PaginateChangeLogRecordsWithTopAndSkip()
+        {
+            // Arrange
+            var searchOptions = new ChangeLogSearchOptions
+            {
+                Top = 1,
+                Skip = 1
+            };
+
+            // Act
+            var filteredChangeLogRecords = _changesService.FilterChangeLogRecords(_changeLogRecords, searchOptions, _graphProxyConfigs, _workloadServiceMappings);
+
+            // Assert -- fetch middle item from the changelog sample
+            Assert.NotNull(filteredChangeLogRecords);
+            Assert.Collection(filteredChangeLogRecords.ChangeLogs,
+                item =>
+                {
+                    Assert.Equal("2d94636a-2d78-44d6-8b08-ff2a9121214b", item.Id);
+                    Assert.Equal("Extensions", item.WorkloadArea);
+                    Assert.Equal("Schema extensions", item.SubArea);
+                    Assert.Collection(item.ChangeList,
+                        item =>
+                        {
+                            Assert.Equal("2d94636a-2d78-44d6-8b08-ff2a9121214b", item.Id);
+                            Assert.Equal("Resource", item.ApiChange);
+                            Assert.Equal("schema extensions,Microsoft Cloud for US Government.", item.ChangedApiName);
+                            Assert.Equal("Addition", item.ChangeType);
+                            Assert.Equal("schema extensions,Microsoft Cloud for US Government", item.Target);
+                        });
+                });
+        }        
 
         private static Dictionary<string, string> GetWorkloadServiceMappingsFile()
         {

--- a/ChangesService/Common/ChangesServiceConstants.cs
+++ b/ChangesService/Common/ChangesServiceConstants.cs
@@ -22,6 +22,7 @@ namespace ChangesService.Common
         // Error constants
         public const string ValueNullError = "Value cannot be null.";
         public const string ValueZeroNegativeInteger = "Value cannot be zero or a negative integer.";
+        public const string ValueNegativeInteger = "Value cannot be a negative integer.";
         public const string JsonStringNullOrEmpty = "The JSON string to be deserialized cannot be null or empty.";
     }
 }

--- a/ChangesService/Models/ChangeLogQueryOptions.cs
+++ b/ChangesService/Models/ChangeLogQueryOptions.cs
@@ -13,7 +13,7 @@ namespace ChangesService.Models
     public record ChangeLogQueryOptions
     {
         private int? _top;
-        private int _skip = 0;
+        private int _skip;
 
         /// <summary>
         /// The maximum number of items in a page.

--- a/ChangesService/Models/ChangeLogQueryOptions.cs
+++ b/ChangesService/Models/ChangeLogQueryOptions.cs
@@ -12,13 +12,14 @@ namespace ChangesService.Models
     /// </summary>
     public record ChangeLogQueryOptions
     {
-        private int? _top;
+        private const int MaxTopValue = 500;
+        private int _top = MaxTopValue;
         private int _skip;
 
         /// <summary>
         /// The maximum number of items in a page.
         /// </summary>
-        public int? Top
+        public int Top
         {
             get => _top;
             set
@@ -27,7 +28,8 @@ namespace ChangesService.Models
                 {
                     throw new ArgumentException(ChangesServiceConstants.ValueNegativeInteger, nameof(Top));
                 }
-                _top = value;
+
+                _top = value > MaxTopValue ? MaxTopValue : value;
             }
         }
 
@@ -43,6 +45,7 @@ namespace ChangesService.Models
                 {
                     throw new ArgumentException(ChangesServiceConstants.ValueNegativeInteger, nameof(Skip));
                 }
+
                 _skip = value;
             }
         }

--- a/ChangesService/Models/ChangeLogQueryOptions.cs
+++ b/ChangesService/Models/ChangeLogQueryOptions.cs
@@ -9,48 +9,44 @@ using System;
 namespace ChangesService.Models
 {
     /// <summary>
-    /// Options for paging changelog data.
+    /// Options for slicing changelog data.
     /// </summary>
-    public record ChangeLogPagination
+    public record ChangeLogQueryOptions
     {
-        private int _page = 1;
-        private int? _pageLimit;
-
-        /// <summary>
-        /// The current page.
-        /// </summary>
-        [JsonProperty(PropertyName = "currentPage")]
-        public int Page
-        {
-            get => _page;
-            set
-            {
-                if (value < 1)
-                {
-                    throw new ArgumentException(ChangesServiceConstants.ValueZeroNegativeInteger, nameof(Page));
-                }
-                _page = value;
-            }
-        }
-
-        /// <summary>
-        /// The total page count.
-        /// </summary>
-        public int TotalPages { get; } = 1;
+        private int? _top;
+        private int _skip;
 
         /// <summary>
         /// The maximum number of items in a page.
         /// </summary>
-        public int? PageLimit
+        [JsonProperty(PropertyName = "top")]
+        public int? Top
         {
-            get => _pageLimit;
+            get => _top;
             set
             {
                 if (value < 1)
                 {
-                    throw new ArgumentException(ChangesServiceConstants.ValueZeroNegativeInteger, nameof(PageLimit));
+                    throw new ArgumentException(ChangesServiceConstants.ValueNegativeInteger, nameof(Top));
                 }
-                _pageLimit = value;
+                _top = value;
+            }
+        }
+
+        /// <summary>
+        /// Number of items skipped.
+        /// </summary>
+        [JsonProperty(PropertyName = "skip")]
+        public int Skip
+        {
+            get => _skip;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentException(ChangesServiceConstants.ValueZeroNegativeInteger, nameof(Skip));
+                }
+                _skip = value;
             }
         }
     }

--- a/ChangesService/Models/ChangeLogQueryOptions.cs
+++ b/ChangesService/Models/ChangeLogQueryOptions.cs
@@ -3,7 +3,6 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using ChangesService.Common;
-using Newtonsoft.Json;
 using System;
 
 namespace ChangesService.Models
@@ -14,18 +13,17 @@ namespace ChangesService.Models
     public record ChangeLogQueryOptions
     {
         private int? _top;
-        private int _skip;
+        private int _skip = 0;
 
         /// <summary>
         /// The maximum number of items in a page.
         /// </summary>
-        [JsonProperty(PropertyName = "top")]
         public int? Top
         {
             get => _top;
             set
             {
-                if (value < 1)
+                if (value < 0)
                 {
                     throw new ArgumentException(ChangesServiceConstants.ValueNegativeInteger, nameof(Top));
                 }
@@ -36,15 +34,14 @@ namespace ChangesService.Models
         /// <summary>
         /// Number of items skipped.
         /// </summary>
-        [JsonProperty(PropertyName = "skip")]
         public int Skip
         {
             get => _skip;
             set
             {
-                if (value < 1)
+                if (value < 0)
                 {
-                    throw new ArgumentException(ChangesServiceConstants.ValueZeroNegativeInteger, nameof(Skip));
+                    throw new ArgumentException(ChangesServiceConstants.ValueNegativeInteger, nameof(Skip));
                 }
                 _skip = value;
             }

--- a/ChangesService/Models/ChangeLogRecords.cs
+++ b/ChangesService/Models/ChangeLogRecords.cs
@@ -11,7 +11,7 @@ namespace ChangesService.Models
     /// <summary>
     /// Holds the <see cref="ChangeLog"/> records.
     /// </summary>
-    public record ChangeLogRecords : ChangeLogQueryOptions
+    public record ChangeLogRecords
     {
         private IEnumerable<ChangeLog> _changeLogs = new List<ChangeLog>();
 

--- a/ChangesService/Models/ChangeLogRecords.cs
+++ b/ChangesService/Models/ChangeLogRecords.cs
@@ -11,7 +11,7 @@ namespace ChangesService.Models
     /// <summary>
     /// Holds the <see cref="ChangeLog"/> records.
     /// </summary>
-    public record ChangeLogRecords : ChangeLogPagination
+    public record ChangeLogRecords : ChangeLogQueryOptions
     {
         private IEnumerable<ChangeLog> _changeLogs = new List<ChangeLog>();
 
@@ -42,19 +42,19 @@ namespace ChangesService.Models
         /// <summary>
         /// The total page count.
         /// </summary>
-        public new int TotalPages
+        public int TotalPages
         {
             get
             {
-                if (TotalItems > 0 && PageLimit.HasValue)
+                if (TotalItems > 0 && Top.HasValue)
                 {
                     int extraPage = 0;
-                    if (TotalItems % PageLimit > 0)
+                    if (TotalItems % Top > 0)
                     {
                         extraPage++;
                     }
 
-                    return (TotalItems / PageLimit.Value) + extraPage;
+                    return (TotalItems / Top.Value) + extraPage;
                 }
 
                 return 1;

--- a/ChangesService/Models/ChangeLogRecords.cs
+++ b/ChangesService/Models/ChangeLogRecords.cs
@@ -40,28 +40,6 @@ namespace ChangesService.Models
         public int TotalItems { get; private set; }
 
         /// <summary>
-        /// The total page count.
-        /// </summary>
-        public int TotalPages
-        {
-            get
-            {
-                if (TotalItems > 0 && Top.HasValue)
-                {
-                    int extraPage = 0;
-                    if (TotalItems % Top > 0)
-                    {
-                        extraPage++;
-                    }
-
-                    return (TotalItems / Top.Value) + extraPage;
-                }
-
-                return 1;
-            }
-        }
-
-        /// <summary>
         /// Updates the TotalItems property.
         /// </summary>
         private void UpdateTotalItems()

--- a/ChangesService/Models/ChangeLogSearchOptions.cs
+++ b/ChangesService/Models/ChangeLogSearchOptions.cs
@@ -9,7 +9,7 @@ namespace ChangesService.Models
     /// <summary>
     /// Options for searching and filtering changelog data.
     /// </summary>
-    public record ChangeLogSearchOptions : ChangeLogPagination
+    public record ChangeLogSearchOptions : ChangeLogQueryOptions
     {
         public string RequestUrl { get; }
         public string Service { get; }

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -180,17 +180,9 @@ namespace ChangesService.Services
             if (changeLogRecords.ChangeLogs.Any())
             {
                 IEnumerable<ChangeLog> enumerableChangeLogs;
-                if (searchOptions.Top != null)
-                {
-                    enumerableChangeLogs = changeLogRecords.ChangeLogs
-                                                           .Skip(searchOptions.Skip)
-                                                           .Take(searchOptions.Top.Value);
-                }
-                else
-                {
-                    enumerableChangeLogs = changeLogRecords.ChangeLogs
-                                                           .Skip(searchOptions.Skip);
-                }
+                enumerableChangeLogs = changeLogRecords.ChangeLogs
+                                                       .Skip(searchOptions.Skip)
+                                                       .Take(searchOptions.Top);
 
                 changeLogRecords.ChangeLogs = enumerableChangeLogs.ToList();
             }

--- a/ChangesService/Services/ChangesService.cs
+++ b/ChangesService/Services/ChangesService.cs
@@ -179,33 +179,20 @@ namespace ChangesService.Services
         {
             if (changeLogRecords.ChangeLogs.Any())
             {
-                IEnumerable<ChangeLog> enumerableChangeLogs = null;
-
-                if (searchOptions.Top != null && searchOptions.Skip > 0)
+                IEnumerable<ChangeLog> enumerableChangeLogs;
+                if (searchOptions.Top != null)
                 {
-                    changeLogRecords.Skip = searchOptions.Skip;
-                    changeLogRecords.Top = searchOptions.Top;
                     enumerableChangeLogs = changeLogRecords.ChangeLogs
                                                            .Skip(searchOptions.Skip)
                                                            .Take(searchOptions.Top.Value);
                 }
-                else if (searchOptions.Top != null)
+                else
                 {
-                    changeLogRecords.Top = searchOptions.Top;
-                    enumerableChangeLogs = changeLogRecords.ChangeLogs
-                                                           .Take(searchOptions.Top.Value);
-                }
-                else if (searchOptions.Skip > 0)
-                {
-                    changeLogRecords.Skip = searchOptions.Skip;
                     enumerableChangeLogs = changeLogRecords.ChangeLogs
                                                            .Skip(searchOptions.Skip);
                 }
 
-                if (enumerableChangeLogs != null)
-                {
-                    changeLogRecords.ChangeLogs = enumerableChangeLogs.ToList();
-                }
+                changeLogRecords.ChangeLogs = enumerableChangeLogs.ToList();
             }
 
             return changeLogRecords;

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -58,8 +58,8 @@ namespace GraphWebApi.Controllers
                                          [FromQuery] double daysRange,
                                          [FromQuery] DateTime? startDate, // yyyy-MM-ddTHH:mm:ss
                                          [FromQuery] DateTime? endDate, // yyyy-MM-ddTHH:mm:ss
-                                         [FromQuery] int? top, // items per page
-                                         [FromQuery] int skip, // items per page
+                                         [FromQuery] int skip, // Items to skip
+                                         [FromQuery] int top = 500, // Max page items
                                          [FromQuery] string graphVersion = "v1.0")
         {
             // Options for searching, filtering and paging the changelog data

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -53,13 +53,13 @@ namespace GraphWebApi.Controllers
         [Produces("application/json")]
         [HttpGet]
         public async Task<IActionResult> GetChangesAsync(
-                                         [FromQuery] string requestUrl = null,
-                                         [FromQuery] string service = null,
-                                         [FromQuery] double daysRange = 0,
-                                         [FromQuery] DateTime? startDate = null, // yyyy-MM-ddTHH:mm:ss
-                                         [FromQuery] DateTime? endDate = null, // yyyy-MM-ddTHH:mm:ss
-                                         [FromQuery] int? top = null, // items per page
-                                         [FromQuery] int skip = 0, // items per page
+                                         [FromQuery] string requestUrl,
+                                         [FromQuery] string service,
+                                         [FromQuery] double daysRange,
+                                         [FromQuery] DateTime? startDate, // yyyy-MM-ddTHH:mm:ss
+                                         [FromQuery] DateTime? endDate, // yyyy-MM-ddTHH:mm:ss
+                                         [FromQuery] int? top, // items per page
+                                         [FromQuery] int skip, // items per page
                                          [FromQuery] string graphVersion = "v1.0")
         {
             // Options for searching, filtering and paging the changelog data

--- a/GraphWebApi/Controllers/ChangesController.cs
+++ b/GraphWebApi/Controllers/ChangesController.cs
@@ -58,8 +58,8 @@ namespace GraphWebApi.Controllers
                                          [FromQuery] double daysRange = 0,
                                          [FromQuery] DateTime? startDate = null, // yyyy-MM-ddTHH:mm:ss
                                          [FromQuery] DateTime? endDate = null, // yyyy-MM-ddTHH:mm:ss
-                                         [FromQuery] int page = 1,
-                                         [FromQuery] int? pageLimit = null,
+                                         [FromQuery] int? top = null, // items per page
+                                         [FromQuery] int skip = 0, // items per page
                                          [FromQuery] string graphVersion = "v1.0")
         {
             // Options for searching, filtering and paging the changelog data
@@ -70,8 +70,8 @@ namespace GraphWebApi.Controllers
                                                            endDate: endDate,
                                                            graphVersion: graphVersion)
             {
-                Page = page,
-                PageLimit = pageLimit
+                Top = top,
+                Skip = skip
             };
 
             // Get the requested culture info.


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/720

This PR:
- Uses OData query options (`top` and `skip`) in place of `page` and `pageLimit` to filter `ChangeLogRecords`. This is to align the API to Graph API standards.
- Update relevant tests to validate the above.

Sample call and response format:

![image](https://user-images.githubusercontent.com/40403681/146188893-998d87fd-befe-465b-b95f-58b47a250eb7.png)

