### PR TITLE
Fixes duplicate key issue

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -231,7 +231,10 @@ namespace OpenAPIService
         {
             UtilityFunctions.CheckArgumentNull(sources, nameof(sources));
 
-            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
+            if (!_openApiTraceProperties.ContainsKey(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore))
+            {
+                _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
+            }
             _telemetryClient?.TrackTrace("Creating OpenApiUrlTreeNode",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -230,11 +230,7 @@ namespace OpenAPIService
         public OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources)
         {
             UtilityFunctions.CheckArgumentNull(sources, nameof(sources));
-
-            if (!_openApiTraceProperties.ContainsKey(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore))
-            {
-                _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
-            }
+            
             _telemetryClient?.TrackTrace("Creating OpenApiUrlTreeNode",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
@@ -245,6 +241,10 @@ namespace OpenAPIService
                 rootNode.Attach(source.Value, source.Key);
             }
 
+            if (!_openApiTraceProperties.ContainsKey(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore))
+            {
+                _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
+            }
             _telemetryClient?.TrackTrace($"Finished creating OpenApiUrlTreeNode",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);


### PR DESCRIPTION
Fixes duplicate `sanitizeIgnore` key issue in the `_openApiTraceProperties` dictionary within the `OpenApiService`