### PR TITLE
fixes a bug where the open api service would fail because of base dictionary management

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -241,10 +241,7 @@ namespace OpenAPIService
                 rootNode.Attach(source.Value, source.Key);
             }
 
-            if (!_openApiTraceProperties.ContainsKey(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore))
-            {
-                _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
-            }
+            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
             _telemetryClient?.TrackTrace($"Finished creating OpenApiUrlTreeNode",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
@@ -496,7 +493,7 @@ namespace OpenAPIService
                 return doc;
             }
 
-            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
+            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
             _telemetryClient?.TrackTrace($"Fetch the OpenApi document from the source: {graphUri}",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);


### PR DESCRIPTION
The open api slicing endpoints would fail with

```json
{"StatusCode":404,"Message":"An item with the same key has already been added. Key: SanitizeIgnore"}
```

(which BTW should be a 500 error, not a 404)

This PR replaces calls to `Dictionary.Add` by `Dictionary.TryAdd`.