### PR TITLE
PowerShell Snippets: Adds UPN as UserId alternative comment to /me segments.

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -186,6 +186,32 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-UserId $userId", result);
+            Assert.Contains("# A UPN can also be used as -UserId.", result);
+        }
+
+        [Theory]
+        [InlineData("/users")]
+        [InlineData("/users/48d31887-5fad-4d73-a9f5-3c356e68a038")]
+        public async Task GeneratesSnippetsForUserSegment(string path)
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{path}");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("-MgUser", result);
+            Assert.DoesNotContain("# A UPN can also be used as -UserId.", result);
+        }
+
+        [Theory]
+        [InlineData("/me/changePassword")]
+        [InlineData("/users/{user-id}/microsoft.graph.changePassword")]
+        public async Task GeneratesSnippetsForODataAction(string path)
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}{path}");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("-UserId $userId", result);
+            Assert.Contains("Update-MgUserPassword", result);
         }
 
         [Theory]

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -51,23 +51,32 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 if (!string.IsNullOrEmpty(additionalKeySegmentParmeter))
                     snippetBuilder.Append($"{additionalKeySegmentParmeter}");
 
-                string keySegmentParameter = GetKeySegmentParameters(snippetModel.PathNodes);
-                if (!string.IsNullOrEmpty(keySegmentParameter))
-                    snippetBuilder.Append($"{keySegmentParameter}");
-
-                var queryParamsPayload = GetRequestQueryParameters(snippetModel);
-                if (!string.IsNullOrEmpty(queryParamsPayload))
-                    snippetBuilder.Append($" {queryParamsPayload}");
-
-                var parameterList = GetActionParametersList(payloadVarName);
-                if (!string.IsNullOrEmpty(parameterList))
-                    snippetBuilder.Append($" {parameterList}");
-
-                var requestHeadersPayload = GetSupportedRequestHeaders(snippetModel);
-                if (!string.IsNullOrEmpty(requestHeadersPayload))
-                    snippetBuilder.Append(requestHeadersPayload);
+                var commandParameters = GetCommandParameters(snippetModel, payloadVarName);
+                if (!string.IsNullOrEmpty(commandParameters))
+                    snippetBuilder.Append($"{commandParameters}");
             }
             return snippetBuilder.ToString();
+        }
+
+        private static string GetCommandParameters(SnippetModel snippetModel, string payloadVarName)
+        {
+            var payloadSB = new StringBuilder();
+            string keySegmentParameter = GetKeySegmentParameters(snippetModel.PathNodes);
+            if (!string.IsNullOrEmpty(keySegmentParameter))
+                payloadSB.Append($"{keySegmentParameter}");
+
+            var queryParamsPayload = GetRequestQueryParameters(snippetModel);
+            if (!string.IsNullOrEmpty(queryParamsPayload))
+                payloadSB.Append($" {queryParamsPayload}");
+
+            var parameterList = GetActionParametersList(payloadVarName);
+            if (!string.IsNullOrEmpty(parameterList))
+                payloadSB.Append($" {parameterList}");
+
+            var requestHeadersPayload = GetSupportedRequestHeaders(snippetModel);
+            if (!string.IsNullOrEmpty(requestHeadersPayload))
+                payloadSB.Append(requestHeadersPayload);
+            return payloadSB.ToString();
         }
 
         private static (string, string) SubstituteMeSegment(bool isMeSegment, string path)

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -99,7 +99,7 @@ namespace CodeSnippetsReflection.OpenAPI
             else if (method == HttpMethod.Trace) return OperationType.Trace;
             else throw new ArgumentOutOfRangeException(nameof(method));
         }
-        private static Regex namespaceRegex = new Regex("^Microsoft.Graph.(.*)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static Regex namespaceRegex = new Regex("Microsoft.Graph.(.*)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         public static string TrimNamespace(string path)
         {
             Match namespaceMatch = namespaceRegex.Match(path);


### PR DESCRIPTION
This PR:
- Adds `"# A UPN can also be used as -UserId."` comment to PowerShell snippets for `/me` segments. The comment will only be displayed on HTTP snippets that call `/me` segment:
  ``` powershell
  Import-Module Microsoft.Graph.Mail

  # A UPN can also be used as -UserId.
  Get-MgUserMessage -UserId $userId
  ```
- Fixes [missing OData actions](https://docs.microsoft.com/en-us/graph/api/user-changepassword?view=graph-rest-1.0&tabs=http#request) PowerShell snippets.
