### PR TITLE
Add PublicationOnly Lazy thread safety mode to prevent caching except…

### DIFF
--- a/CodeSnippetsReflection.OData/ODataSnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OData/ODataSnippetsGenerator.cs
@@ -10,6 +10,7 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights;
 using UtilityService;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace CodeSnippetsReflection.OData
 {
@@ -78,8 +79,8 @@ namespace CodeSnippetsReflection.OData
             ServiceRootBeta = new Uri(UtilityConstants.ServiceRootBeta);
 
             // use clean metadata
-            IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(UtilityConstants.CleanV1Metadata)));
-            IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(UtilityConstants.CleanBetaMetadata)));
+            IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(UtilityConstants.CleanV1Metadata)), LazyThreadSafetyMode.PublicationOnly);
+            IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(UtilityConstants.CleanBetaMetadata)), LazyThreadSafetyMode.PublicationOnly);
 
             if (customMetadataPath == null)
             {


### PR DESCRIPTION
…ions

### Overview
This PR proposes adding a `PublicationOnly` Lazy thread safety mode to avoid caching of exceptions thrown while loading Graph metadata.
Fixes #858 

#### Issue
We're recording a lot of server errors for the `/snippets` endpoint due to a HttpClient timeout of 100 secs elapsing when downloading metadata files leading to tasks being cancelled.
Our current Lazy loading technique caches the `System.Threading.Tasks.TaskCanceledException` exception which is then thrown again on subsequent calls to fetch Snippets.
By adding the `PublicationOnly` lazy thread safety option, we'll avoid caching the exception and any subsequent call to the endpoint will trigger a reinitialization of the metadata loading process and reduce the errors.

#### Screenshot 
![image](https://user-images.githubusercontent.com/36787645/151143879-c6bb9efd-9744-4ba2-9799-6463c43ff0b6.png)
 
Reference doc: https://docs.microsoft.com/en-us/dotnet/api/system.threading.lazythreadsafetymode?view=net-6.0#remarks