### PR TITLE
[Snippet Generation] Fix expand clause parsing

### DIFF
--- a/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
@@ -1339,5 +1339,26 @@ namespace CodeSnippetsReflection.Test
             Assert.Contains(expectedType, result);
             Assert.Contains(addedReference, result);
         }
+
+        [Fact]
+        public void ShouldSupportCountParameterAndNestedSelectAndExpand()
+        {
+            // Arrange
+            var expressions = new CSharpExpressions();
+            // Request example from https://docs.microsoft.com/en-us/graph/api/user-list-manager?view=graph-rest-1.0&tabs=http#request-1
+            var requestPayload = new HttpRequestMessage(
+                HttpMethod.Get,
+                "https://graph.microsoft.com/v1.0/me?$expand=directReports,manager($levels=max;$select=id,displayName)&$select=id,displayName&$count=true");
+            requestPayload.Headers.Add("ConsistencyLevel","eventual");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
+            // Act
+            var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
+            // Assert
+            var countParameter = "new QueryOption(\"$count\", \"true\")";  // the count query option
+            var expandClause = ".Expand(\"directReports,manager($levels=max;$select=id,displayName)\")";  // Adds the created type
+            Assert.Contains(countParameter, result);
+            Assert.Contains(expandClause, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
@@ -875,7 +875,8 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
         private static string GenerateCustomQuerySection(SnippetModel snippetModel)
         {
             if (!snippetModel.CustomQueryOptions.Any()
-            && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
+            && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken)
+            && !snippetModel.ODataUri.QueryCount.HasValue)
             {
                 return string.Empty;//nothing to do here
             }
@@ -893,6 +894,12 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
             if (!string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
             {
                 stringBuilder.Append($"\tnew QueryOption(\"$skiptoken\", \"{snippetModel.ODataUri.SkipToken}\"),\r\n");
+            }
+
+            //Append any $count present
+            if (snippetModel.ODataUri.QueryCount.HasValue)
+            {
+                stringBuilder.Append($"\tnew QueryOption(\"$count\", \"{snippetModel.ODataUri.QueryCount.Value.ToString().ToLower()}\"),\r\n");
             }
 
             stringBuilder.Remove(stringBuilder.Length - 3, 1);//remove the trailing comma

--- a/CodeSnippetsReflection.OData/SnippetModel.cs
+++ b/CodeSnippetsReflection.OData/SnippetModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -101,8 +101,11 @@ namespace CodeSnippetsReflection
                         break;
                     //its an expand query
                     case ExpandedNavigationSelectItem expandedNavigationSelectItem:
+                        if (!string.IsNullOrEmpty(ExpandFieldExpression))
+                            break; // multiple expand parameters will result in this case being processed multiple times. So don't do it again if we already did it the first time.
+
                         //get the string from the start of the navigation source name.
-                        ExpandFieldExpression = queryString.Substring(queryString.IndexOf( expandedNavigationSelectItem.NavigationSource.Name, StringComparison.Ordinal));
+                        ExpandFieldExpression = queryString.Substring(queryString.IndexOf( expandedNavigationSelectItem.PathToNavigationProperty.First().Identifier, StringComparison.Ordinal));
                         //check if there are other queries present and chunk them off to remain with only the expand parameter
                         var index = ExpandFieldExpression.IndexOf("&", StringComparison.Ordinal);
                         if (index > 0)


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1246

It fixes an issue with expand clause parsing that would result in the extraction of the expand clause as `NavigationSource.Name` refers to the navigation path of the expanded item rather than using the `navigationProperty` being expanded.

It also adds missing support for `$count` in C# snippets.

Generation diff can be viewed at the link below .
https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/67984..snippet-generation/67982