### PR TITLE
Fixes intermittent `openapi/tree` endpoint failure issue

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -11,6 +11,7 @@ using OpenAPIService;
 using OpenAPIService.Common;
 using OpenAPIService.Interfaces;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -113,7 +114,7 @@ namespace GraphWebApi.Controllers
                 graphVersionsList.Add(graphVersions.ToLower());
             }
 
-            var sources = new Dictionary<string, OpenApiDocument>();
+            var sources = new ConcurrentDictionary<string, OpenApiDocument>();
             foreach (var graphVersion in graphVersionsList)
             {
                 var graphUri = GetVersionUri(graphVersion);
@@ -122,7 +123,7 @@ namespace GraphWebApi.Controllers
                     throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
-                sources.Add(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
+                sources.TryAdd(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Interfaces;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -406,7 +407,8 @@ namespace OpenAPIService.Test
         public void GetOpenApiTreeNode()
         {
             // Arrange
-            var sources = new Dictionary<string, OpenApiDocument>() { { GraphVersion, _graphMockSource } };
+            var sources = new ConcurrentDictionary<string, OpenApiDocument>();
+            sources.TryAdd(GraphVersion, _graphMockSource);
 
             // Act
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Common;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ namespace OpenAPIService.Interfaces
 
         Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh);
 
-        OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources);
+        OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(ConcurrentDictionary<string, OpenApiDocument> sources);
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -26,6 +26,7 @@ using Microsoft.ApplicationInsights;
 using OpenAPIService.Interfaces;
 using System.Text.Json;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace OpenAPIService
 {
@@ -585,11 +586,14 @@ namespace OpenAPIService
 
         private async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref)
         {
+            var stopwatch = new Stopwatch();
             var httpClient = CreateHttpClient();
 
+            stopwatch.Start();
             Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+            stopwatch.Stop();
 
-            _telemetryClient?.TrackTrace("Success getting CSDL ",
+            _telemetryClient?.TrackTrace($"Success getting CSDL for {csdlHref} in {stopwatch.ElapsedMilliseconds}ms",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -190,7 +190,8 @@ namespace OpenAPIService
             }
             else if (url != null)
             {
-                var sources = new Dictionary<string, OpenApiDocument> { { graphVersion, source } };
+                var sources = new ConcurrentDictionary<string, OpenApiDocument>();
+                sources.TryAdd(graphVersion, source);
                 var rootNode = CreateOpenApiUrlTreeNode(sources);
 
                 url = url.BaseUriPath()
@@ -227,10 +228,10 @@ namespace OpenAPIService
         /// </summary>
         /// <param name="sources">Dictionary of labels and their corresponding <see cref="OpenApiDocument"/> objects.</param>
         /// <returns>The created <see cref="OpenApiUrlTreeNode"/>.</returns>
-        public OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(Dictionary<string, OpenApiDocument> sources)
+        public OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(ConcurrentDictionary<string, OpenApiDocument> sources)
         {
             UtilityFunctions.CheckArgumentNull(sources, nameof(sources));
-            
+
             _telemetryClient?.TrackTrace("Creating OpenApiUrlTreeNode",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
@@ -587,6 +588,10 @@ namespace OpenAPIService
             var httpClient = CreateHttpClient();
 
             Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+
+            _telemetryClient?.TrackTrace("Success getting CSDL ",
+                                         SeverityLevel.Information,
+                                         _openApiTraceProperties);
 
             OpenApiDocument document = await ConvertCsdlToOpenApiAsync(csdl);
 


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/894

This PR:
- Attempts to fix the intermittent `openapi/tree` endpoint issue by using a `ConcurrentDictionary` object to store the `async` results of the asynchronously calls to fetch both `v1.0` and `beta` versions of the OpenAPI document during requests to the `openapi/tree` endpoint.
- Adds `Trace` telemetry to help gain visibility to the time taken for calls to fetch the csdl.