### PR TITLE
Resolves typescript array and map generation

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/IndentManager.cs
+++ b/CodeSnippetsReflection.OpenAPI/IndentManager.cs
@@ -1,7 +1,8 @@
-namespace CodeSnippetsReflection.OpenAPI {
+﻿namespace CodeSnippetsReflection.OpenAPI {
     public class IndentManager {
         private int _indentLevel;
         public void Indent() => _indentLevel++;
+        public void Indent(int depth) => _indentLevel=+depth;
         public void Unindent() => _indentLevel--;
         public string GetIndent() => new string('\t', _indentLevel < 0 ? 0 : _indentLevel);
     }


### PR DESCRIPTION
## Overview

Fixes Map and array generation for typescript

Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/816
Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/817

### Demo
An array of objects will be generated as such 

```typecsript
const extension = new Extension();
extension.additionalData = new Map<string, unknown>([
				["@odata.type", "microsoft.graph.openTypeExtension"],
				["extensionName", "Com.Contoso.Referral"],
				["companyName", "Wingtip Toys"],
				["expirationDate", "2015-12-30T11:00:00.000Z"],
				["dealValue", 10000]
			]);
requestBody.extensions = [
		extension
	]
```
[Sample source](https://docs.microsoft.com/en-us/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0&tabs=http)