### PR TITLE
Fix missing queryOptions parameter in dotnet snippets and unblock dependabot PRs

### DIFF
--- a/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
@@ -1085,7 +1085,7 @@ namespace CodeSnippetsReflection.Test
                                            "\r\n" +
                                            "await graphClient.Me.CalendarView\r\n" +
                                                 "\t.Delta()\r\n" +
-                                                "\t.Request()\r\n" +
+                                                "\t.Request( queryOptions )\r\n" +
                                                 "\t.PostAsync();";
 
             //Assert the snippet generated is as expected
@@ -1359,6 +1359,25 @@ namespace CodeSnippetsReflection.Test
             var expandClause = ".Expand(\"directReports,manager($levels=max;$select=id,displayName)\")";  // Adds the created type
             Assert.Contains(countParameter, result);
             Assert.Contains(expandClause, result);
+        }
+
+        [Fact]
+        public void ShouldUseGeneratedQueryOptions()
+        {
+            // Arrange
+            var expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,"https://graph.microsoft.com/v1.0/applications?$count=true&$skip=10");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
+            // Act
+            var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
+            // Assert
+            var countParameter = "new QueryOption(\"$count\", \"true\")";  // the count query option
+            var skipParameter = ".Skip(10)";  // the skip query option
+            var queryOptions = ".Request( queryOptions )";  // Adds the custom query options
+            Assert.Contains(countParameter, result);
+            Assert.Contains(queryOptions, result);
+            Assert.Contains(skipParameter, result);
         }
     }
 }

--- a/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OData.UriParser;
+using Microsoft.OData.UriParser;
 using Newtonsoft.Json;
 using System;
 using System.Linq;
@@ -764,7 +764,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
             //Generate the Resources path for Csharp
             stringBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
             //check if there are any custom query options appended
-            stringBuilder.Append(snippetModel.CustomQueryOptions.Any() ? "\r\n\t.Request( queryOptions )" : "\r\n\t.Request()");
+            stringBuilder.Append(ShouldGenerateCustomQueryOptions(snippetModel) ? "\r\n\t.Request( queryOptions )" : "\r\n\t.Request()");
             //Append footers
             stringBuilder.Append(actions);
 
@@ -874,9 +874,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
         /// <param name="snippetModel">Snippet model built from the request</param>
         private static string GenerateCustomQuerySection(SnippetModel snippetModel)
         {
-            if (!snippetModel.CustomQueryOptions.Any()
-            && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken)
-            && !snippetModel.ODataUri.QueryCount.HasValue)
+            if (!ShouldGenerateCustomQueryOptions(snippetModel))
             {
                 return string.Empty;//nothing to do here
             }
@@ -906,6 +904,20 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
             stringBuilder.Append("};\r\n\r\n");//closing brace
             //return custom query options section
             return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Determine if we should be using custom query options in C#
+        /// </summary>
+        /// <param name="snippetModel">Snippet model built from the request</param>
+        private static bool ShouldGenerateCustomQueryOptions(SnippetModel snippetModel)
+        {
+            if (!snippetModel.CustomQueryOptions.Any()
+                && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken)
+                && !snippetModel.ODataUri.QueryCount.HasValue)
+                    return false;
+
+            return true;
         }
 
         /// <summary>

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -22,7 +22,11 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
 									$"var {clientVarName} = new {clientVarType}({httpCoreVarName});{Environment.NewLine}{Environment.NewLine}");
 			var (requestPayload, payloadVarName) = GetRequestPayloadAndVariableName(snippetModel, indentManager);
 			snippetBuilder.Append(requestPayload);
-			var responseAssignment = snippetModel.ResponseSchema == null ? string.Empty : "var result = ";
+            var responseAssignment = "var result = ";
+            // have a return type if we have a response schema that is not an error
+            if (snippetModel.ResponseSchema == null || (snippetModel.ResponseSchema.Properties.Count == 1 && snippetModel.ResponseSchema.Properties.First().Key.Equals("error",StringComparison.OrdinalIgnoreCase)))
+                responseAssignment = string.Empty;
+
 			var (queryParamsPayload, queryParamsVarName) = GetRequestQueryParameters(snippetModel, indentManager);
 			if(!string.IsNullOrEmpty(queryParamsPayload))
 				snippetBuilder.Append(queryParamsPayload);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -23,7 +23,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
                                     $"{clientVarName} := msgraphsdk.New{clientVarType}({httpCoreVarName}){Environment.NewLine}{Environment.NewLine}");
             var (requestPayload, payloadVarName) = GetRequestPayloadAndVariableName(snippetModel, indentManager);
             snippetBuilder.Append(requestPayload);
-            var responseAssignment = snippetModel.ResponseSchema == null ? string.Empty : "result, err := ";
+            var responseAssignment = "result, err := ";
+            // have a return type if we have a response schema that is not an error
+            if (snippetModel.ResponseSchema == null || (snippetModel.ResponseSchema.Properties.Count == 1 && snippetModel.ResponseSchema.Properties.First().Key.Equals("error", StringComparison.OrdinalIgnoreCase)))
+                responseAssignment = string.Empty;
             var (queryParamsPayload, queryParamsVarName) = GetRequestQueryParameters(snippetModel, indentManager);
             if(!string.IsNullOrEmpty(queryParamsPayload))
                 snippetBuilder.Append(queryParamsPayload);


### PR DESCRIPTION
This PR closes #908 

In summary changes include: -
- Unblocking dependabot PRs #904, #905, #906 and #907 dues to failing tests due to the updated openApi document containing error response schema for delete methods. This breaks the tests as the snippet generator assumed the schema would be null in this scenario.
- Fixes #908 where some scenarios would miss the generated `queryOptions` parameter in the request methods.