### PR TITLE
Resolves structured and collection-valued function parameters for PowerShell style

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -771,7 +771,7 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
-                    ["/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids=@ids)"] = new OpenApiPathItem()
+                    ["/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids={ids})"] = new OpenApiPathItem()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -771,6 +771,105 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
+                    ["/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids=@ids)"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        new OpenApiTag()
+                                        {
+                                            Name = "deviceManagement.Functions"
+                                        }
+                                    },
+                                    OperationId = "deviceManagement.getRoleScopeTagsByIds",
+                                    Summary = "Invoke function getRoleScopeTagsByIds",
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        new OpenApiParameter()
+                                        {
+                                            Name = "ids",
+                                            In = ParameterLocation.Query,
+                                            Description = "Usage: ids={ids}",
+                                            Required = true,
+                                            Content = new Dictionary<string, OpenApiMediaType>
+                                            {
+                                                {
+                                                    applicationJsonMediaType,
+                                                    new OpenApiMediaType
+                                                    {
+                                                        Schema = new OpenApiSchema
+                                                        {
+                                                            Type = "array",
+                                                            Items = new OpenApiSchema
+                                                            {
+                                                                Type = "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200", new OpenApiResponse()
+                                            {
+                                                Description = "Success",
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    {
+                                                        applicationJsonMediaType,
+                                                        new OpenApiMediaType
+                                                        {
+                                                            Schema = new OpenApiSchema
+                                                            {
+                                                                Title = "Collection of deviceManagement",
+                                                                Type = "object",
+                                                                Properties = new Dictionary<string, OpenApiSchema>
+                                                                {
+                                                                    {
+                                                                        "value", new OpenApiSchema
+                                                                        {
+                                                                            Type = "array",
+                                                                            Items = new OpenApiSchema
+                                                                            {
+                                                                                AnyOf = new List<OpenApiSchema>
+                                                                                {
+                                                                                    new OpenApiSchema
+                                                                                    {
+                                                                                        Reference = new OpenApiReference
+                                                                                        {
+                                                                                            Type = ReferenceType.Schema,
+                                                                                            Id = "microsoft.graph.roleScopeTag"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("function")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     ["/applications/{application-id}/createdOnBehalfOf/$ref"] = new OpenApiPathItem()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>

--- a/OpenAPIService.Test/OpenAPIService.Test.csproj
+++ b/OpenAPIService.Test/OpenAPIService.Test.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.3.1-preview5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -25,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenAPIService\OpenAPIService.csproj" />
+    <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -2,15 +2,17 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Interfaces;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using UtilityService;
 using Xunit;
 
 namespace OpenAPIService.Test
@@ -355,6 +357,45 @@ namespace OpenAPIService.Test
 
             // Assert
             Assert.Equal(expectedOperationId, operationId);
+        }
+
+        [Fact]
+        public void ResolveStructuredAndCollectionValuedFunctionParameters()
+        {
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids=@ids)",
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+
+            var parameter = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
+                              .Operations[OperationType.Get]
+                              .Parameters
+                              .FirstOrDefault();
+
+            Assert.NotNull(parameter);
+
+            var json = parameter.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            var expectedPayload = $@"{{
+  ""name"": ""ids"",
+  ""in"": ""query"",
+  ""description"": ""Usage: ids={{ids}}"",
+  ""required"": true,
+  ""schema"": {{
+    ""type"": ""array"",
+    ""items"": {{
+      ""type"": ""string""
+    }}
+  }}
+}}";
+
+            // Assert
+            Assert.Equal(expectedPayload.ChangeLineBreaks(), json);
         }
 
         [Theory]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -365,7 +365,7 @@ namespace OpenAPIService.Test
             // Act
             var predicate = _openApiService.CreatePredicate(operationIds: null,
                                                            tags: null,
-                                                           url: "/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids=@ids)",
+                                                           url: "/deviceManagement/microsoft.graph.getRoleScopeTagsByIds(ids={ids})",
                                                            source: _graphMockSource,
                                                            graphVersion: GraphVersion);
 

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -369,8 +369,17 @@ namespace OpenAPIService.Test
                                                            source: _graphMockSource,
                                                            graphVersion: GraphVersion);
 
+            var predicate2 = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/reports/microsoft.graph.getSharePointSiteUsageDetail(period={period})",
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            var subsetOpenApiDocument2 = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate2);
+
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument2 = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument2);
 
             var parameter = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
@@ -378,9 +387,18 @@ namespace OpenAPIService.Test
                               .Parameters
                               .FirstOrDefault();
 
+            var parameter2 = subsetOpenApiDocument2.Paths
+                              .FirstOrDefault().Value
+                              .Operations[OperationType.Get]
+                              .Parameters
+                              .FirstOrDefault();
+
             Assert.NotNull(parameter);
+            Assert.NotNull(parameter2);
 
             var json = parameter.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            var json2 = parameter2.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
             var expectedPayload = $@"{{
   ""name"": ""ids"",
   ""in"": ""query"",
@@ -394,8 +412,19 @@ namespace OpenAPIService.Test
   }}
 }}";
 
+            var expectedPayload2 = $@"{{
+  ""name"": ""period"",
+  ""in"": ""path"",
+  ""description"": ""Usage: period={{period}}"",
+  ""required"": true,
+  ""schema"": {{
+    ""type"": ""string""
+  }}
+}}";
+
             // Assert
             Assert.Equal(expectedPayload.ChangeLineBreaks(), json);
+            Assert.Equal(expectedPayload2.ChangeLineBreaks(), json2);
         }
 
         [Theory]

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -7,7 +7,6 @@ using Microsoft.OpenApi.Services;
 using OpenAPIService.Common;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.10.0" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.8" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.10-preview3" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.0-preview" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -742,8 +742,8 @@ namespace OpenAPIService
                 /* The Type and Format properties describe the data type of the function parameters.
                  * For string data types the Format property is usually undefined.
                  */
-                if (string.IsNullOrEmpty(parameter.Schema.Format) &&
-                    !string.IsNullOrEmpty(parameter.Schema.Type))
+                if (string.IsNullOrEmpty(parameter.Schema?.Format) &&
+                    !string.IsNullOrEmpty(parameter.Schema?.Type))
                 {
                     parameterTypes.Add(parameter.Name, parameter.Schema.Type);
                 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -593,9 +593,11 @@ namespace OpenAPIService
             Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
             stopwatch.Stop();
 
+            _openApiTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
             _telemetryClient?.TrackTrace($"Success getting CSDL for {csdlHref} in {stopwatch.ElapsedMilliseconds}ms",
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
+            _openApiTraceProperties.Remove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore);
 
             OpenApiDocument document = await ConvertCsdlToOpenApiAsync(csdl);
 

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -72,6 +72,11 @@ namespace OpenAPIService
                     // OperationIds to how they were being constructed in earlier versions of the lib.
                     operationId = ResolveActionFunctionOperationId(operation);
                 }
+
+                if ("function".Equals(operationType, StringComparison.OrdinalIgnoreCase))
+                {
+                    ResolveFunctionOperationParameterSchema(operation);
+                }
             }
 
             var charPos = operationId.LastIndexOf('.', operationId.Length - 1);
@@ -158,6 +163,26 @@ namespace OpenAPIService
             updatedOperationId = regex.Match(updatedOperationId).Value;
 
             return updatedOperationId;
+        }
+
+        private static void ResolveFunctionOperationParameterSchema(OpenApiOperation operation)
+        {
+            foreach (var parameter in operation.Parameters)
+            {
+                if (parameter.Content != null)
+                {
+                    // Replace with schema object
+                    parameter.Content = null;
+                    parameter.Schema = new OpenApiSchema
+                    {
+                        Type = "array",
+                        Items = new OpenApiSchema
+                        {
+                            Type = "string"
+                        }
+                    };
+                }
+            }
         }
     }
 }

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -75,7 +75,7 @@ namespace OpenAPIService
 
                 if ("function".Equals(operationType, StringComparison.OrdinalIgnoreCase))
                 {
-                    ResolveFunctionOperationParameterSchema(operation);
+                    ResolveFunctionParameters(operation);
                 }
             }
 
@@ -165,13 +165,18 @@ namespace OpenAPIService
             return updatedOperationId;
         }
 
-        private static void ResolveFunctionOperationParameterSchema(OpenApiOperation operation)
+        /// <summary>
+        /// Resolves structured or collection-valued function parameters.
+        /// </summary>
+        /// <param name="operation">The target OpenAPI operation of the function.</param>
+        private static void ResolveFunctionParameters(OpenApiOperation operation)
         {
             foreach (var parameter in operation.Parameters)
             {
-                if (parameter.Content != null)
+                if (parameter.Content?.Any() ?? false)
                 {
-                    // Replace with schema object
+                    // Replace content with a schema object of type array
+                    // for structured or collection-valued function parameters
                     parameter.Content = null;
                     parameter.Schema = new OpenApiSchema
                     {

--- a/UtilityService/UtilityExtensions.cs
+++ b/UtilityService/UtilityExtensions.cs
@@ -154,5 +154,18 @@ namespace UtilityService
 
             return string.Join(ForwardSlash, segments);
         }
+
+        /// <summary>
+        /// Change the input string's line breaks
+        /// </summary>
+        /// <param name="rawString">The raw input string</param>
+        /// <param name="newLine">The new line break.</param>
+        /// <returns>The changed string.</returns>
+        public static string ChangeLineBreaks(this string rawString, string newLine = "\n")
+        {
+            rawString = rawString.Trim('\n', '\r');
+            rawString = rawString.Replace("\r\n", newLine);
+            return rawString;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/911

This PR:
- Updates the properties of structured and collection-valued function parameters for PowerShell style by nulling the `content` property and setting the `schema` property appropriately as: 

```
  "schema": {
    "type": "array",
    "items": {
      "type": "string"
    }
```

- Adds a test to validate the above fix.
- Adds a string extension method in the `UtilityService` project and have it referenced in the above test.
- Add reference to `Microsoft.OpenApi` lib `v1.3.1-preview5` in the OpenAPIService tests. This is needed for the above test.
- Fixes a nullable `schema` bug.
- Other minor code refactorings.