### PR TITLE
Update OpenAPI convert settings

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -630,7 +630,8 @@ namespace OpenAPIService
                 EnableDerivedTypesReferencesForRequestBody = false,
                 EnableDerivedTypesReferencesForResponses = false,
                 ShowRootPath = true,
-                ShowLinks = true
+                ShowLinks = true,
+                AddSingleQuotesForStringParameters = true
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -621,17 +621,20 @@ namespace OpenAPIService
 
             var settings = new OpenApiConvertSettings()
             {
+                AddSingleQuotesForStringParameters = true,
+                AddEnumDescriptionExtension = true,
+                DeclarePathParametersOnPathItem = true,
                 EnableKeyAsSegment = true,
                 EnableOperationId = true,
+                ErrorResponsesAsDefault = false,
                 PrefixEntityTypeNameBeforeKey = true,
                 TagDepth = 2,
                 EnablePagination = true,
                 EnableDiscriminatorValue = false,
                 EnableDerivedTypesReferencesForRequestBody = false,
                 EnableDerivedTypesReferencesForResponses = false,
-                ShowRootPath = true,
-                ShowLinks = true,
-                AddSingleQuotesForStringParameters = true
+                ShowRootPath = false,
+                ShowLinks = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 


### PR DESCRIPTION
This PR:
- Sets the below convert settings to align with Hidi:
  - `AddSingleQuotesForStringParameters = true`
  - `AddEnumDescriptionExtension = true`
  - `DeclarePathParametersOnPathItem = true`
  - `ErrorResponsesAsDefault = false`