### PR TITLE
Update typescript initialization and record types

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
@@ -45,12 +45,12 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains(".me.messagesById(\"message-id\")", result);
         }
         [Fact]
-        public async Task GeneratesTheSnippetHeader()
+        public async Task GeneratesTheSnippetInitializationStatement()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("const graphServiceClient = new GraphServiceClient(requestAdapter)", result);
+            Assert.Contains("const graphServiceClient = GraphServiceClient.init({authProvider});", result);
         }
         [Fact]
         public async Task GeneratesTheGetMethodCall()
@@ -188,7 +188,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("\"members@odata.bind\", [", result);
+            Assert.Contains("\"members@odata.bind\" : [", result);
             Assert.Contains("requestBody.additionalData", result);
             Assert.Contains("members", result); // property name hasn't been changed
         }
@@ -203,7 +203,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("const extension = new Extension();", result); // property is initialized on its own
-            Assert.Contains("extension.additionalData = new Map<string, unknown>([", result); // separate entity is assigned
+            Assert.Contains("extension.additionalData = {", result); // additional data is initialized as a Record not mpa
             Assert.Contains("requestBody.extensions = [", result); // property is added to list
         }
         [Fact]

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
@@ -22,7 +22,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private const string clientVarName = "graphServiceClient";
         private const string clientVarType = "GraphServiceClient";
-        private const string httpCoreVarName = "requestAdapter";
 
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
@@ -30,7 +29,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var indentManager = new IndentManager();
             var snippetBuilder = new StringBuilder(
                                     "//THIS SNIPPET IS A PREVIEW FOR THE KIOTA BASED SDK. NON-PRODUCTION USE ONLY" + Environment.NewLine +
-                                    $"const {clientVarName} = new {clientVarType}({httpCoreVarName});{Environment.NewLine}{Environment.NewLine}");
+                                    $"const {clientVarName} = {clientVarType}.init({{authProvider}});{Environment.NewLine}{Environment.NewLine}");
             var (requestPayload, payloadVarName) = GetRequestPayloadAndVariableName(snippetModel, indentManager);
             snippetBuilder.Append(requestPayload);
             var responseAssignment = snippetModel.ResponseSchema == null ? string.Empty : "const result = ";
@@ -205,19 +204,19 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var propertiesWithoutSchema = propertiesAndSchema.Where(x => x.Item2 == null).Select(x => x.Item1);
             if (propertiesWithoutSchema.Any())
             {
-                payloadSB.AppendLine($"{objectName}.additionalData = new Map<string, unknown>([");
+                payloadSB.AppendLine($"{objectName}.additionalData = {{");
                 indentManager.Indent();
 
                 int elementIndex = 0;
                 var lastIndex = propertiesWithoutSchema.Count() - 1;
                 foreach (var property in propertiesWithoutSchema)
                 {
-                    var propertyAssignment = $"{indentManager.GetIndent()}[\"{property.Name}\", ";
-                    WriteProperty(objectName, payloadSB, property.Value, null, indentManager, propertyAssignment, "]", (lastIndex == elementIndex) ? default : ",");
+                    var propertyAssignment = $"{indentManager.GetIndent()} \"{property.Name}\" : ";
+                    WriteProperty(objectName, payloadSB, property.Value, null, indentManager, propertyAssignment, "", (lastIndex == elementIndex) ? default : ",");
                     elementIndex++;
                 }
                 indentManager.Unindent();
-                payloadSB.AppendLine($"{indentManager.GetIndent()}]);");
+                payloadSB.AppendLine($"{indentManager.GetIndent()} }}");
             }
             indentManager.Unindent();
         }

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -32,6 +32,7 @@ paths:
               - Objective-C
               - Go
               - PowerShell
+              - TypeScript
             default: C#
         - name: generation
           in: query

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -44,8 +44,8 @@ steps:
 
 - pwsh: |
     # override build languag incase provided in pipeline
-    $buildLanguages = if (!"$env:LANGUAGES") { "$(snippetLanguages)" } else { "$env:LANGUAGES" }
-    $branchPrefix = if (!"$env:LANGUAGES") { "snippet-generation" } else { "preview-snippet-generation" }
+    $buildLanguages = if ("$env:LANGUAGES") { "$env:LANGUAGES" } else { "$(snippetLanguages)" }
+    $branchPrefix = if ("$env:LANGUAGES") { "preview-snippet-generation" } else { "snippet-generation" }
     Write-Host "##vso[task.setvariable variable=buildLanguages]$buildLanguages"
     Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
     Write-Host "Branch prefix is $branchPrefix"


### PR DESCRIPTION
## Overview

Fixes code initialization and `additionalData` type for TypeScript generation 

Closes https://github.com/microsoftgraph/msgraph-sdk-raptor/pull/879

### Demo

**Current code** 
```typescript
const graphServiceClient = new GraphServiceClient(requestAdapter);
```

**New behavior**
```typescript
const graphServiceClient = GraphServiceClient.init({authProvider});
```


**Current code** 
```typescript

const requestBody = new Message()
requestBody.body = new ItemBody();
const extension = new Extension();
extension.additionalData = new Map<string, unknown>([
					["dealValue", 10000]
				]);
requestBody.extensions = [
			extension
		]

```

**New behavior**
```typescript
const requestBody = new Message()
requestBody.body = new ItemBody();
const extension = new Extension();
extension.additionalData = {
					 "dealValue" : 10000,
					 "dealValue2" : 10000
				 }
requestBody.extensions = [
			extension
		]
```


