### PR TITLE
Add request body content to improve autocomplete experience

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -53,7 +53,7 @@ namespace GraphWebApi.Controllers
                                     [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
                                     [FromQuery]string format = null,
                                     [FromQuery]string graphVersion = null,
-                                    [FromQuery] bool requestBody = false,
+                                    [FromQuery]bool requestBody = false,
                                     [FromQuery]bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -53,6 +53,7 @@ namespace GraphWebApi.Controllers
                                     [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
                                     [FromQuery]string format = null,
                                     [FromQuery]string graphVersion = null,
+                                    [FromQuery] bool requestBody = false,
                                     [FromQuery]bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
@@ -65,7 +66,7 @@ namespace GraphWebApi.Controllers
             }
 
             var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
-            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh);
+            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, requestBody);
         }
 
         [Route("openapi/operations")]
@@ -142,24 +143,25 @@ namespace GraphWebApi.Controllers
                                               [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
                                               [FromQuery] string format = null,
                                               [FromQuery] string graphVersion = null,
-                                              [FromQuery] bool forceRefresh = false)
+                                              [FromQuery] bool forceRefresh = false,
+                                              [FromQuery] bool requestBody = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
             var source = await _openApiService.ConvertCsdlToOpenApiAsync(Request.Body);
-            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh);
+            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, requestBody);
         }
 
         private FileStreamResult CreateSubsetOpenApiDocument(string operationIds, string tags,
                                                              string url, OpenApiDocument source,
                                                              string title, OpenApiStyleOptions styleOptions,
-                                                             bool forceRefresh)
+                                                             bool forceRefresh, bool requestBody)
         {
             var predicate = _openApiService.CreatePredicate(operationIds, tags, url, source, styleOptions.GraphVersion, forceRefresh);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument, requestBody);
 
             var stream = _openApiService.SerializeOpenApiDocument(subsetOpenApiDocument, styleOptions);
 

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -53,7 +53,7 @@ namespace GraphWebApi.Controllers
                                     [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
                                     [FromQuery]string format = null,
                                     [FromQuery]string graphVersion = null,
-                                    [FromQuery]bool requestBody = false,
+                                    [FromQuery]bool includeRequestBody = false,
                                     [FromQuery]bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
@@ -66,7 +66,7 @@ namespace GraphWebApi.Controllers
             }
 
             var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
-            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, requestBody);
+            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody);
         }
 
         [Route("openapi/operations")]
@@ -144,24 +144,24 @@ namespace GraphWebApi.Controllers
                                               [FromQuery] string format = null,
                                               [FromQuery] string graphVersion = null,
                                               [FromQuery] bool forceRefresh = false,
-                                              [FromQuery] bool requestBody = false)
+                                              [FromQuery] bool includeRequestBody = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
             var source = await _openApiService.ConvertCsdlToOpenApiAsync(Request.Body);
-            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, requestBody);
+            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody);
         }
 
         private FileStreamResult CreateSubsetOpenApiDocument(string operationIds, string tags,
                                                              string url, OpenApiDocument source,
                                                              string title, OpenApiStyleOptions styleOptions,
-                                                             bool forceRefresh, bool requestBody)
+                                                             bool forceRefresh, bool includeRequestBody)
         {
             var predicate = _openApiService.CreatePredicate(operationIds, tags, url, source, styleOptions.GraphVersion, forceRefresh);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument, requestBody);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument, includeRequestBody);
 
             var stream = _openApiService.SerializeOpenApiDocument(subsetOpenApiDocument, styleOptions);
 

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -427,6 +427,30 @@ namespace OpenAPIService.Test
                                                 Schema = new OpenApiSchema()
                                                 {
                                                     Type = "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    RequestBody = new OpenApiRequestBody()
+                                    {
+                                        Description = "Invoke action restore",
+                                        Content = new Dictionary<string, OpenApiMediaType>
+                                        {
+                                            {
+                                                applicationJsonMediaType,
+                                                new OpenApiMediaType
+                                                {
+                                                    Schema = new OpenApiSchema
+                                                    {
+                                                        AnyOf = new List<OpenApiSchema>
+                                                        {
+                                                            new OpenApiSchema
+                                                            {
+                                                                Type = "string"
+                                                            }
+                                                        },
+                                                        Nullable = true
+                                                    }
                                                 }
                                             }
                                         }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -129,7 +129,7 @@ namespace OpenAPIService.Test
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
             // Act & Assert
-            var message = Assert.Throws<ArgumentException>(() => _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument)).Message;
+            var message = Assert.Throws<ArgumentException>(() => _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false)).Message;
             Assert.Equal("No paths found for the supplied parameters.", message);
         }
 
@@ -222,7 +222,7 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, false);
 
             // Assert
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
@@ -293,6 +293,44 @@ namespace OpenAPIService.Test
         }
 
         [Fact]
+        public void ReturnContentForGEAutoCompleteStyleIfReQuestBodyIsTrue()
+        {
+            // Arrange
+            var style = OpenApiStyle.GEAutocomplete;
+            var url = "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore";
+            var operationType = OperationType.Post;
+            var requestBody = true;
+
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: url,
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, requestBody);
+
+            // Assert
+            var requestBodyContent = subsetOpenApiDocument.Paths
+                            .FirstOrDefault().Value
+                            .Operations[operationType]
+                            .RequestBody                                
+                            .Content;
+
+            var responseContent = subsetOpenApiDocument.Paths
+                                .FirstOrDefault().Value
+                                .Operations[operationType]
+                                .Responses["200"]
+                                .Content;
+
+            Assert.Single(subsetOpenApiDocument.Paths);
+            Assert.NotEmpty(requestBodyContent);
+            Assert.NotEmpty(responseContent);
+        }
+
+        [Fact]
         public void RemoveRootPathFromOpenApiDocumentInApplyStyleForPowerShellOpenApiStyle()
         {
             // Act
@@ -303,7 +341,7 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
 
             // Assert
             Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
@@ -323,7 +361,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
 
             var parentSchema = subsetOpenApiDocument.Components.Schemas["microsoft.graph.networkInterface"];
             var descriptionSchema = parentSchema.Properties["description"];
@@ -347,7 +385,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
             var operationId = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[operationType]
@@ -372,7 +410,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, false);
 
             var parameter = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
@@ -393,7 +431,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
             var operationId = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[OperationType.Get]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -295,7 +295,7 @@ namespace OpenAPIService.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ReturnContentForGEAutoCompleteStyleIfRequestBodyIsTrue(bool requestBody)
+        public void IncludeRequestBody(bool requestBody)
         {
             // Arrange
             var style = OpenApiStyle.GEAutocomplete;

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -129,7 +129,7 @@ namespace OpenAPIService.Test
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
             // Act & Assert
-            var message = Assert.Throws<ArgumentException>(() => _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false)).Message;
+            var message = Assert.Throws<ArgumentException>(() => _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument)).Message;
             Assert.Equal("No paths found for the supplied parameters.", message);
         }
 
@@ -222,7 +222,7 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
 
             // Assert
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
@@ -341,7 +341,7 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
 
             // Assert
             Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
@@ -361,7 +361,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
 
             var parentSchema = subsetOpenApiDocument.Components.Schemas["microsoft.graph.networkInterface"];
             var descriptionSchema = parentSchema.Properties["description"];
@@ -385,7 +385,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
             var operationId = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[operationType]
@@ -410,7 +410,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
 
             var parameter = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
@@ -431,7 +431,7 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument, false);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
             var operationId = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[OperationType.Get]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -295,7 +295,7 @@ namespace OpenAPIService.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void IncludeRequestBody(bool requestBody)
+        public void ReturnContentForGEAutoCompleteStyleIfRequestBodyIsTrue(bool includeRequestBody)
         {
             // Arrange
             var style = OpenApiStyle.GEAutocomplete;
@@ -311,7 +311,7 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
-            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, requestBody);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, includeRequestBody);
             var requestBodyContent = subsetOpenApiDocument.Paths
                 .FirstOrDefault().Value
                 .Operations[operationType]
@@ -326,7 +326,7 @@ namespace OpenAPIService.Test
             // Assert
             Assert.Single(subsetOpenApiDocument.Paths);
 
-            if (requestBody)
+            if (includeRequestBody)
             {
                 Assert.NotEmpty(requestBodyContent);
                 Assert.NotEmpty(responseContent);

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -292,14 +292,15 @@ namespace OpenAPIService.Test
             }
         }
 
-        [Fact]
-        public void ReturnContentForGEAutoCompleteStyleIfReQuestBodyIsTrue()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReturnContentForGEAutoCompleteStyleIfRequestBodyIsTrue(bool requestBody)
         {
             // Arrange
             var style = OpenApiStyle.GEAutocomplete;
             var url = "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore";
             var operationType = OperationType.Post;
-            var requestBody = true;
 
             // Act
             var predicate = _openApiService.CreatePredicate(operationIds: null,
@@ -311,23 +312,30 @@ namespace OpenAPIService.Test
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
             subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument, requestBody);
-
-            // Assert
             var requestBodyContent = subsetOpenApiDocument.Paths
-                            .FirstOrDefault().Value
-                            .Operations[operationType]
-                            .RequestBody                                
-                            .Content;
-
+                .FirstOrDefault().Value
+                .Operations[operationType]
+                .RequestBody
+                .Content;
             var responseContent = subsetOpenApiDocument.Paths
                                 .FirstOrDefault().Value
                                 .Operations[operationType]
                                 .Responses["200"]
                                 .Content;
 
+            // Assert
             Assert.Single(subsetOpenApiDocument.Paths);
-            Assert.NotEmpty(requestBodyContent);
-            Assert.NotEmpty(responseContent);
+
+            if (requestBody)
+            {
+                Assert.NotEmpty(requestBodyContent);
+                Assert.NotEmpty(responseContent);
+            }
+            else
+            {
+                Assert.Empty(requestBodyContent);
+                Assert.Empty(responseContent);
+            }
         }
 
         [Fact]

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -28,7 +28,7 @@ namespace OpenAPIService.Interfaces
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 
-        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody);
+        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody = false);
 
         Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
 

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -28,7 +28,7 @@ namespace OpenAPIService.Interfaces
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 
-        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument);
+        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody);
 
         Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
 

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -7,7 +7,6 @@ using Microsoft.OpenApi.Services;
 using OpenAPIService.Common;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -28,7 +27,7 @@ namespace OpenAPIService.Interfaces
 
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 
-        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody = false);
+        OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false);
 
         Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -512,7 +512,7 @@ namespace OpenAPIService
         /// <param name="style">The OpenApiStyle value.</param>
         /// <param name="subsetOpenApiDocument">The subset of an OpenAPI document.</param>
         /// <returns>An OpenAPI doc with the respective style applied.</returns>
-        public OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument)
+        public OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody)
         {
             _telemetryClient?.TrackTrace($"Applying style for '{style}'",
                                          SeverityLevel.Information,
@@ -523,9 +523,13 @@ namespace OpenAPIService
                 // Clone doc before making changes
                 subsetOpenApiDocument = Clone(subsetOpenApiDocument);
 
-                // The Content property and its schema $refs are unnecessary for autocomplete
-                RemoveContent(subsetOpenApiDocument);
+                if(!requestBody)
+                {
+                    // The Content property and its schema $refs are unnecessary for autocomplete
+                    RemoveContent(subsetOpenApiDocument);
+                }
             }
+
             else if (style == OpenApiStyle.PowerShell || style == OpenApiStyle.PowerPlatform)
             {
                 /* For Powershell and PowerPlatform Styles */

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -512,7 +512,7 @@ namespace OpenAPIService
         /// <param name="style">The OpenApiStyle value.</param>
         /// <param name="subsetOpenApiDocument">The subset of an OpenAPI document.</param>
         /// <returns>An OpenAPI doc with the respective style applied.</returns>
-        public OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool requestBody)
+        public OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody)
         {
             _telemetryClient?.TrackTrace($"Applying style for '{style}'",
                                          SeverityLevel.Information,
@@ -523,7 +523,7 @@ namespace OpenAPIService
                 // Clone doc before making changes
                 subsetOpenApiDocument = Clone(subsetOpenApiDocument);
 
-                if(!requestBody)
+                if(!includeRequestBody)
                 {
                     // The Content property and its schema $refs are unnecessary for autocomplete
                     RemoveContent(subsetOpenApiDocument);


### PR DESCRIPTION
## Overview
This PR adds an optional request body parameter that populates the request body content when using autocomplete on Graph Explorer.

Fixes #926 

### Before
![image](https://user-images.githubusercontent.com/36787645/161506054-cd3ba0e4-bfaf-4b8d-9c71-a13eaa7a6d5a.png)


### After
![image](https://user-images.githubusercontent.com/36787645/161505957-a03007db-caec-4eb3-95d0-94aa0a57898b.png)

