### PR TITLE
Remove convert setting `DeclarePathParametersOnPathItem`

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -133,6 +133,12 @@ namespace OpenAPIService.Test
                                                 }
                                             }
                                         }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("function")
+                                        }
                                     }
                                 }
                             }
@@ -191,6 +197,12 @@ namespace OpenAPIService.Test
                                                     }
                                                 }
                                             }
+                                        }
+                                    },
+                                    Extensions = new Dictionary<string, IOpenApiExtension>
+                                    {
+                                        {
+                                            "x-ms-docs-operation-type", new OpenApiString("function")
                                         }
                                     }
                                 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -27,6 +27,7 @@ using OpenAPIService.Interfaces;
 using System.Text.Json;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.OpenApi.Any;
 
 namespace OpenAPIService
 {
@@ -97,7 +98,11 @@ namespace OpenAPIService
             foreach (var result in results)
             {
                 OpenApiPathItem pathItem;
-                string pathKey = FormatPathFunctions(result.CurrentKeys.Path, result.Operation.Parameters);
+                var pathKey = result.CurrentKeys.Path;
+                if (result.Operation.Extensions.TryGetValue("x-ms-docs-operation-type", out var value) && (value as OpenApiString).Value.Equals("function"))
+                {
+                    pathKey = FormatPathFunctions(pathKey, result.Operation.Parameters);
+                }
 
                 if (subset.Paths == null)
                 {

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -623,7 +623,6 @@ namespace OpenAPIService
             {
                 AddSingleQuotesForStringParameters = true,
                 AddEnumDescriptionExtension = true,
-                DeclarePathParametersOnPathItem = true,
                 EnableKeyAsSegment = true,
                 EnableOperationId = true,
                 ErrorResponsesAsDefault = false,

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -99,7 +99,7 @@ namespace OpenAPIService
             {
                 OpenApiPathItem pathItem;
                 var pathKey = result.CurrentKeys.Path;
-                if (result.Operation.Extensions.TryGetValue("x-ms-docs-operation-type", out var value) && value is OpenApiString oasString && oasString.Value.Equals("function"))
+                if (result.Operation.Extensions.TryGetValue("x-ms-docs-operation-type", out var value) && value is OpenApiString oasString && oasString.Value.Equals("function", StringComparison.Ordinal))
                 {
                     pathKey = FormatPathFunctions(pathKey, result.Operation.Parameters);
                 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -99,7 +99,7 @@ namespace OpenAPIService
             {
                 OpenApiPathItem pathItem;
                 var pathKey = result.CurrentKeys.Path;
-                if (result.Operation.Extensions.TryGetValue("x-ms-docs-operation-type", out var value) && (value as OpenApiString).Value.Equals("function"))
+                if (result.Operation.Extensions.TryGetValue("x-ms-docs-operation-type", out var value) && value is OpenApiString oasString && oasString.Value.Equals("function"))
                 {
                     pathKey = FormatPathFunctions(pathKey, result.Operation.Parameters);
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/928

This PR:
- Removes the OpenAPI convert setting `DeclarePathParametersOnPathItem`. This setting removes path parameters from the parameter object