### PR TITLE
Increases the HTTP Client timeout to 5 minutes

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -673,7 +673,10 @@ namespace OpenAPIService
             var httpClient = new HttpClient(new HttpClientHandler()
             {
                 AutomaticDecompression = DecompressionMethods.GZip
-            });
+            })
+            {
+                Timeout = TimeSpan.FromMinutes(5)
+            };
             httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
             httpClient.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("graphslice", "1.0"));
             return httpClient;


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/851

This PR:
- Hopes to fix the HTTP Client timeout issues experienced in the DevX API service while fetching the beta metadata from the GitHub repo. The default is 100 secs.