### PR TITLE
Removes lazy initialization causing failing builds

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -33,10 +33,10 @@ namespace CodeSnippetsReflection.OpenAPI
             if(string.IsNullOrEmpty(betaOpenApiDocumentUrl)) throw new ArgumentNullException(nameof(betaOpenApiDocumentUrl));
 
             _telemetryClient = telemetryClient;
-            _v1OpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
-            _betaOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
+            _v1OpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult());
+            _betaOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult());
             if(!string.IsNullOrEmpty(customOpenApiPathOrUrl))
-                _customOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
+                _customOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult());
         }
         private static async Task<OpenApiUrlTreeNode> GetOpenApiDocument(string url) {
             Stream stream;

--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -33,10 +33,10 @@ namespace CodeSnippetsReflection.OpenAPI
             if(string.IsNullOrEmpty(betaOpenApiDocumentUrl)) throw new ArgumentNullException(nameof(betaOpenApiDocumentUrl));
 
             _telemetryClient = telemetryClient;
-            _v1OpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult());
-            _betaOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult());
+            _v1OpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
+            _betaOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
             if(!string.IsNullOrEmpty(customOpenApiPathOrUrl))
-                _customOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult());
+                _customOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
         }
         private static async Task<OpenApiUrlTreeNode> GetOpenApiDocument(string url) {
             Stream stream;


### PR DESCRIPTION
## Overview
Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/927
This PR removes Lazy Initialization of GetOpenAPIDocument Method

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
[Sample generation run](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=72310&view=results)