### PR TITLE
Removes function parameters from incoming urls when querying for permissions

### DIFF
--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -183,32 +183,19 @@ namespace PermissionsService.Test
               });
         }
 
-        [Fact]
-        public void RemoveFunctionParametersFromRequestUrlsDuringLoadingAndQueryingOfPermissionsFiles()
+        [Theory]
+        [InlineData("/workbook/worksheets/{id}/charts/{id}/image")]
+        [InlineData("/workbook/worksheets/{id}/charts/{id}/image(width={value})")]
+        public void RemoveFunctionParametersFromRequestUrlsDuringLoadingAndQueryingOfPermissionsFiles(string url)
         {
             // Act
-            // RequestUrl in permission file: "/workbook/worksheets/{id}/charts/{id}/image(width=640)"
             List<ScopeInformation> result =
                 _permissionsStore.GetScopesAsync(scopeType: DelegatedWork,
-                                                 requestUrl: "/workbook/worksheets/{id}/charts/{id}/image(width=640)",
-                                                 method: "GET").GetAwaiter().GetResult();
-            List<ScopeInformation> result2 =
-                _permissionsStore.GetScopesAsync(scopeType: DelegatedWork,
-                                                 requestUrl: "/workbook/worksheets/{id}/charts/{id}/image",
+                                                 requestUrl: url,
                                                  method: "GET").GetAwaiter().GetResult();
 
             /* Assert */
-
             Assert.Collection(result,
-                item =>
-                {
-                    Assert.Equal("Files.ReadWrite", item.ScopeName);
-                    Assert.Equal("Have full access to your files", item.DisplayName);
-                    Assert.Equal("Allows the app to read, create, update, and delete your files.", item.Description);
-                    Assert.False(item.IsAdmin);
-                });
-
-            Assert.Collection(result2,
                 item =>
                 {
                     Assert.Equal("Files.ReadWrite", item.ScopeName);

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -184,11 +184,15 @@ namespace PermissionsService.Test
         }
 
         [Fact]
-        public void RemoveParameterParanthesesFromRequestUrlsDuringLoadingOfPermissionsFiles()
+        public void RemoveFunctionParametersFromRequestUrlsDuringLoadingAndQueryingOfPermissionsFiles()
         {
             // Act
             // RequestUrl in permission file: "/workbook/worksheets/{id}/charts/{id}/image(width=640)"
             List<ScopeInformation> result =
+                _permissionsStore.GetScopesAsync(scopeType: DelegatedWork,
+                                                 requestUrl: "/workbook/worksheets/{id}/charts/{id}/image(width=640)",
+                                                 method: "GET").GetAwaiter().GetResult();
+            List<ScopeInformation> result2 =
                 _permissionsStore.GetScopesAsync(scopeType: DelegatedWork,
                                                  requestUrl: "/workbook/worksheets/{id}/charts/{id}/image",
                                                  method: "GET").GetAwaiter().GetResult();
@@ -196,6 +200,15 @@ namespace PermissionsService.Test
             /* Assert */
 
             Assert.Collection(result,
+                item =>
+                {
+                    Assert.Equal("Files.ReadWrite", item.ScopeName);
+                    Assert.Equal("Have full access to your files", item.DisplayName);
+                    Assert.Equal("Allows the app to read, create, update, and delete your files.", item.Description);
+                    Assert.False(item.IsAdmin);
+                });
+
+            Assert.Collection(result2,
                 item =>
                 {
                     Assert.Equal("Files.ReadWrite", item.ScopeName);

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -467,7 +467,8 @@ namespace PermissionsService
             }
 
             requestUrl = requestUrl.BaseUriPath() // remove any query params
-                                   .UriTemplatePathFormat(true);
+                                   .UriTemplatePathFormat(true)
+                                   .RemoveParentheses();
 
             /* Remove ${value} segments from paths,
              * ex: /me/photo/$value --> $value or /applications/{application-id}/owners/$ref --> $ref

--- a/UtilityService.Test/UtilityExtensionsShould.cs
+++ b/UtilityService.Test/UtilityExtensionsShould.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -71,6 +71,8 @@ namespace UtilityService.Test
                     "/permissions?requesturl=/students/'MeganB@M365x214355.onmicrosoft.com'/classes")]
         [InlineData("/permissions?requesturl=/students/('MeganB@M365x214355.onmicrosoft.com')/classes",
                     "/permissions?requesturl=/students/'MeganB@M365x214355.onmicrosoft.com'/classes")]
+        [InlineData("/reports/getemailactivityusercounts(period={value})",
+                    "/reports/getemailactivityusercounts(period={value})")]
         public void GetUriTemplatePathFormatWithSimplifyNamespaceTrue(string targetString, string expectedString)
         {
             // Arrange and Act
@@ -91,6 +93,8 @@ namespace UtilityService.Test
                     "worksheets/range/microsoft.graph.range(address={address})")]
         [InlineData("/drive/list/items(listItem-id)microsoft.graph.getActivitiesByInterval()",
                     "/drive/list/items/listItem-id/microsoft.graph.getActivitiesByInterval()")]
+        [InlineData("/reports/getemailactivityusercounts(period={value})",
+                    "/reports/getemailactivityusercounts(period={value})")]
         public void GetUriTemplatePathFormatWithSimplifyNamespaceFalse(string targetString, string expectedString)
         {
             // Arrange and Act

--- a/UtilityService/UtilityExtensions.cs
+++ b/UtilityService/UtilityExtensions.cs
@@ -125,6 +125,13 @@ namespace UtilityService
 
                 if (segment.Contains(OpenParen) || segment.Contains(CloseParen))
                 {
+                    if (segment.Contains('='))
+                    {
+                        // Don't remove parentheses of namespace-simplified function parameters
+                        // ex: /reports/getemailactivityusercounts(period={value})
+                        continue;
+                    }
+
                     /* Resolve any possible parentheses as key instances
                      */
                     if (matchFunction?.Success ?? false)


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/924

This PR addresses the below when querying for permissions:
- Fixes a bug that was translating namespace-simplified function parameters as path segments.
- Removes function parameters from incoming request urls.
- Updates the permission test appropriately.