### PR TITLE
Add validation for requestUrl property on samples

### DIFF
--- a/SamplesService.Test/SampleQueryModelShould.cs
+++ b/SamplesService.Test/SampleQueryModelShould.cs
@@ -78,6 +78,18 @@ namespace SamplesService.Test
             Assert.Equal("/v1.0/me/photo/$value", sampleQueryModel.RequestUrl);
         }
 
+        [Fact]
+        public void ThrowArgumentExceptionIfRequestUrlHasWhiteSpaces()
+        {
+            // Arrange
+            SampleQueryModel sampleQueryModel = new SampleQueryModel();
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() =>
+                sampleQueryModel.RequestUrl = "/v1.0/users/{id | userPrincipalName}/identities"); // there's space between id and userPrincipalName
+
+        }
+
         #endregion
 
         #region DocLink Property Test

--- a/SamplesService/Models/SampleQueryModel.cs
+++ b/SamplesService/Models/SampleQueryModel.cs
@@ -57,8 +57,9 @@ namespace SamplesService.Models
             set
             {
                 string testValue = value;
+                string[] requestUrlSection = testValue.Split('?');
                 // Check if value starts with '/' and whether there are any subsequent '/'
-                if(!testValue.Trim(' ').StartsWith("/") || !testValue.TrimStart('/').Contains("/"))
+                if(!testValue.Trim(' ').StartsWith("/") || !testValue.TrimStart('/').Contains("/") || requestUrlSection[0].Trim().Contains(" "))
                 {
                     throw new ArgumentException("Invalid request url.\r\nEx.: /v1.0/me/messages", nameof(RequestUrl));
                 }


### PR DESCRIPTION
## Overview
Related to https://github.com/microsoftgraph/microsoft-graph-devx-content/issues/211
This PR adds validation to requestUrl property of a sample

### Demo
More information is provided here: https://github.com/microsoftgraph/microsoft-graph-devx-content/issues/211 and here https://github.com/microsoftgraph/microsoft-graph-devx-content/pull/210

### Notes
RequestUrl property of a sample should not have white spaces within.  

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output