### PR TITLE
Adds  a simple lazy object

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/SimpleLazyTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/SimpleLazyTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeSnippetsReflection.OpenAPI.Test
+{
+    public class SimpleLazyTest
+    {
+        private static Random random = new Random();
+
+        // return a random string or throw an exception
+        private String chaoticService()
+        {
+            if (random.Next() % 2 == 0 ) throw new Exception("Chaos just because");
+
+            Thread.Sleep(300);
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            return new string(Enumerable.Repeat(chars, 10)
+                .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+
+        [Fact]
+        public async Task NoExceptionCaching()
+        {
+            var responseProvider = new SimpleLazy<String>(() => chaoticService());
+
+            String result = default;
+
+            Parallel.For(0, 15, t =>
+            {
+                for (int i = 0; i < 10; i++)
+                {
+
+                    if(result != default) // once value is set value should not be changed
+                    {
+                        if (result != responseProvider.Value)
+                        {
+                            Assert.Equal(result , responseProvider.Value);
+                        }
+                    }
+                    else
+                    {
+                        try
+                        {
+                            result = responseProvider.Value;
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex.ToString());
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -20,9 +20,9 @@ namespace CodeSnippetsReflection.OpenAPI
         private readonly TelemetryClient _telemetryClient;
         private readonly Dictionary<string, string> _snippetsTraceProperties =
                     new() { { UtilityConstants.TelemetryPropertyKey_Snippets, nameof(OpenApiSnippetsGenerator) } };
-        private readonly Lazy<OpenApiUrlTreeNode> _v1OpenApiDocument;
-        private readonly Lazy<OpenApiUrlTreeNode> _betaOpenApiDocument;
-        private readonly Lazy<OpenApiUrlTreeNode> _customOpenApiDocument;
+        private readonly SimpleLazy<OpenApiUrlTreeNode> _v1OpenApiDocument;
+        private readonly SimpleLazy<OpenApiUrlTreeNode> _betaOpenApiDocument;
+        private readonly SimpleLazy<OpenApiUrlTreeNode> _customOpenApiDocument;
         public OpenApiSnippetsGenerator(
             string v1OpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml",
             string betaOpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml",
@@ -33,10 +33,10 @@ namespace CodeSnippetsReflection.OpenAPI
             if(string.IsNullOrEmpty(betaOpenApiDocumentUrl)) throw new ArgumentNullException(nameof(betaOpenApiDocumentUrl));
 
             _telemetryClient = telemetryClient;
-            _v1OpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
-            _betaOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
+            _v1OpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult());
+            _betaOpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult());
             if(!string.IsNullOrEmpty(customOpenApiPathOrUrl))
-                _customOpenApiDocument = new Lazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);
+                _customOpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult());
         }
         private static async Task<OpenApiUrlTreeNode> GetOpenApiDocument(string url) {
             Stream stream;

--- a/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
+++ b/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
@@ -13,7 +13,7 @@ namespace CodeSnippetsReflection.OpenAPI
      * This is a bypass for the dotnet issue https://github.com/dotnet/runtime/issues/27421 for lazy initialization without exception caching
      * 
      */
-    class SimpleLazy<T> where T : class
+    public class SimpleLazy<T> where T : class
     {
         private readonly Func<T> valueFactory;
         private T instance;

--- a/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
+++ b/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeSnippetsReflection.OpenAPI
+{
+
+    /*
+     * A Simple lazy factory that substitues https://referencesource.microsoft.com/#mscorlib/system/Lazy.cs
+     * by disregarding any exceptions thrown by the value factory.
+     * This is a bypass for the dotnet issue https://github.com/dotnet/runtime/issues/27421 for lazy initialization without exception caching
+     * 
+     */
+    class SimpleLazy<T> where T : class
+    {
+        private readonly Func<T> valueFactory;
+        private T instance;
+        private readonly object locker = new object();
+
+        public SimpleLazy(Func<T> valueFactory)
+        {
+            if (valueFactory == null)
+                throw new ArgumentNullException("valueFactory");
+
+            this.valueFactory = valueFactory;
+            this.instance = null;
+        }
+
+        public T Value
+        {
+            get
+            {
+                lock (locker)
+                    return instance ?? (instance = valueFactory());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Prevents caching exception when downloading OpenAPI document. 

Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/927

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output