### PR TITLE
Removes convert setting `ErrorResponsesAsDefault`

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -630,7 +630,6 @@ namespace OpenAPIService
                 DeclarePathParametersOnPathItem = true,
                 EnableKeyAsSegment = true,
                 EnableOperationId = true,
-                ErrorResponsesAsDefault = false,
                 PrefixEntityTypeNameBeforeKey = true,
                 TagDepth = 2,
                 EnablePagination = true,


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/953

This PR:
- Having the `ErrorResponsesAsDefault` setting set to `false` currently breaks PowerShell codegen. We need to delete this so as to revert it to its default value in the conversion lib., `true`.
- Work to redesign the `OpenAPIService` to have the convert settings configurable for the different styles is being tracked here: https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/956.