### PR TITLE
Reverts `Microsoft.OpenApi.Readers` version

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/CodeSnippetsReflection.OpenAPI.csproj
+++ b/CodeSnippetsReflection.OpenAPI/CodeSnippetsReflection.OpenAPI.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1-preview5" />
     <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.11.0" />
     <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.10-preview3" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1-preview5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR reverts `Microsoft.OpenApi.Readers` `v1.3.1` to `v1.3.1-preview5`. There's a current bug with the latest version. Details can be found in this [issue](https://github.com/microsoft/OpenAPI.NET/issues/850).