### PR TITLE
Updates dotnet generation for request config revamp

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/SimpleLazyTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/SimpleLazyTest.cs
@@ -5,12 +5,19 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {
     public class SimpleLazyTest
     {
+        private readonly ITestOutputHelper _testOutputHelper;
         private static Random random = new Random();
+
+        public SimpleLazyTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         // return a random string or throw an exception
         private String chaoticService()
@@ -24,7 +31,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
 
         [Fact]
-        public async Task NoExceptionCaching()
+        public void NoExceptionCaching()
         {
             var responseProvider = new SimpleLazy<String>(() => chaoticService());
 
@@ -50,7 +57,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(ex.ToString());
+                            _testOutputHelper.WriteLine(ex.ToString());
                         }
                     }
                 }


### PR DESCRIPTION
This PR closes #969 

Changes include:-

- Align generation to new request configuration updates to result in generation of snippets of the form for headers and query parameters
```cs
var graphClient = new GraphServiceClient(requestAdapter);

var result = await graphClient.Users.GetAsync((requestConfiguration) =>
{
	requestConfiguration.QueryParameters.Count = true;
	requestConfiguration.QueryParameters.Filter = "Department%20eq%20'Finance'";
	requestConfiguration.Headers.Add("ConsistencyLevel", "eventual");
	requestConfiguration.QueryParameters.Select = new [] { "id" , "displayName" , "department" };
});
```
- Add support for query parameters that are collections as shown above.
- Replace `Console.WriteLine` with `_testOutputHelper.WriteLine(ex.ToString())` in SimpleLazyTest.cs