### PR TITLE
Removes operation descriptions from OpenAPI docs

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -296,7 +296,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.Directory().DeletedItemsById(&directoryObjectId).Get()", result);
+            Assert.Contains("graphClient.Directory().DeletedItems().Group().Get()", result);
         }
         [Fact]
         public async Task DoesntFailOnTerminalSlash() {

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -542,7 +542,7 @@ namespace OpenAPIService.Test
         }
 
         [Fact]
-        public void RemoveOperationDescriptionsInPowerShellStyle()
+        public void RemoveOperationDescriptionsInCreateFilteredDocument()
         {
             // Arrange
             var predicate = _openApiService.CreatePredicate(operationIds: null,
@@ -552,15 +552,10 @@ namespace OpenAPIService.Test
                                                            graphVersion: GraphVersion);
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
-            var description = subsetOpenApiDocument.Paths
-                              .FirstOrDefault().Value
-                              .Operations[OperationType.Get]
-                              .Description;
-            Assert.NotNull(description);
 
             // Act
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
-            description = subsetOpenApiDocument.Paths
+            var description = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[OperationType.Get]
                               .Description;

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -541,8 +541,12 @@ namespace OpenAPIService.Test
             Assert.Contains(expectedPayloadContent, jsonPayload);
         }
 
-        [Fact]
-        public void RemoveOperationDescriptionsInCreateFilteredDocument()
+        [Theory]
+        [InlineData(OpenApiStyle.PowerPlatform)]
+        [InlineData(OpenApiStyle.PowerShell)]
+        [InlineData(OpenApiStyle.Plain)]
+        [InlineData(OpenApiStyle.GEAutocomplete)]
+        public void RemoveOperationDescriptionsInCreateFilteredDocument(OpenApiStyle style)
         {
             // Arrange
             var predicate = _openApiService.CreatePredicate(operationIds: null,
@@ -554,7 +558,7 @@ namespace OpenAPIService.Test
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
 
             // Act
-            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(style, subsetOpenApiDocument);
             var description = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
                               .Operations[OperationType.Get]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -541,6 +541,34 @@ namespace OpenAPIService.Test
             Assert.Contains(expectedPayloadContent, jsonPayload);
         }
 
+        [Fact]
+        public void RemoveOperationDescriptionsInPowerShellStyle()
+        {
+            // Arrange
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/users/{user-id}/messages/{message-id}",
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            var description = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
+                              .Operations[OperationType.Get]
+                              .Description;
+            Assert.NotNull(description);
+
+            // Act
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            description = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
+                              .Operations[OperationType.Get]
+                              .Description;
+
+            // Assert
+            Assert.Null(description);
+        }
+
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)
         {
             Assert.NotNull(node);

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.11.0" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.10-preview3" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.10" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1-preview5" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -641,7 +641,8 @@ namespace OpenAPIService
                 EnableDerivedTypesReferencesForRequestBody = false,
                 EnableDerivedTypesReferencesForResponses = false,
                 ShowRootPath = true,
-                ShowLinks = true
+                ShowLinks = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 

--- a/OpenAPIService/OperationSearch.cs
+++ b/OpenAPIService/OperationSearch.cs
@@ -30,6 +30,9 @@ namespace OpenAPIService
         {
             if (_predicate(operation))
             {
+                // Remove the operation description.
+                // This is temporary until some of the invalid/incorrect texts coming from the CSDL are fixed.
+                operation.Description = null;
                 _searchResults.Add(new SearchResult()
                 {
                     Operation = operation,

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -100,6 +100,10 @@ namespace OpenAPIService
             }
 
             operation.OperationId = operationId;
+
+            // Remove the operation description.
+            // This is temporarily until some of the invalid/incorrect texts coming from the CSDL are fixed.
+            operation.Description = null;
         }
 
         /// <summary>

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -100,10 +100,6 @@ namespace OpenAPIService
             }
 
             operation.OperationId = operationId;
-
-            // Remove the operation description.
-            // This is temporarily until some of the invalid/incorrect texts coming from the CSDL are fixed.
-            operation.Description = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/999

This PR:
- Removes operation descriptions from OpenAPI docs. This is temporary until we get a fix in the Api Doctor to resolve the incorrect/inaccurate descriptions in the metadata.
- Bumps the OpenAPI.NET.OData lib to the latest stable version -`v1.0.10`
- Adds a new OpenAPI convert setting, `ExpandDerivedTypesNavigationProperties = false`