### PR TITLE
Add PHP tag for syntax highlighting + Fix minor bug

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -251,4 +251,13 @@ public class PhpGeneratorTests
         var result = _generator.GenerateCodeSnippet(snippetModel);
         Assert.Contains("$requestBody->setAdditionalData($additionalData);", result);
     }
+
+    [Fact]
+    public async Task GenerateFluentApiPathCornerCase()
+    {
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/activities/recent");
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+        Assert.Contains("->me()->activities()->recent()->get()", result);
+    }
 }


### PR DESCRIPTION
## Overview

The current PHP snippets don't have PHP Syntax highlighting.

- Add PHP tag to beginning of snippet for GE syntax highlighting.
- Fix issue with handling endpoints with `()` leading to `()()` in generating snippet fluent path.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output