### PR TITLE
Added provision for mime contents on powershell snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -75,7 +75,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         /// <param name="snippetModel"></param>
         /// <param name="path"></param>
         /// <returns>true/false</returns>
-        private bool RequiresMIMEContentOutPut(SnippetModel snippetModel, string path)
+        private static bool RequiresMIMEContentOutPut(SnippetModel snippetModel, string path)
         {
             int lastIndex = path.LastIndexOf('/');
             var lastValue = path.Substring(lastIndex + 1);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -59,9 +59,30 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 var commandParameters = GetCommandParameters(snippetModel, payloadVarName);
                 if (!string.IsNullOrEmpty(commandParameters))
                     snippetBuilder.Append($"{commandParameters}");
+                if (RequiresMIMEContentOutPut(snippetModel,path))
+                {
+                    //Allows genration of an output file for MIME content of the message
+                    snippetBuilder.Append($" -OutFile $outFileId");
+                }
             }
             return snippetBuilder.ToString();
         }
+        /// <summary>
+        /// Checks if the path has an optional query parameter. e.g $value
+        /// The parameter can be used to get the mime content of a message
+        /// Mime content should be stored in a file, therefore powershell snippets will have '-OutFile $outFileId' appended at the end of the snipper body
+        /// </summary>
+        /// <param name="snippetModel"></param>
+        /// <param name="path"></param>
+        /// <returns>true/false</returns>
+        private bool RequiresMIMEContentOutPut(SnippetModel snippetModel, string path)
+        {
+            int lastIndex = path.LastIndexOf('/');
+            var lastValue = path.Substring(lastIndex + 1);
+            if (!lastValue.StartsWith("{") && snippetModel.Method == HttpMethod.Get) return true;
+            return false;
+        }
+
 
         private static string GetCommandParameters(SnippetModel snippetModel, string payloadVarName)
         {


### PR DESCRIPTION
## Overview

This PR fixes powershell snippet generation by including -OutFile parameter whenever HTTP snippets returns a stream response.  We make use of the optional query parameter $value as described [here](https://docs.microsoft.com/en-us/graph/api/message-get?view=graph-rest-1.0&tabs=http) to get the mime content of the message.
It addresses this [raptor issue](https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/1148) and partly addresses [this devx issue](https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1058)

### Demo
<img width="627" alt="image" src="https://user-images.githubusercontent.com/10947120/178956526-744e0694-0272-4e01-abd3-02e34a2bb6cc.png">