### PR TITLE
Remove environment variable for builds

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -42,16 +42,6 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
-- pwsh: |
-    # override build languag incase provided in pipeline
-    $buildLanguages = if ("$env:LANGUAGES") { "$env:LANGUAGES" } else { "$(snippetLanguages)" }
-    $branchPrefix = if ("$env:LANGUAGES") { "preview-snippet-generation" } else { "snippet-generation" }
-    Write-Host "##vso[task.setvariable variable=buildLanguages]$buildLanguages"
-    Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
-    Write-Host "Branch prefix is $branchPrefix"
-    Write-Host "Branch languages to generate are $buildLanguages"
-  displayName: 'Evaluate snippets to generate'
-
 - template: templates/git-config.yml
 
 - task: UseDotNet@2
@@ -92,7 +82,7 @@ steps:
     $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
-    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $env:BUILDLANGUAGES --git-path "/bin/git"
+    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"
   displayName: 'Generate snippets'
   workingDirectory: microsoft-graph-docs
 

--- a/pipelines/templates/git-config.yml
+++ b/pipelines/templates/git-config.yml
@@ -1,6 +1,6 @@
 steps:
 - pwsh: |
-    $branchName = "$env:BRANCHPREFIX/$env:BUILD_BUILDID" # Conditionally Match the spec in the GH Actions
+    $branchName = "snippet-generation/$env:BUILD_BUILDID" # Match the spec in the GH Action
     Write-Host "Branch path spec for the pull request will be $branchName"
     Write-Host "##vso[task.setvariable variable=branchName]$branchName"
   displayName: 'Calculate and set pipeline variables for this job'


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1059

Remove 'LANGUAGE' as an environment variable for build configuration. Environment variables are persisted beyond the scope of a single build