### PR TITLE
Fix issue of broken Regex slicing by tags

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -12,6 +12,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using UtilityService;
 using Xunit;
 
@@ -172,6 +173,7 @@ namespace OpenAPIService.Test
         [Theory]
         [InlineData(null, null, "/users?$filter=startswith(displayName,'John Doe')")]
         [InlineData(null, "users.user", null)]
+        [InlineData(null, "^users.user$", null)]
         [InlineData("users.user.ListUser", null, null)]
         public void ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
         {

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -183,7 +183,7 @@ namespace OpenAPIService
                 var tagsArray = tags.Split(',');
                 if (tagsArray.Length == 1)
                 {
-                    var regex = new Regex(Regex.Escape(tagsArray[0]));
+                    var regex = new Regex(tagsArray[0]);
 
                     predicate = (o) => o.Tags.Any(t => regex.IsMatch(t.Name));
                 }

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -24,11 +24,17 @@ resources:
 pool:
   vmImage: 'ubuntu-latest'
 
+
+parameters:
+  - name: snippetLanguages
+    default: 'C#,JavaScript,Java,Go,PowerShell,PHP'
+    displayName: 'Languages to generate snippets (comma separated list)'
+
 variables:
   buildConfiguration: 'Release'
   apidoctorPath: 'microsoft-graph-devx-api/apidoctor'
   apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
-  snippetLanguages: 'C#,JavaScript,Java,Go,PowerShell,PHP'
+  snippetLanguages: ${{ parameters.snippetLanguages }}
 
 steps:
 - checkout: self
@@ -43,14 +49,11 @@ steps:
   persistCredentials: true
 
 - pwsh: |
-    # override build languag incase provided in pipeline
-    $buildLanguages = if ("$env:LANGUAGES") { "$env:LANGUAGES" } else { "$(snippetLanguages)" }
-    $branchPrefix = if ("$env:LANGUAGES") { "preview-snippet-generation" } else { "snippet-generation" }
-    Write-Host "##vso[task.setvariable variable=buildLanguages]$buildLanguages"
+    # override branch prefix incase the run is manually triggered
+    $branchPrefix = if ($env:BUILD_REASON -eq 'Manual') { "preview-snippet-generation" } else { "snippet-generation" }
     Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
     Write-Host "Branch prefix is $branchPrefix"
-    Write-Host "Branch languages to generate are $buildLanguages"
-  displayName: 'Evaluate snippets to generate'
+  displayName: 'Evaluate branch prefix to use'
 
 - template: templates/git-config.yml
 
@@ -92,7 +95,7 @@ steps:
     $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
-    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $env:BUILDLANGUAGES --git-path "/bin/git"
+    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"
   displayName: 'Generate snippets'
   workingDirectory: microsoft-graph-docs
 


### PR DESCRIPTION
## Overview

Fixes #1082 

This PR:

* Fixes the broken OpenAPI regex slicing by removing the `Regex.Escape()` function. The `Regex.Escape()` function was flagged as a security vulnerability by SonarCloud so as to prevent malicious attacks via regex. However, using this approach breaks the regex matching engine and thus, a better way needs to be investigated for escaping malicious regex metacharacters.

* Updates the ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified test by adding a test case for a regex-formatted tag.