### PR TITLE
Implements thread locking in OpenApiService during OpenAPI conversion

### DIFF
--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -17,33 +17,33 @@
     "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml",
     "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml"
   },
-    "BlobStorage": {
-        "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",
-        "GithubHost": "https://raw.githubusercontent.com/",
-        "RepoName": "/microsoft-graph-devx-content/",
-        "Containers": {
-            "SampleQueries": "sample-queries",
-            "Permissions": "permissions",
-            "Changelog": "changelog",
-            "TourSteps": "ge-tour"
-        },
-        "Blobs": {
-            "SampleQueries": "sample-queries.json",
-            "Permissions": {
-                "Names": [
-                    "permissions-v1.0.json",
-                    "permissions-beta.json"
-                ],
-                "Descriptions": "permissions-descriptions.json"
-            },
-            "ChangeLog": {
-                "BaseUrl": "https://graphprodblobstorage.blob.core.windows.net/",
-                "RelativeUrl": "content/graph/{0}/json/changelog.json"
-            },
-            "WorkloadMapping": "workload-mapping.json",
-            "TourSteps": "tour-steps.json"
-        }
+  "BlobStorage": {
+    "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",
+    "GithubHost": "https://raw.githubusercontent.com/",
+    "RepoName": "/microsoft-graph-devx-content/",
+    "Containers": {
+      "SampleQueries": "sample-queries",
+      "Permissions": "permissions",
+      "Changelog": "changelog",
+      "TourSteps": "ge-tour"
     },
+    "Blobs": {
+      "SampleQueries": "sample-queries.json",
+      "Permissions": {
+        "Names": [
+          "permissions-v1.0.json",
+          "permissions-beta.json"
+        ],
+        "Descriptions": "permissions-descriptions.json"
+      },
+      "ChangeLog": {
+        "BaseUrl": "https://graphprodblobstorage.blob.core.windows.net/",
+        "RelativeUrl": "content/graph/{0}/json/changelog.json"
+      },
+      "WorkloadMapping": "workload-mapping.json",
+      "TourSteps": "tour-steps.json"
+    }
+  },
   "GraphProxy": {
     "BaseUrl": "https://graph.office.net/en-us/graph/api/proxy",
     "RelativeUrl": "?url=https://graph.microsoft.com/{0}{1}?$whatif",
@@ -54,6 +54,9 @@
     "SampleQueries": "24",
     "Permissions": "24",
     "ChangeLog": "24",
-    "TourSteps":  "24"
+    "TourSteps": "24"
+  },
+  "FileCacheRefreshTimeInMinutes": {
+    "OpenAPIDocuments": "10"
   }
 }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -1,7 +1,8 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -25,6 +26,15 @@ namespace OpenAPIService.Test
         {
             _openApiService = openApiService
                 ?? throw new ArgumentNullException(nameof(openApiService), $"{ NullValueError }: { nameof(openApiService) }");
+        }
+
+        public static IOpenApiService GetOpenApiService(string configFilePath)
+        {
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                                    .AddJsonFile(configFilePath)
+                                    .Build();
+
+            return new OpenApiService(configuration);
         }
 
         /// <summary>

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
@@ -31,8 +32,8 @@ namespace OpenAPIService.Test
         public static IOpenApiService GetOpenApiService(string configFilePath)
         {
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                                    .AddJsonFile(configFilePath)
-                                    .Build();
+                                                    .AddJsonFile(configFilePath)
+                                                    .Build();
 
             return new OpenApiService(configuration);
         }

--- a/OpenAPIService.Test/OpenAPIService.Test.csproj
+++ b/OpenAPIService.Test/OpenAPIService.Test.csproj
@@ -1,10 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="TestFiles\appsettingstest.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="TestFiles\appsettingstest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2">
@@ -15,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.3.1-preview5" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -25,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MockTestUtility\MockTestUtility.csproj" />
     <ProjectReference Include="..\OpenAPIService\OpenAPIService.csproj" />
     <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
   </ItemGroup>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -25,10 +25,11 @@ namespace OpenAPIService.Test
         private readonly OpenApiDocument _graphMockSource = null;
         private readonly IOpenApiService _openApiService;
         private readonly OpenApiDocumentCreatorMock _openAPIDocumentCreatorMock;
+        private static string ConfigFilePath => Path.Combine(Environment.CurrentDirectory, "TestFiles", "appsettingstest-valid.json");
 
         public OpenApiServiceShould()
         {
-            _openApiService = new OpenApiService();
+            _openApiService = OpenApiDocumentCreatorMock.GetOpenApiService(ConfigFilePath);
             _openAPIDocumentCreatorMock = new OpenApiDocumentCreatorMock(_openApiService);
 
             // Create OpenAPI document with default OpenApiStyle = Plain

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -12,7 +12,6 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using UtilityService;
 using Xunit;
 
@@ -25,7 +24,7 @@ namespace OpenAPIService.Test
         private readonly OpenApiDocument _graphMockSource = null;
         private readonly IOpenApiService _openApiService;
         private readonly OpenApiDocumentCreatorMock _openAPIDocumentCreatorMock;
-        private static string ConfigFilePath => Path.Combine(Environment.CurrentDirectory, "TestFiles", "appsettingstest-valid.json");
+        private static string ConfigFilePath => Path.Combine(Environment.CurrentDirectory, "TestFiles", "appsettingstest.json");
 
         public OpenApiServiceShould()
         {

--- a/OpenAPIService.Test/TestFiles/appsettingstest.json
+++ b/OpenAPIService.Test/TestFiles/appsettingstest.json
@@ -1,0 +1,5 @@
+{
+  "FileCacheRefreshTimeInMinutes": {
+    "OpenAPIDocuments": "10"
+  }
+}

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -5,12 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.1" />
     <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.11" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1-preview5" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FileService\FileService.csproj" />
     <ProjectReference Include="..\UriMatchService\UriMatchingService.csproj" />
     <ProjectReference Include="..\UtilityService\UtilityService.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1101
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1055
Potentially Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/851

This PR:
- Updates the OpenAPI conversion process by ensuring that only one thread converts an OpenAPI document. This will help prevent multiple processes trying to perform the conversion before the cache has been set. Having multiple requests attempting to perform the conversion increases both CPU and memory load.
- Introduces a _forceRefresh_ elapsed time (in minutes) check that will be used to determine the period in which `forceRefresh`  updates are allowed. This will help in mitigating potential DoS requests from either bad or legitimate actors. The current default value is 10 minutes. This value is configurable in the app service configuration settings.
