### PR TITLE
Fix: Allow two threads to convert the OpenAPI document asynchronously

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -553,7 +553,7 @@ namespace OpenAPIService
                                              _openApiTraceProperties);
                 _openApiTraceProperties.Remove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore);
 
-                OpenApiDocument source = await CreateOpenApiDocumentAsync(csdlHref);
+                OpenApiDocument source = CreateOpenApiDocumentAsync(csdlHref).GetAwaiter().GetResult();
                 _OpenApiDocuments[csdlHref] = source;
                 _OpenApiDocumentsDateCreated[csdlHref] = DateTime.UtcNow;
                 return source;


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1101
This PR:
- Allows only two threads to convert the OpenAPI document synchronously - provided they are converting different Graph versions of the OpenAPI.