### PR TITLE
[Fix] Safely exit all recursive threads and avoid blocking the thread lock when converting the OpenAPI doc.

### DIFF
--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -57,6 +57,6 @@
     "TourSteps": "24"
   },
   "FileCacheRefreshTimeInMinutes": {
-    "OpenAPIDocuments": "10"
+    "OpenAPIDocuments": "15"
   }
 }


### PR DESCRIPTION
This PR:

- Ensures we safely exit all recursive threads by using a `Queue` to store and remove the graph versions that are used to check whether a thread will be recursed back to await a lock. This `Queue` is dequeued at the `finally` block, so as to ensure this happens even at the event of an exception. This will help avoid blocking the release of the lock by the recursed threads.
- Increases the OpenAPI document default refresh time to 15 mins. Our Azure availability tests run every 15 mins. This is to keep it in line with our availability tests frequency.
