### PR TITLE
Replaces `System.IO.MemoryStream` with `Microsoft.IO.RecyclableMemoryStream` when converting OpenAPI documents

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -33,6 +33,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly IOpenApiService _openApiService;
+        private readonly RecyclableMemoryStreamManager _streamManager = new();
 
         public OpenApiController(IConfiguration configuration, IOpenApiService openApiService)
         {
@@ -129,8 +130,7 @@ namespace GraphWebApi.Controllers
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
-            var streamManager = new RecyclableMemoryStreamManager();
-            using var stream = streamManager.GetStream(nameof(OpenApiController));
+            using var stream = _streamManager.GetStream($"{nameof(OpenApiController)}.openapi_tree");
             _openApiService.ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
             return Content(Encoding.ASCII.GetString(stream.ToArray()), "application/json");
         }

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -5,6 +5,7 @@
 using GraphWebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.IO;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService;
@@ -128,7 +129,8 @@ namespace GraphWebApi.Controllers
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
-            using MemoryStream stream = new();
+            var streamManager = new RecyclableMemoryStreamManager();
+            using var stream = streamManager.GetStream(nameof(OpenApiController));
             _openApiService.ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
             return Content(Encoding.ASCII.GetString(stream.ToArray()), "application/json");
         }

--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.7" />
     <PackageReference Include="Serilog" Version="2.11.0" />

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -57,6 +57,6 @@
     "TourSteps": "24"
   },
   "FileCacheRefreshTimeInMinutes": {
-    "OpenAPIDocuments": "10"
+    "OpenAPIDocuments": "15"
   }
 }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -964,7 +964,7 @@ namespace OpenAPIService.Test
                 }
             };
 
-            return _openApiService.FixReferences(document);
+            return _openApiService.CloneOpenApiDocument(document);
         }
     }
 }

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -31,6 +31,6 @@ namespace OpenAPIService.Interfaces
 
         Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
 
-        OpenApiDocument FixReferences(OpenApiDocument document);
+        OpenApiDocument CloneOpenApiDocument(OpenApiDocument subsetOpenApiDocument);
     }
 }

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.1" />
     <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.11" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.1-preview5" />

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -18,7 +18,6 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
-using System.Text;
 using OpenAPIService.Common;
 using UtilityService;
 using Microsoft.ApplicationInsights.DataContracts;
@@ -32,8 +31,6 @@ using System.Threading;
 using Microsoft.Extensions.Configuration;
 using FileService.Common;
 using Microsoft.IO;
-using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi;
 
 namespace OpenAPIService
 {
@@ -57,7 +54,7 @@ namespace OpenAPIService
         private const string CacheRefreshTimeConfig = "FileCacheRefreshTimeInMinutes:OpenAPIDocuments";
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
-        private static readonly RecyclableMemoryStreamManager _streamManager = new ();
+        private static readonly RecyclableMemoryStreamManager _streamManager = new();
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)
         {


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1116

This PR:
- Replaces instances of `System.IO.MemoryStream` with `Microsoft.IO.RecyclableMemoryStream` in the conversion process of OpenAPI documents to help address the `System.OutOfMemoryException`.
- Replaces the `FixReferences` method with the already existing method `Clone` because they are functionally doing the same thing. This has been renamed to `CloneOpenApiDocument()`
