### PR TITLE
Fix/go snippet generation filter param

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -57,6 +57,24 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").Checkin().", result);
         }
         [Fact]
+        public async Task IgnoreOdataTypeWhenGenerating() {
+            var sampleJson = @"
+                {
+                ""@odata.type"": ""microsoft.graph.socialIdentityProvider"",
+                ""displayName"": ""Login with Amazon"",
+                ""identityProviderType"": ""Amazon"",
+                ""clientId"": ""56433757-cadd-4135-8431-2c9e3fd68ae8"",
+                ""clientSecret"": ""000000000000""
+                }
+            ";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/identity/identityProviders"){
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.DoesNotContain("@odata.type", result);
+        }
+        [Fact]
         public async Task GeneratesTheSnippetHeader() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -296,6 +296,16 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("SetIncludeUserActions", result);
         }
+        [Fact]
+        public async Task WriteCorrectTypesForFilterParameters()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get,
+                $"{ServiceRootBetaUrl}/identityGovernance/accessReviews/definitions?$top=100&$skip=0");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("requestTop := int32(100)", result);
+            Assert.Contains("requestSkip := int32(0)", result);
+        }
 
         /**
          

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -189,7 +189,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             }
             else
             {
-                builder.AppendLine($"{indentManager.GetIndent()}{requestBodyVarName} := graphmodels.New{codeGraph.Body.Name}()");
+                builder.AppendLine($"{indentManager.GetIndent()}{requestBodyVarName} := graphmodels.New{codeGraph.Body.Name.ToFirstCharacterUpperCase()}()");
                 WriteCodePropertyObject(requestBodyVarName, builder, codeGraph.Body, indentManager);
             }
         }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -120,7 +120,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var nonArrayParams = codeGraph.Parameters.Where(x => x.PropertyType != PropertyType.Array);
 
             if (nonArrayParams.Any())
-                builder.AppendLine("");
+                builder.AppendLine(string.Empty);
 
             foreach (var param in nonArrayParams)
             {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -10,7 +10,8 @@ using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 
-namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
+namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
+{
     public class GoGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
     {
         private const string clientVarName = "graphClient";
@@ -42,8 +43,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
 
             return snippetBuilder.ToString();
         }
-        
-        private static void writeSnippet(SnippetCodeGraph codeGraph, StringBuilder builder){
+
+        private static void writeSnippet(SnippetCodeGraph codeGraph, StringBuilder builder)
+        {
             writeHeadersAndOptions(codeGraph, builder);
             WriteBody(codeGraph, builder);
             builder.AppendLine("");
@@ -51,7 +53,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
             WriteExecutionStatement(
                 codeGraph,
                 builder,
-                codeGraph.HasHeaders() || codeGraph.HasOptions() || codeGraph.HasParameters() ,
+                codeGraph.HasHeaders() || codeGraph.HasOptions() || codeGraph.HasParameters(),
                 codeGraph.HasBody() ? requestBodyVarName : default,
                 codeGraph.HasHeaders() || codeGraph.HasOptions() || codeGraph.HasParameters() ? requestConfigurationVarName : default
             );
@@ -62,7 +64,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
             if (!codeGraph.HasHeaders() && !codeGraph.HasOptions() && !codeGraph.HasParameters()) return;
 
             var indentManager = new IndentManager();
-            
+
             WriteHeader(codeGraph, builder, indentManager);
             WriteOptions(codeGraph, builder, indentManager);
             WriteParameters(codeGraph, builder, indentManager);
@@ -71,13 +73,13 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
             builder.AppendLine($"{requestConfigurationVarName} := &{className}{{");
             indentManager.Indent();
 
-            if(codeGraph.HasHeaders())
+            if (codeGraph.HasHeaders())
                 builder.AppendLine($"{indentManager.GetIndent()}Headers: {requestHeadersVarName},");
 
-            if(codeGraph.HasOptions())
+            if (codeGraph.HasOptions())
                 builder.AppendLine($"{indentManager.GetIndent()}Options: {optionsParameterVarName},");
 
-            if(codeGraph.HasParameters())
+            if (codeGraph.HasParameters())
                 builder.AppendLine($"{indentManager.GetIndent()}QueryParameters: {requestParametersVarName},");
 
             indentManager.Unindent();
@@ -112,20 +114,46 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
         {
             if (!codeGraph.HasParameters()) return;
 
+            var nonArrayParams = codeGraph.Parameters.Where(x => x.PropertyType != PropertyType.Array);
+
+            if (nonArrayParams.Any())
+                builder.AppendLine("");
+
+            foreach (var param in nonArrayParams)
+            {
+                builder.AppendLine($"request{indentManager.GetIndent()}{NormalizeJsonName(param.Name).ToFirstCharacterUpperCase()} := {evaluateParameter(param)}");
+            }
+
+            if (nonArrayParams.Any())
+                builder.AppendLine("");
+
             var className = $"graphconfig.{codeGraph.Nodes.Last().GetClassName("RequestBuilder").ToFirstCharacterUpperCase()}{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}QueryParameters";
             builder.AppendLine($"{indentManager.GetIndent()}{requestParametersVarName} := &{className}{{");
             indentManager.Indent();
+
             foreach (var param in codeGraph.Parameters)
-                builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(param.Name).ToFirstCharacterUpperCase()}: {evaluateParameter(param)},");
+            {
+                if (param.PropertyType == PropertyType.Array)
+                {
+                    builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(param.Name).ToFirstCharacterUpperCase()}: {evaluateParameter(param)},");
+                }
+                else
+                {
+                    builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(param.Name).ToFirstCharacterUpperCase()}: &request{NormalizeJsonName(param.Name).ToFirstCharacterUpperCase()},");
+                }
+            }
             indentManager.Unindent();
             builder.AppendLine($"{indentManager.GetIndent()}}}");
         }
 
-        private static string evaluateParameter(CodeProperty param){
-            if(param.PropertyType == PropertyType.Array)
-                return $"[] string {{{string.Join(",", param.Children.Select(x =>  $"\"{x.Value}\"" ).ToList())}}}";
-            else if (param.PropertyType == PropertyType.Boolean || param.PropertyType == PropertyType.Int32)
+        private static string evaluateParameter(CodeProperty param)
+        {
+            if (param.PropertyType == PropertyType.Array)
+                return $"[] string {{{string.Join(",", param.Children.Select(x => $"\"{x.Value}\"").ToList())}}}";
+            else if (param.PropertyType == PropertyType.Boolean)
                 return param.Value;
+            else if (param.PropertyType == PropertyType.Int32)
+                return $"int32({param.Value})";
             else
                 return $"\"{param.Value.EscapeQuotes()}\"";
         }
@@ -140,10 +168,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
             var methodName = $"{codeGraph.HttpMethod.ToString().ToLower().ToFirstCharacterUpperCase()}{(hasOptions ? "WithRequestConfigurationAndResponseHandler" : "")}";
 
             var parametersList = GetActionParametersList(parameters);
-            if(hasOptions)
+            if (hasOptions)
                 parametersList += ", nil";
 
-            if(codeGraph.HasReturnedBody())
+            if (codeGraph.HasReturnedBody())
                 builder.AppendLine($"result, err := {clientVarName}.{GetFluentApiPath(codeGraph.Nodes)}{methodName}({parametersList})");
             else
                 builder.AppendLine($"{clientVarName}.{GetFluentApiPath(codeGraph.Nodes)}{methodName}({parametersList})");
@@ -173,7 +201,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
             else return string.Empty;
         }
 
-        private static void WriteArrayProperty(string propertyAssignment, string objectName, StringBuilder builder, CodeProperty parentProperty, CodeProperty codeProperty, IndentManager indentManager){
+        private static void WriteArrayProperty(string propertyAssignment, string objectName, StringBuilder builder, CodeProperty parentProperty, CodeProperty codeProperty, IndentManager indentManager)
+        {
             var contentBuilder = new StringBuilder();
             var propertyName = NormalizeJsonName(codeProperty.Name.ToFirstCharacterLowerCase());
 
@@ -182,31 +211,36 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
 
             indentManager.Indent();
             var childPosition = 0;
-            foreach (var child in codeProperty.Children){
-                if(child.PropertyType == PropertyType.Object){
-                    WriteCodeProperty(propertyAssignment, objectBuilder, codeProperty, child , indentManagerObjects, childPosition);
+            foreach (var child in codeProperty.Children)
+            {
+                if (child.PropertyType == PropertyType.Object)
+                {
+                    WriteCodeProperty(propertyAssignment, objectBuilder, codeProperty, child, indentManagerObjects, childPosition);
                     contentBuilder.AppendLine($"{indentManager.GetIndent()}{child.Name.ToFirstCharacterLowerCase()?.IndexSuffix(childPosition)},");
-                }else{
-                    WriteCodeProperty(propertyAssignment, contentBuilder, codeProperty, child , indentManager, childPosition);
+                }
+                else
+                {
+                    WriteCodeProperty(propertyAssignment, contentBuilder, codeProperty, child, indentManager, childPosition);
                 }
                 childPosition++;
             }
             indentManager.Unindent();
 
-            if(objectBuilder.Length > 0){
+            if (objectBuilder.Length > 0)
+            {
                 builder.AppendLine(Environment.NewLine);
                 builder.AppendLine(objectBuilder.ToString());
             }
-            
-            var typeName = NativeTypes.Contains(codeProperty.TypeDefinition?.ToLower()?.Trim()) ? codeProperty.TypeDefinition?.ToLower() : $"graphmodels.{codeProperty.TypeDefinition }able" ;
+
+            var typeName = NativeTypes.Contains(codeProperty.TypeDefinition?.ToLower()?.Trim()) ? codeProperty.TypeDefinition?.ToLower() : $"graphmodels.{codeProperty.TypeDefinition}able";
             builder.AppendLine($"{indentManager.GetIndent()}{propertyName} := []{typeName} {{");
             builder.AppendLine(contentBuilder.ToString());
             builder.AppendLine($"{indentManager.GetIndent()}}}");
-            if(parentProperty.PropertyType == PropertyType.Object)
+            if (parentProperty.PropertyType == PropertyType.Object)
                 builder.AppendLine($"{indentManager.GetIndent()}{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}({objectName})");
 
         }
-        
+
         private static void WriteCodeProperty(string propertyAssignment, StringBuilder builder, CodeProperty codeProperty, CodeProperty child, IndentManager indentManager, int childPosition = 0)
         {
             var isArray = codeProperty.PropertyType == PropertyType.Array;
@@ -266,7 +300,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
                 case PropertyType.Float32:
                 case PropertyType.Float64:
                 case PropertyType.Double:
-                    WriteNumericProperty(propertyAssignment,isMap, builder, indentManager, child);
+                    WriteNumericProperty(propertyAssignment, isMap, builder, indentManager, child);
                     break;
                 case PropertyType.Base64Url:
                     builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(child.Name.ToFirstCharacterLowerCase())} := []byte(\"{child.Value.ToFirstCharacterLowerCase()}\")");
@@ -278,8 +312,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
                     break;
             }
         }
-        private static void WriteStringProperty(string propertyAssignment, CodeProperty codeProperty, StringBuilder builder, IndentManager indentManager, CodeProperty child){
-            
+        private static void WriteStringProperty(string propertyAssignment, CodeProperty codeProperty, StringBuilder builder, IndentManager indentManager, CodeProperty child)
+        {
+
             var isArray = codeProperty.PropertyType == PropertyType.Array;
             var isMap = codeProperty.PropertyType == PropertyType.Map;
 
@@ -323,19 +358,22 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators {
         {
             var childPosition = 0;
             foreach (var child in codeProperty.Children)
-                WriteCodeProperty(propertyAssignment,builder,codeProperty,child,indentManager,childPosition++);
+                WriteCodeProperty(propertyAssignment, builder, codeProperty, child, indentManager, childPosition++);
         }
 
-        private static string GetFluentApiPath(IEnumerable<OpenApiUrlTreeNode> nodes){
+        private static string GetFluentApiPath(IEnumerable<OpenApiUrlTreeNode> nodes)
+        {
             if (!(nodes?.Any() ?? false)) return string.Empty;
-            return nodes.Select(x => {
+            return nodes.Select(x =>
+            {
                 if (x.Segment.IsCollectionIndex())
                     return $"ById{x.Segment.Replace("{", "(\"").Replace("}", "\")")}.";
                 else if (x.Segment.IsFunction())
                     return x.Segment.Split('.').Last().ToFirstCharacterUpperCase() + "().";
                 return x.Segment.ToFirstCharacterUpperCase() + "().";
             })
-                        .Aggregate((x, y) => {
+                        .Aggregate((x, y) =>
+                        {
                             return $"{x}{y}";
                         })
                         .Replace("().ById(", "ById(")

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -128,7 +128,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             }
 
             if (nonArrayParams.Any())
-                builder.AppendLine("");
+                builder.AppendLine(string.Empty);
 
             var className = $"graphconfig.{codeGraph.Nodes.Last().GetClassName("RequestBuilder").ToFirstCharacterUpperCase()}{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}QueryParameters";
             builder.AppendLine($"{indentManager.GetIndent()}{requestParametersVarName} := &{className}{{");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -23,6 +23,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private const string requestOptionsVarName = "options";
         private const string requestParametersVarName = "requestParameters";
         private const string requestConfigurationVarName = "configuration";
+        
+        private static IImmutableSet<string> specialProperties = ImmutableHashSet.Create("@odata.type");
+        
         private static IImmutableSet<string> NativeTypes = GetNativeTypes();
 
         static IImmutableSet<string> GetNativeTypes()
@@ -361,7 +364,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static void WriteCodePropertyObject(string propertyAssignment, StringBuilder builder, CodeProperty codeProperty, IndentManager indentManager)
         {
             var childPosition = 0;
-            foreach (var child in codeProperty.Children)
+            foreach (var child in codeProperty.Children.Where(x => !specialProperties.Contains(x.Name.Trim())))
                 WriteCodeProperty(propertyAssignment, builder, codeProperty, child, indentManager, childPosition++);
         }
 

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -21,8 +21,6 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
         private static readonly Regex splitCommasExcludingBracketsRegex = new(@"([^,\(\)]+(\(.*?\))*)+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex specialOdataPropertiesRegex = new(@"@+(.+)+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private static readonly CodeProperty EMPTY_PROPERTY = new() { Name = null, Value = null, Children = null, PropertyType = PropertyType.Default };
 
         private static Dictionary<string, PropertyType> _formatPropertyTypes = new (StringComparer.OrdinalIgnoreCase)
@@ -310,18 +308,8 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             return new CodeProperty { Name = propertyName, Value = propertyValue, PropertyType = propertyType, Children = new List<CodeProperty>() };
         }
 
-        private static string cleanPropertyName(string propertyName){
-            var match = specialOdataPropertiesRegex.Match(propertyName);
-            if(match.Success){
-                return string.Join("",match.Groups[1].Value.Split(".").Select(x => x.ToFirstCharacterUpperCase()));
-            }else{
-                return propertyName;
-            }
-        }
-
-        private static CodeProperty parseProperty(string propertyRawName, JsonElement value, OpenApiSchema propSchema)
+        private static CodeProperty parseProperty(string propertyName, JsonElement value, OpenApiSchema propSchema)
         {
-            var propertyName = cleanPropertyName(propertyRawName);
             switch (value.ValueKind)
             {
                 case JsonValueKind.String:

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -20,6 +20,8 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
         private static readonly Regex splitCommasExcludingBracketsRegex = new(@"([^,\(\)]+(\(.*?\))*)+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        private static readonly Regex specialOdataPropertiesRegex = new(@"@+(.+)+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static readonly CodeProperty EMPTY_PROPERTY = new() { Name = null, Value = null, Children = null, PropertyType = PropertyType.Default };
 
         public SnippetCodeGraph(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiUrlTreeNode treeNode) : this(new SnippetModel(requestPayload, serviceRootUrl, treeNode)) {}
@@ -297,8 +299,18 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             return new CodeProperty { Name = propertyName, Value = propertyValue, PropertyType = propertyType, Children = new List<CodeProperty>() };
         }
 
-        private static CodeProperty parseProperty(string propertyName, JsonElement value, OpenApiSchema propSchema)
+        private static string cleanPropertyName(string propertyName){
+            var match = specialOdataPropertiesRegex.Match(propertyName);
+            if(match.Success){
+                return string.Join("",match.Groups[1].Value.Split(".").Select(x => x.ToFirstCharacterUpperCase()));
+            }else{
+                return propertyName;
+            }
+        }
+
+        private static CodeProperty parseProperty(string propertyRawName, JsonElement value, OpenApiSchema propSchema)
         {
+            var propertyName = cleanPropertyName(propertyRawName);
             switch (value.ValueKind)
             {
                 case JsonValueKind.String:


### PR DESCRIPTION
## Overview

Fixes filter params

Example  https://docs.microsoft.com/en-us/graph/api/accessreviewset-list-definitions?view=graph-rest-1.0&tabs=go

```go

requestParameters := &graphconfig.DefinitionsRequestBuilderGetQueryParameters{
	Top: 100,
	Skip: 0,
}
configuration := &graphconfig.DefinitionsRequestBuilderGetRequestConfiguration{
	QueryParameters: requestParameters,
}

result, err := graphClient.IdentityGovernance().AccessReviews().Definitions().GetWithRequestConfigurationAndResponseHandler(configuration, nil)


```

Will be generated as 

```go

requestTop := int32(100)
requestSkip := int32(0)

requestParameters := &graphconfig.DefinitionsRequestBuilderGetQueryParameters{
	Top: &requestTop,
	Skip: &requestSkip,
}
configuration := &graphconfig.DefinitionsRequestBuilderGetRequestConfiguration{
	QueryParameters: requestParameters,
}

result, err := graphClient.IdentityGovernance().AccessReviews().Definitions().GetWithRequestConfigurationAndResponseHandler(configuration, nil)


```

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Add unit tests for the generation