### PR TITLE
Corrected wrong provision of mime contents generating an OutFile parameter on powershell snippets.

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -79,7 +79,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             int lastIndex = path.LastIndexOf('/');
             var lastValue = path.Substring(lastIndex + 1);
-            if (!lastValue.StartsWith("{") && snippetModel.Method == HttpMethod.Get) return true;
+            if (lastValue.Equals("$value") && snippetModel.Method == HttpMethod.Get) return true;
             return false;
         }
 


### PR DESCRIPTION

## Overview

This PR addresses this [issue](https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1135) whereby non-required ``-OutFile`` parameter is added. An example is on the screenshot below

<img width="580" alt="incorrect" src="https://user-images.githubusercontent.com/10947120/184102549-66101cfd-0abb-4bc8-8ba6-a84ebc1b8d82.png">

### Fix result (Does not contain optional query parameter ``$value``)


<img width="624" alt="correctone" src="https://user-images.githubusercontent.com/10947120/184102859-f7a25671-5da9-489b-82d9-0e0dc6ee4486.png">

### ### Fix result (Contains optional query parameter ``$value``)

<img width="620" alt="image" src="https://user-images.githubusercontent.com/10947120/184102937-e4747372-3513-416a-8067-74feca82e06b.png">

The use of optional query parameter is described [here](https://docs.microsoft.com/en-us/graph/api/message-get?view=graph-rest-1.0&tabs=http)