### PR TITLE
Improve performance and reduce memory usage of /openapi/tree

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -129,10 +129,12 @@ namespace GraphWebApi.Controllers
                 sources.TryAdd(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
             }
 
+            var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
+            
             Response.ContentType = "application/json";
             Response.StatusCode = 200;
             await Response.StartAsync();
-            var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
+            
             var writer = new Utf8JsonWriter(Response.BodyWriter, new JsonWriterOptions() { Indented = false });
             OpenApiService.ConvertOpenApiUrlTreeNodeToJson(writer, rootNode);
             await writer.FlushAsync();

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -18,6 +18,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using UtilityService;
 using Constants = OpenAPIService.Common.Constants;
@@ -97,7 +98,7 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi/tree")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery] string graphVersions = "*",
+        public async Task Get([FromQuery] string graphVersions = "*",
                                              [FromQuery] bool forceRefresh = false)
         {
             if (string.IsNullOrEmpty(graphVersions))
@@ -129,10 +130,13 @@ namespace GraphWebApi.Controllers
                 sources.TryAdd(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
             }
 
+            Response.ContentType = "application/json";
+            Response.StatusCode = 200;
+            await Response.StartAsync();
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
-            using var stream = _streamManager.GetStream($"{nameof(OpenApiController)}.openapi_tree");
-            _openApiService.ConvertOpenApiUrlTreeNodeToJson(rootNode, stream);
-            return Content(Encoding.ASCII.GetString(stream.ToArray()), "application/json");
+            var writer = new Utf8JsonWriter(Response.BodyWriter, new JsonWriterOptions() { Indented = false });
+            OpenApiService.ConvertOpenApiUrlTreeNodeToJson(writer, rootNode);
+            await writer.FlushAsync();
         }
 
         [Route("openapi")]

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -34,8 +34,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly IOpenApiService _openApiService;
-        private readonly RecyclableMemoryStreamManager _streamManager = new();
-
+ 
         public OpenApiController(IConfiguration configuration, IOpenApiService openApiService)
         {
             UtilityFunctions.CheckArgumentNull(openApiService, nameof(openApiService));

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -5,7 +5,6 @@
 using GraphWebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
-using Microsoft.IO;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using OpenAPIService;

--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.8" />
     <PackageReference Include="Serilog" Version="2.11.0" />

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -14,8 +14,8 @@
   },
   "AllowedHosts": "*",
   "GraphMetadata": {
-    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml",
-    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml"
+    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsAndErrorsv1.0.xml",
+    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsAndAnnotationsAndErrorsbeta.xml"
   },
   "BlobStorage": {
     "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -402,7 +402,7 @@ namespace OpenAPIService
         /// <param name="writer">An instance of the <see cref="Utf8JsonWriter"/> class that
         /// uses a specified stream to write the JSON output to.</param>
         /// <param name="rootNode">The target <see cref="OpenApiUrlTreeNode"/> object.</param>
-        private static void ConvertOpenApiUrlTreeNodeToJson(Utf8JsonWriter writer, OpenApiUrlTreeNode rootNode)
+        public static void ConvertOpenApiUrlTreeNodeToJson(Utf8JsonWriter writer, OpenApiUrlTreeNode rootNode)
         {
             writer.WriteStartObject();
             writer.WriteString("segment", rootNode.Segment);


### PR DESCRIPTION
## Overview

This PR changes the way the `/openapi/tree` action returns the response payload to minimize memory usage.

### Notes
This change takes advantage of the fact that the ASP.NET Response object provides access to a BodyWriter instance that can be passed to the constructor of Urtf8JsonWriter.  This enables the server to construct the JSON response and have it written directly to the network stream without having to have the entire document buffered in memory.

A further enhancement could be made to cache the entire UrlNodeTree rather than reconstructing on every request.

One downside to this approach is that if an exception occurs whilst writing the tree, the HTTP response will already have returned a 200 response.

## Testing Instructions

Calling `https://localhost:5001/openapi/tree?graphVersions=v1.0` from multiple concurrent threads shows reduced memory usage on the server and shorter time to first byte.