### PR TITLE
Update Exception middleware

### DIFF
--- a/GraphWebApi/Middleware/ExceptionMiddleware.cs
+++ b/GraphWebApi/Middleware/ExceptionMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -52,6 +52,7 @@ namespace GraphWebApi.Middleware
                 ArgumentNullException => StatusCodes.Status400BadRequest,
                 InvalidOperationException => StatusCodes.Status400BadRequest,
                 ArgumentException => StatusCodes.Status404NotFound,
+                EntryPointNotFoundException => StatusCodes.Status404NotFound,
                 Exception => StatusCodes.Status500InternalServerError
             };
 


### PR DESCRIPTION
Explicitly defines the status code of `EntryPointNotFound` exceptions as 404 as opposed to recording them as 500s

