### PR TITLE
Have OpenApiConvertSettings configurable for each style

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -66,7 +66,7 @@ namespace GraphWebApi.Controllers
                 throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
             }
 
-            var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
+            var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh);
             return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody);
         }
 
@@ -87,7 +87,7 @@ namespace GraphWebApi.Controllers
                 throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
             }
 
-            var graphOpenApi = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
+            var graphOpenApi = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh);
             await WriteIndex(Request.Scheme + "://" + Request.Host.Value, styleOptions.GraphVersion, styleOptions.OpenApiVersion, styleOptions.OpenApiFormat,
                 graphOpenApi, Response.Body, styleOptions.Style);
 
@@ -125,7 +125,7 @@ namespace GraphWebApi.Controllers
                     throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
-                sources.TryAdd(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh));
+                sources.TryAdd(graphVersion, await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, OpenApiStyle.Plain, forceRefresh));
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
@@ -155,7 +155,10 @@ namespace GraphWebApi.Controllers
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
-            var source = await _openApiService.ConvertCsdlToOpenApiAsync(Request.Body);
+            var openApiConvertSettings = _openApiService.GetOpenApiConvertSettings(style);
+
+            var source = await _openApiService.ConvertCsdlToOpenApiAsync(Request.Body, openApiConvertSettings);
+
             return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody);
         }
 

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -50,6 +50,18 @@
     "RequestUrl": "https://cdn.graph.office.net/en-us/graph/api/proxy/endpoint",
     "Authorization": "ENTER_BEARER_TOKEN"
   },
+  "OpenAPI": {
+    "ConvertSettings": {
+      "PowerShell": {
+        "ShowLinks":  false,
+        "DeclarePathParametersOnPathItem": true,
+        "EnableODataAnnotationReferencesForResponses": false
+      },
+      "GEAutocomplete": {
+        "ShowRootPath": true
+      }
+    }
+  },
   "FileCacheRefreshTimeInHours": {
     "SampleQueries": "24",
     "Permissions": "24",

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -625,6 +625,40 @@ namespace OpenAPIService.Test
             Assert.Equal("number", defaultPriceProperty.Type);
             Assert.Equal("double", defaultPriceProperty.Format);
         }
+
+        [Theory]
+        [InlineData(OpenApiStyle.GEAutocomplete)]
+        [InlineData(OpenApiStyle.PowerPlatform)]
+        [InlineData(OpenApiStyle.PowerShell)]
+        public void ReturnsCorrectOpenApiConvertSettingsForStyle(OpenApiStyle openApiStyle)
+        {
+            var defaultSettings = _openApiService.GetOpenApiConvertSettings();
+            
+            // Act
+            var styleSettings = _openApiService.GetOpenApiConvertSettings(openApiStyle);
+
+            // Assert
+            if (openApiStyle == OpenApiStyle.PowerShell)
+            {
+                Assert.NotEqual(defaultSettings.EnablePagination, styleSettings.EnablePagination);
+                Assert.Equal(defaultSettings.TagDepth, styleSettings.TagDepth);
+                Assert.Equal(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
+            }
+            else if (openApiStyle == OpenApiStyle.PowerPlatform)
+            {
+                Assert.NotEqual(defaultSettings.TagDepth, styleSettings.TagDepth);
+                Assert.Equal(defaultSettings.EnablePagination, styleSettings.EnablePagination);
+                Assert.Equal(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
+
+            }
+            else if (openApiStyle == OpenApiStyle.GEAutocomplete)
+            {
+                Assert.NotEqual(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
+                Assert.Equal(defaultSettings.EnablePagination, styleSettings.EnablePagination);
+                Assert.Equal(defaultSettings.TagDepth, styleSettings.TagDepth);
+            }
+        }
+
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)
         {
             Assert.NotNull(node);

--- a/OpenAPIService.Test/TestFiles/appsettingstest.json
+++ b/OpenAPIService.Test/TestFiles/appsettingstest.json
@@ -1,4 +1,20 @@
 {
+  "OpenAPI": {
+    "ConvertSettings": {
+      "PowerShell": {
+        "EnablePagination": false
+      },
+      "PowerPlatform": {
+        "TagDepth": 1
+      },
+      "Plain": {
+        "AddSingleQuotesForStringParameters": false
+      },
+      "GEAutocomplete": {
+        "ExpandDerivedTypesNavigationProperties": true
+      }
+    }
+  },
   "FileCacheRefreshTimeInMinutes": {
     "OpenAPIDocuments": "10"
   }

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData;
 using Microsoft.OpenApi.Services;
 using OpenAPIService.Common;
 using System;
@@ -21,7 +22,7 @@ namespace OpenAPIService.Interfaces
 
         MemoryStream SerializeOpenApiDocument(OpenApiDocument subset, OpenApiStyleOptions styleOptions);
 
-        Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh);
+        Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, OpenApiStyle openApiStyle, bool forceRefresh);
 
         OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(ConcurrentDictionary<string, OpenApiDocument> sources);
 
@@ -29,8 +30,10 @@ namespace OpenAPIService.Interfaces
 
         OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false);
 
-        Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl);
+        Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl, OpenApiConvertSettings settings);
 
         OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument);
+
+        OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain);
     }
 }

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.3" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />


### PR DESCRIPTION
## Overview
Closes #956
This PR:
- Reads convert settings specific to each Open API style e.g. PowerShell, PowerPlatform etc, from appsettings.json
- Apply settings when converting CSDL to Open API document

