### PR TITLE
Show operation descriptions in generated Open API document

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -561,7 +561,7 @@ namespace OpenAPIService.Test
         [InlineData(OpenApiStyle.PowerShell)]
         [InlineData(OpenApiStyle.Plain)]
         [InlineData(OpenApiStyle.GEAutocomplete)]
-        public void RemoveOperationDescriptionsInCreateFilteredDocument(OpenApiStyle style)
+        public void ShowOperationDescriptionsInCreateFilteredDocument(OpenApiStyle style)
         {
             // Arrange
             var predicate = _openApiService.CreatePredicate(operationIds: null,
@@ -580,7 +580,7 @@ namespace OpenAPIService.Test
                               .Description;
 
             // Assert
-            Assert.Null(description);
+            Assert.NotNull(description);
         }
 
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)

--- a/OpenAPIService/OperationSearch.cs
+++ b/OpenAPIService/OperationSearch.cs
@@ -30,9 +30,6 @@ namespace OpenAPIService
         {
             if (_predicate(operation))
             {
-                // Remove the operation description.
-                // This is temporary until some of the invalid/incorrect texts coming from the CSDL are fixed.
-                operation.Description = null;
                 _searchResults.Add(new SearchResult()
                 {
                     Operation = operation,


### PR DESCRIPTION
## Overview
Fixes #1126 

Removes code that was setting operation description to null.