### PR TITLE
Add regex match timeout

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -173,6 +173,7 @@ namespace OpenAPIService.Test
         [Theory]
         [InlineData(null, null, "/users?$filter=startswith(displayName,'John Doe')")]
         [InlineData(null, "users.user", null)]
+        [InlineData(null, "^users.user$", null)]
         [InlineData("users.user.ListUser", null, null)]
         public void ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
         {
@@ -200,19 +201,6 @@ namespace OpenAPIService.Test
             {
                 Assert.Single(subsetOpenApiDocument.Paths);
             }
-        }
-
-        [Fact]
-        public void ShouldFailWhenARegexIsPassedAsTag()
-        {
-            // Act
-            var predicate = _openApiService.CreatePredicate(operationIds: null, 
-                                                                                            tags: "^users.user$",
-                                                                                            url: null,
-                                                           source: _graphMockSource,
-                                                           graphVersion: GraphVersion);
-
-            Assert.Throws<ArgumentException>(() => _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate));
         }
 
         [Theory]

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -196,7 +196,8 @@ namespace OpenAPIService
                 var tagsArray = tags.Split(',');
                 if (tagsArray.Length == 1)
                 {
-                    var regex = new Regex(Regex.Escape(tagsArray[0]));
+                    // Specify timeout to prevent DOS. See https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices.
+                    var regex = new Regex(tagsArray[0], RegexOptions.None, TimeSpan.FromSeconds(1));
 
                     predicate = (o) => o.Tags.Any(t => regex.IsMatch(t.Name));
                 }


### PR DESCRIPTION
## Overview
This PR closes #1082 by adding a 1 second RegEx match timeout to prevent DOS from untrusted user input. Slicing the API by RegEx is needed since PowerShell uses a RegEx based config file to partition the API into modules. See https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/dev/config/ModulesMapping.jsonc.

### Notes
See .NET's recommendations at [Best practices for regular expressions in .NET](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices) and [Defining a ReGex match Time-Out Value](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex?view=net-6.0#defining-a-time-out-value).

## Testing Instructions
* `GET https://graphexplorerapi.azurewebsites.net/$openapi?tags=^groups.group$&title=Groups&openapiversion=3&style=Powershell&graphVersion=v1.0` should work.
* `GET https://graphexplorerapi.azurewebsites.net/$openapi?tags=^applications\.*|^servicePrincipals\.*&title=Applications&openapiversion=3&style=Powershell&graphVersion=v1.0` should work.