### PR TITLE
Adds requestBodies and other missing fields to the components object.

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -936,6 +936,34 @@ namespace OpenAPIService.Test
                                 }
                             }
                         }
+                    },
+                    ["/applications/{application-id}/owners/$ref"] = new OpenApiPathItem
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Post, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        new OpenApiTag()
+                                        {
+                                            Name = "applications.directoryObject"
+                                        }
+                                    },
+                                    OperationId = "applications.CreateRefOwners",
+                                    Summary = "Create new navigation property ref to owners for applications",
+                                    RequestBody = new OpenApiRequestBody
+                                    {
+                                        Reference = new OpenApiReference
+                                        {
+                                            Type = ReferenceType.RequestBody,
+                                            Id = "refPostBody"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 Components = new OpenApiComponents
@@ -955,6 +983,45 @@ namespace OpenAPIService.Test
                                             Type = "string",
                                             Description = "Description of the NIC (e.g. Ethernet adapter, Wireless LAN adapter Local Area Connection <#>, etc.).",
                                             Nullable = true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "ReferenceCreate", new OpenApiSchema
+                            {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>
+                                {
+                                    {
+                                        "@odata.id", new OpenApiSchema
+                                        {
+                                            Type = "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    RequestBodies = new Dictionary<string, OpenApiRequestBody>
+                    {
+                        {
+                            "refPostBody", new OpenApiRequestBody
+                            {
+                                Content = new Dictionary<string, OpenApiMediaType>
+                                {
+                                    {
+                                        "application/json", new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchema
+                                            {
+                                                Reference = new OpenApiReference
+                                                {
+                                                    Type = ReferenceType.Schema,
+                                                    Id = "ReferenceCreate"
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -275,9 +275,46 @@ namespace OpenAPIService.Test
                                                             }
                                                         }
                                                     }
+                                                },
+                                                Links = new Dictionary<string, OpenApiLink>
+                                                {
+                                                    {
+                                                        "link-1", new OpenApiLink
+                                                        {
+                                                            Reference = new OpenApiReference
+                                                            {
+                                                                Type = ReferenceType.Link,
+                                                                Id = "link-1"
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
+                                    },
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        new OpenApiParameter
+                                            {
+                                                Reference = new OpenApiReference
+                                                {
+                                                    Type = ReferenceType.Header,
+                                                    Id = "ConsistencyLevel"
+                                                },
+                                                Examples = new Dictionary<string, OpenApiExample>
+                                                {
+                                                    {
+                                                        "eventual-consistency-example", new OpenApiExample
+                                                        {
+                                                            Reference = new OpenApiReference
+                                                            {
+                                                                Type = ReferenceType.Example,
+                                                                Id = "eventual-consistency-example"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
                                     }
                                 }
                             }
@@ -917,7 +954,7 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
-                    ["/applications/{application-id}/createdOnBehalfOf/$ref"] = new OpenApiPathItem()
+                    ["/applications/{application-id}/createdOnBehalfOf/$ref"] = new OpenApiPathItem
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
@@ -932,7 +969,31 @@ namespace OpenAPIService.Test
                                         }
                                     },
                                     OperationId = "applications.GetRefCreatedOnBehalfOf",
-                                    Summary = "Get ref of createdOnBehalfOf from applications"
+                                    Summary = "Get ref of createdOnBehalfOf from applications",
+                                    Parameters = new List<OpenApiParameter>
+                                    {
+                                        new OpenApiParameter
+                                        {
+                                            Reference = new OpenApiReference
+                                            {
+                                                Type = ReferenceType.Parameter,
+                                                Id = "top"
+                                            }
+                                        }
+                                    },
+                                    Responses = new OpenApiResponses
+                                    {
+                                        {
+                                            "200", new OpenApiResponse
+                                            {
+                                                Reference = new OpenApiReference
+                                                {
+                                                    Type = ReferenceType.Response,
+                                                    Id = "StringCollectionResponse"
+                                                }
+                                            }
+                                        } 
+                                    }
                                 }
                             }
                         }
@@ -1002,6 +1063,25 @@ namespace OpenAPIService.Test
                                     }
                                 }
                             }
+                        },
+                        {
+                            "StringCollectionResponse", new OpenApiSchema
+                            {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>
+                                {
+                                    {
+                                        "value", new OpenApiSchema
+                                        {
+                                            Type = "array",
+                                            Items = new OpenApiSchema
+                                            {
+                                                Type = "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     RequestBodies = new Dictionary<string, OpenApiRequestBody>
@@ -1025,6 +1105,85 @@ namespace OpenAPIService.Test
                                         }
                                     }
                                 }
+                            }
+                        }
+                    },
+                    Parameters = new Dictionary<string, OpenApiParameter>
+                    {
+                        {
+                            "top", new OpenApiParameter
+                            {
+                                Name = "$top",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema
+                                {
+                                    Minimum = 0,
+                                    Type = "integer"
+                                }
+                            }
+                        }
+                    },
+                    Responses = new Dictionary<string, OpenApiResponse>
+                    {
+                        {
+                            "StringCollectionResponse", new OpenApiResponse
+                            {
+                                Content = new Dictionary<string, OpenApiMediaType>
+                                {
+                                    {
+                                        "application/json", new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchema
+                                            {
+                                                Reference = new OpenApiReference
+                                                {
+                                                    Type = ReferenceType.Schema,
+                                                    Id = "StringCollectionResponse"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Examples = new Dictionary<string, OpenApiExample>
+                    {
+                        {
+                            "eventual-consistency-example", new OpenApiExample
+                            {
+                                Summary = "ConsistencyLevel header",
+                                Description = "Set the ConsistencyLevel HTTP header to 'eventual'."
+                            }
+                        }
+                    },
+                    Headers = new Dictionary<string, OpenApiHeader>
+                    {
+                        {
+                            "ConsistencyLevel", new OpenApiHeader
+                            {
+                                Schema = new OpenApiSchema
+                                {
+                                    Type = "string"
+                                }
+                            }
+                        }
+                    },
+                    SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>
+                    {
+                        {
+                            "azureaadv2", new OpenApiSecurityScheme
+                            {
+                                Type = SecuritySchemeType.OAuth2
+                            }
+                        }
+                    },
+                    Links = new Dictionary<string, OpenApiLink>
+                    {
+                        {
+                            "link-1", new OpenApiLink
+                            {
+                                OperationId = "users.user.ListUser"
                             }
                         }
                     }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -571,6 +571,27 @@ namespace OpenAPIService.Test
             Assert.NotNull(description);
         }
 
+        [Fact]
+        public void HaveRequestBodyForPostRefOperations()
+        {
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: "/applications/{application-id}/owners/$ref",
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var requestBody = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
+                              .Operations[OperationType.Post]
+                              .RequestBody;
+
+            // Assert
+            Assert.Contains(requestBody.Reference.Id, subsetOpenApiDocument.Components.RequestBodies.Keys);
+        }
+
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)
         {
             Assert.NotNull(node);

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -363,7 +363,6 @@ namespace OpenAPIService.Test
             Assert.NotEmpty(subsetOpenApiDocument.Components.Parameters);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Responses);
             Assert.NotEmpty(subsetOpenApiDocument.Components.RequestBodies);
-            Assert.NotEmpty(subsetOpenApiDocument.Components.SecuritySchemes);
         }
 
         [Fact]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -358,7 +358,7 @@ namespace OpenAPIService.Test
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.Plain, subsetOpenApiDocument);
 
             // Assert
-            Assert.Equal(14, subsetOpenApiDocument.Paths.Count);
+            Assert.Equal(15, subsetOpenApiDocument.Paths.Count);
         }
 
         [Fact]

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -359,6 +359,11 @@ namespace OpenAPIService.Test
 
             // Assert
             Assert.Equal(15, subsetOpenApiDocument.Paths.Count);
+            Assert.NotEmpty(subsetOpenApiDocument.Components.Schemas);
+            Assert.NotEmpty(subsetOpenApiDocument.Components.Parameters);
+            Assert.NotEmpty(subsetOpenApiDocument.Components.Responses);
+            Assert.NotEmpty(subsetOpenApiDocument.Components.RequestBodies);
+            Assert.NotEmpty(subsetOpenApiDocument.Components.SecuritySchemes);
         }
 
         [Fact]
@@ -513,13 +518,16 @@ namespace OpenAPIService.Test
 
             var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
-            var operationId = subsetOpenApiDocument.Paths
+            var operation = subsetOpenApiDocument.Paths
                               .FirstOrDefault().Value
-                              .Operations[OperationType.Get]
-                              .OperationId;
+                              .Operations[OperationType.Get];
+            var topParameter = operation.Parameters.FirstOrDefault(p => p.Reference.Id == "top");
+            var successResponse = operation.Responses.FirstOrDefault(r => r.Key == "200");
 
             // Assert
-            Assert.Equal("applications_GetCreatedOnBehalfOfByRef", operationId);
+            Assert.Equal("applications_GetCreatedOnBehalfOfByRef", operation.OperationId);
+            Assert.Contains(topParameter.Reference.Id, subsetOpenApiDocument.Components.Parameters.Keys);
+            Assert.Contains(successResponse.Value.Reference.Id, subsetOpenApiDocument.Components.Responses.Keys);
         }
 
         [Fact]

--- a/OpenAPIService/CopyReferences.cs
+++ b/OpenAPIService/CopyReferences.cs
@@ -36,26 +36,6 @@ namespace OpenAPIService
                     CopyComponentsRequestBodyReference(requestBody);
                     break;
 
-                case OpenApiExample example:
-                    CopyComponentsExampleReference(example);
-                    break;
-
-                case OpenApiHeader header:
-                    CopyComponentsHeaderReference(header);
-                    break;
-
-                case OpenApiSecurityScheme securityScheme:
-                    CopyComponentsSecuritySchemeReference(securityScheme);
-                    break;
-
-                case OpenApiLink link:
-                    CopyComponentsLinkReference(link);
-                    break;
-
-                case OpenApiCallback callBack:
-                    CopyComponentsCallBackReference(callBack);
-                    break;
-
                 default:
                     break;
             }
@@ -85,51 +65,6 @@ namespace OpenAPIService
         private void EnsureSchemasExists()
         {
             target.Components.Schemas ??= new Dictionary<string, OpenApiSchema>();
-        }
-
-        private void CopyComponentsCallBackReference(OpenApiCallback callBack)
-        {
-            target.Components.Callbacks ??= new Dictionary<string, OpenApiCallback>();
-            if (!Components.Callbacks.ContainsKey(callBack.Reference.Id))
-            {
-                Components.Callbacks.Add(callBack.Reference.Id, callBack);
-            }
-        }
-
-        private void CopyComponentsLinkReference(OpenApiLink link)
-        {
-            target.Components.Links ??= new Dictionary<string, OpenApiLink>();
-            if (!Components.Links.ContainsKey(link.Reference.Id))
-            {
-                Components.Links.Add(link.Reference.Id, link);
-            }
-        }
-
-        private void CopyComponentsSecuritySchemeReference(OpenApiSecurityScheme securityScheme)
-        {
-            target.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
-            if (!Components.SecuritySchemes.ContainsKey(securityScheme.Reference.Id))
-            {
-                Components.SecuritySchemes.Add(securityScheme.Reference.Id, securityScheme);
-            }
-        }
-
-        private void CopyComponentsHeaderReference(OpenApiHeader header)
-        {
-            target.Components.Headers ??= new Dictionary<string, OpenApiHeader>();
-            if (!Components.Headers.ContainsKey(header.Reference.Id))
-            {
-                Components.Headers.Add(header.Reference.Id, header);
-            }
-        }
-
-        private void CopyComponentsExampleReference(OpenApiExample example)
-        {
-            target.Components.Examples ??= new Dictionary<string, OpenApiExample>();
-            if (!Components.Examples.ContainsKey(example.Reference.Id))
-            {
-                Components.Examples.Add(example.Reference.Id, example);
-            }
         }
 
         private void CopyComponentsRequestBodyReference(OpenApiRequestBody requestBody)

--- a/OpenAPIService/CopyReferences.cs
+++ b/OpenAPIService/CopyReferences.cs
@@ -46,6 +46,60 @@ namespace OpenAPIService
                     }
                     break;
 
+                case OpenApiRequestBody requestBody:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.RequestBodies.ContainsKey(requestBody.Reference.Id))
+                    {
+                        Components.RequestBodies.Add(requestBody.Reference.Id, requestBody);
+                    }
+                    break;
+
+                case OpenApiExample example:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.Examples.ContainsKey(example.Reference.Id))
+                    {
+                        Components.Examples.Add(example.Reference.Id, example);
+                    }
+                    break;
+
+                case OpenApiHeader header:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.Headers.ContainsKey(header.Reference.Id))
+                    {
+                        Components.Headers.Add(header.Reference.Id, header);
+                    }
+                    break;
+
+                case OpenApiSecurityScheme securityScheme:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.SecuritySchemes.ContainsKey(securityScheme.Reference.Id))
+                    {
+                        Components.SecuritySchemes.Add(securityScheme.Reference.Id, securityScheme);
+                    }
+                    break;
+
+                case OpenApiLink link:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.Links.ContainsKey(link.Reference.Id))
+                    {
+                        Components.Links.Add(link.Reference.Id, link);
+                    }
+                    break;
+
+                case OpenApiCallback callBack:
+                    EnsureComponentsExists();
+                    EnsureResponsesExists();
+                    if (!Components.Callbacks.ContainsKey(callBack.Reference.Id))
+                    {
+                        Components.Callbacks.Add(callBack.Reference.Id, callBack);
+                    }
+                    break;
+
                 default:
                     break;
             }

--- a/OpenAPIService/CopyReferences.cs
+++ b/OpenAPIService/CopyReferences.cs
@@ -17,87 +17,43 @@ namespace OpenAPIService
 
         public override void Visit(IOpenApiReferenceable referenceable)
         {
+            EnsureComponentsExists();
             switch (referenceable)
             {
                 case OpenApiSchema schema:
-                    EnsureComponentsExists();
-                    EnsureSchemasExists();
-                    if (!Components.Schemas.ContainsKey(schema.Reference.Id))
-                    {
-                        Components.Schemas.Add(schema.Reference.Id, schema);
-                    }
+                    CopyComponentsSchemaReference(schema);
                     break;
 
                 case OpenApiParameter parameter:
-                    EnsureComponentsExists();
-                    EnsureParametersExists();
-                    if (!Components.Parameters.ContainsKey(parameter.Reference.Id))
-                    {
-                        Components.Parameters.Add(parameter.Reference.Id, parameter);
-                    }
+                    CopyComponentsParameterReference(parameter);
                     break;
 
                 case OpenApiResponse response:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.Responses.ContainsKey(response.Reference.Id))
-                    {
-                        Components.Responses.Add(response.Reference.Id, response);
-                    }
+                    CopyComponentsResponseReference(response);
                     break;
 
                 case OpenApiRequestBody requestBody:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.RequestBodies.ContainsKey(requestBody.Reference.Id))
-                    {
-                        Components.RequestBodies.Add(requestBody.Reference.Id, requestBody);
-                    }
+                    CopyComponentsRequestBodyReference(requestBody);
                     break;
 
                 case OpenApiExample example:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.Examples.ContainsKey(example.Reference.Id))
-                    {
-                        Components.Examples.Add(example.Reference.Id, example);
-                    }
+                    CopyComponentsExampleReference(example);
                     break;
 
                 case OpenApiHeader header:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.Headers.ContainsKey(header.Reference.Id))
-                    {
-                        Components.Headers.Add(header.Reference.Id, header);
-                    }
+                    CopyComponentsHeaderReference(header);
                     break;
 
                 case OpenApiSecurityScheme securityScheme:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.SecuritySchemes.ContainsKey(securityScheme.Reference.Id))
-                    {
-                        Components.SecuritySchemes.Add(securityScheme.Reference.Id, securityScheme);
-                    }
+                    CopyComponentsSecuritySchemeReference(securityScheme);
                     break;
 
                 case OpenApiLink link:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.Links.ContainsKey(link.Reference.Id))
-                    {
-                        Components.Links.Add(link.Reference.Id, link);
-                    }
+                    CopyComponentsLinkReference(link);
                     break;
 
                 case OpenApiCallback callBack:
-                    EnsureComponentsExists();
-                    EnsureResponsesExists();
-                    if (!Components.Callbacks.ContainsKey(callBack.Reference.Id))
-                    {
-                        Components.Callbacks.Add(callBack.Reference.Id, callBack);
-                    }
+                    CopyComponentsCallBackReference(callBack);
                     break;
 
                 default:
@@ -115,7 +71,7 @@ namespace OpenAPIService
                 EnsureSchemasExists();
                 if (!Components.Schemas.ContainsKey(schema.Reference.Id))
                 {
-                    Components.Schemas.Add(schema.Reference.Id, schema); 
+                    Components.Schemas.Add(schema.Reference.Id, schema);
                 }
             }
             base.Visit(schema);
@@ -123,33 +79,92 @@ namespace OpenAPIService
 
         private void EnsureComponentsExists()
         {
-            if (target.Components == null)
-            {
-                target.Components = new OpenApiComponents();
-            }
+            target.Components ??= new OpenApiComponents();
         }
 
         private void EnsureSchemasExists()
         {
-            if (target.Components.Schemas == null)
+            target.Components.Schemas ??= new Dictionary<string, OpenApiSchema>();
+        }
+
+        private void CopyComponentsCallBackReference(OpenApiCallback callBack)
+        {
+            target.Components.Callbacks ??= new Dictionary<string, OpenApiCallback>();
+            if (!Components.Callbacks.ContainsKey(callBack.Reference.Id))
             {
-                target.Components.Schemas = new Dictionary<string, OpenApiSchema>();
+                Components.Callbacks.Add(callBack.Reference.Id, callBack);
             }
         }
 
-        private void EnsureParametersExists()
+        private void CopyComponentsLinkReference(OpenApiLink link)
         {
-            if (target.Components.Parameters == null)
+            target.Components.Links ??= new Dictionary<string, OpenApiLink>();
+            if (!Components.Links.ContainsKey(link.Reference.Id))
             {
-                target.Components.Parameters = new Dictionary<string, OpenApiParameter>();
+                Components.Links.Add(link.Reference.Id, link);
             }
         }
 
-        private void EnsureResponsesExists()
+        private void CopyComponentsSecuritySchemeReference(OpenApiSecurityScheme securityScheme)
         {
-            if (target.Components.Responses == null)
+            target.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
+            if (!Components.SecuritySchemes.ContainsKey(securityScheme.Reference.Id))
             {
-                target.Components.Responses = new Dictionary<string, OpenApiResponse>();
+                Components.SecuritySchemes.Add(securityScheme.Reference.Id, securityScheme);
+            }
+        }
+
+        private void CopyComponentsHeaderReference(OpenApiHeader header)
+        {
+            target.Components.Headers ??= new Dictionary<string, OpenApiHeader>();
+            if (!Components.Headers.ContainsKey(header.Reference.Id))
+            {
+                Components.Headers.Add(header.Reference.Id, header);
+            }
+        }
+
+        private void CopyComponentsExampleReference(OpenApiExample example)
+        {
+            target.Components.Examples ??= new Dictionary<string, OpenApiExample>();
+            if (!Components.Examples.ContainsKey(example.Reference.Id))
+            {
+                Components.Examples.Add(example.Reference.Id, example);
+            }
+        }
+
+        private void CopyComponentsRequestBodyReference(OpenApiRequestBody requestBody)
+        {
+            target.Components.RequestBodies ??= new Dictionary<string, OpenApiRequestBody>();
+            if (!Components.RequestBodies.ContainsKey(requestBody.Reference.Id))
+            {
+                Components.RequestBodies.Add(requestBody.Reference.Id, requestBody);
+            }
+        }
+
+        private void CopyComponentsResponseReference(OpenApiResponse response)
+        {
+            target.Components.Responses ??= new Dictionary<string, OpenApiResponse>();
+            if (!Components.Responses.ContainsKey(response.Reference.Id))
+            {
+                Components.Responses.Add(response.Reference.Id, response);
+            }
+        }
+
+        private void CopyComponentsParameterReference(OpenApiParameter parameter)
+        {
+            target.Components.Parameters ??= new Dictionary<string, OpenApiParameter>();
+            if (!Components.Parameters.ContainsKey(parameter.Reference.Id))
+            {
+                Components.Parameters.Add(parameter.Reference.Id, parameter);
+            }
+        }
+
+        private void CopyComponentsSchemaReference(OpenApiSchema schema)
+        {
+            EnsureSchemasExists();
+            if (!Components.Schemas.ContainsKey(schema.Reference.Id))
+            {
+                Components.Schemas.Add(schema.Reference.Id, schema);
             }
         }
     }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -774,6 +774,20 @@ namespace OpenAPIService
         private static bool AddReferences(OpenApiComponents newComponents, OpenApiComponents target)
         {
             var moreStuff = false;
+            moreStuff = AddComponentsSchemas(newComponents, target, moreStuff);
+            moreStuff = AddComponentsParameters(newComponents, target, moreStuff);
+            moreStuff = AddComponentsResponses(newComponents, target, moreStuff);
+            moreStuff = AddComponentsRequestBodies(newComponents, target, moreStuff);
+            moreStuff = AddComponentsExamples(newComponents, target, moreStuff);
+            moreStuff = AddComponentsHeaders(newComponents, target, moreStuff);
+            moreStuff = AddComponentsSecuritySchemes(newComponents, target, moreStuff);
+            moreStuff = AddComponentsLinks(newComponents, target, moreStuff);
+            moreStuff = AddComponentsCallBacks(newComponents, target, moreStuff);
+            return moreStuff;
+        }
+
+        private static bool AddComponentsSchemas(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Schemas)
             {
                 if (!target.Schemas.ContainsKey(item.Key))
@@ -783,6 +797,11 @@ namespace OpenAPIService
                 }
             }
 
+            return moreStuff;
+        }
+
+        private static bool AddComponentsParameters(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Parameters)
             {
                 if (!target.Parameters.ContainsKey(item.Key))
@@ -791,7 +810,11 @@ namespace OpenAPIService
                     target.Parameters.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsResponses(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Responses)
             {
                 if (!target.Responses.ContainsKey(item.Key))
@@ -800,7 +823,11 @@ namespace OpenAPIService
                     target.Responses.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsRequestBodies(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.RequestBodies)
             {
                 if (!target.RequestBodies.ContainsKey(item.Key))
@@ -809,7 +836,11 @@ namespace OpenAPIService
                     target.RequestBodies.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsExamples(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Examples)
             {
                 if (!target.Examples.ContainsKey(item.Key))
@@ -818,7 +849,11 @@ namespace OpenAPIService
                     target.Examples.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsHeaders(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Headers)
             {
                 if (!target.Headers.ContainsKey(item.Key))
@@ -827,7 +862,11 @@ namespace OpenAPIService
                     target.Headers.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsSecuritySchemes(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.SecuritySchemes)
             {
                 if (!target.SecuritySchemes.ContainsKey(item.Key))
@@ -836,7 +875,11 @@ namespace OpenAPIService
                     target.SecuritySchemes.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsLinks(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Links)
             {
                 if (!target.Links.ContainsKey(item.Key))
@@ -845,7 +888,11 @@ namespace OpenAPIService
                     target.Links.Add(item);
                 }
             }
+            return moreStuff;
+        }
 
+        private static bool AddComponentsCallBacks(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        {
             foreach (var item in newComponents.Callbacks)
             {
                 if (!target.Callbacks.ContainsKey(item.Key))

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -774,15 +774,16 @@ namespace OpenAPIService
         private static bool AddReferences(OpenApiComponents newComponents, OpenApiComponents target)
         {
             var moreStuff = false;
-            moreStuff = AddComponentsSchemas(newComponents, target, moreStuff);
-            moreStuff = AddComponentsParameters(newComponents, target, moreStuff);
-            moreStuff = AddComponentsResponses(newComponents, target, moreStuff);
-            moreStuff = AddComponentsRequestBodies(newComponents, target, moreStuff);
+            moreStuff |= AddComponentsSchemas(newComponents, target);
+            moreStuff |= AddComponentsParameters(newComponents, target);
+            moreStuff |= AddComponentsResponses(newComponents, target);
+            moreStuff |= AddComponentsRequestBodies(newComponents, target);
             return moreStuff;
         }
 
-        private static bool AddComponentsSchemas(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        private static bool AddComponentsSchemas(OpenApiComponents newComponents, OpenApiComponents target)
         {
+            bool moreStuff = false;
             foreach (var item in newComponents.Schemas)
             {
                 if (!target.Schemas.ContainsKey(item.Key))
@@ -791,12 +792,12 @@ namespace OpenAPIService
                     target.Schemas.Add(item);
                 }
             }
-
             return moreStuff;
         }
 
-        private static bool AddComponentsParameters(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        private static bool AddComponentsParameters(OpenApiComponents newComponents, OpenApiComponents target)
         {
+            bool moreStuff = false;
             foreach (var item in newComponents.Parameters)
             {
                 if (!target.Parameters.ContainsKey(item.Key))
@@ -808,8 +809,9 @@ namespace OpenAPIService
             return moreStuff;
         }
 
-        private static bool AddComponentsResponses(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        private static bool AddComponentsResponses(OpenApiComponents newComponents, OpenApiComponents target)
         {
+            bool moreStuff = false;
             foreach (var item in newComponents.Responses)
             {
                 if (!target.Responses.ContainsKey(item.Key))
@@ -821,8 +823,9 @@ namespace OpenAPIService
             return moreStuff;
         }
 
-        private static bool AddComponentsRequestBodies(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
+        private static bool AddComponentsRequestBodies(OpenApiComponents newComponents, OpenApiComponents target)
         {
+            bool moreStuff = false;
             foreach (var item in newComponents.RequestBodies)
             {
                 if (!target.RequestBodies.ContainsKey(item.Key))

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -778,11 +778,6 @@ namespace OpenAPIService
             moreStuff = AddComponentsParameters(newComponents, target, moreStuff);
             moreStuff = AddComponentsResponses(newComponents, target, moreStuff);
             moreStuff = AddComponentsRequestBodies(newComponents, target, moreStuff);
-            moreStuff = AddComponentsExamples(newComponents, target, moreStuff);
-            moreStuff = AddComponentsHeaders(newComponents, target, moreStuff);
-            moreStuff = AddComponentsSecuritySchemes(newComponents, target, moreStuff);
-            moreStuff = AddComponentsLinks(newComponents, target, moreStuff);
-            moreStuff = AddComponentsCallBacks(newComponents, target, moreStuff);
             return moreStuff;
         }
 
@@ -834,71 +829,6 @@ namespace OpenAPIService
                 {
                     moreStuff = true;
                     target.RequestBodies.Add(item);
-                }
-            }
-            return moreStuff;
-        }
-
-        private static bool AddComponentsExamples(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
-        {
-            foreach (var item in newComponents.Examples)
-            {
-                if (!target.Examples.ContainsKey(item.Key))
-                {
-                    moreStuff = true;
-                    target.Examples.Add(item);
-                }
-            }
-            return moreStuff;
-        }
-
-        private static bool AddComponentsHeaders(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
-        {
-            foreach (var item in newComponents.Headers)
-            {
-                if (!target.Headers.ContainsKey(item.Key))
-                {
-                    moreStuff = true;
-                    target.Headers.Add(item);
-                }
-            }
-            return moreStuff;
-        }
-
-        private static bool AddComponentsSecuritySchemes(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
-        {
-            foreach (var item in newComponents.SecuritySchemes)
-            {
-                if (!target.SecuritySchemes.ContainsKey(item.Key))
-                {
-                    moreStuff = true;
-                    target.SecuritySchemes.Add(item);
-                }
-            }
-            return moreStuff;
-        }
-
-        private static bool AddComponentsLinks(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
-        {
-            foreach (var item in newComponents.Links)
-            {
-                if (!target.Links.ContainsKey(item.Key))
-                {
-                    moreStuff = true;
-                    target.Links.Add(item);
-                }
-            }
-            return moreStuff;
-        }
-
-        private static bool AddComponentsCallBacks(OpenApiComponents newComponents, OpenApiComponents target, bool moreStuff)
-        {
-            foreach (var item in newComponents.Callbacks)
-            {
-                if (!target.Callbacks.ContainsKey(item.Key))
-                {
-                    moreStuff = true;
-                    target.Callbacks.Add(item);
                 }
             }
             return moreStuff;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -800,6 +800,60 @@ namespace OpenAPIService
                     target.Responses.Add(item);
                 }
             }
+
+            foreach (var item in newComponents.RequestBodies)
+            {
+                if (!target.RequestBodies.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.RequestBodies.Add(item);
+                }
+            }
+
+            foreach (var item in newComponents.Examples)
+            {
+                if (!target.Examples.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.Examples.Add(item);
+                }
+            }
+
+            foreach (var item in newComponents.Headers)
+            {
+                if (!target.Headers.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.Headers.Add(item);
+                }
+            }
+
+            foreach (var item in newComponents.SecuritySchemes)
+            {
+                if (!target.SecuritySchemes.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.SecuritySchemes.Add(item);
+                }
+            }
+
+            foreach (var item in newComponents.Links)
+            {
+                if (!target.Links.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.Links.Add(item);
+                }
+            }
+
+            foreach (var item in newComponents.Callbacks)
+            {
+                if (!target.Callbacks.ContainsKey(item.Key))
+                {
+                    moreStuff = true;
+                    target.Callbacks.Add(item);
+                }
+            }
             return moreStuff;
         }
 

--- a/OpenAPIService/OperationSearch.cs
+++ b/OpenAPIService/OperationSearch.cs
@@ -49,7 +49,7 @@ namespace OpenAPIService
              * as used in Microsoft Graph implement explode: false
              * ex: $select=id,displayName,givenName
              */
-            foreach (var parameter in parameters.Where(x => x.Style == ParameterStyle.Form))
+            foreach (var parameter in parameters.Where(x => x?.Style == ParameterStyle.Form))
             {
                 parameter.Explode = false;
             }


### PR DESCRIPTION
## Overview

This PR fixes #1160 by:
- Ensuring we copy references of all `Components` object fields to the sliced OpenAPI document. See https://swagger.io/specification/#components-object.
- Updates unit tests to reflect the change above.