### PR TITLE
[Snippet Generation] Csharp openAPI generation fixes

### DIFF
--- a/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
@@ -1379,5 +1379,25 @@ namespace CodeSnippetsReflection.Test
             Assert.Contains(queryOptions, result);
             Assert.Contains(skipParameter, result);
         }
+        
+        [Fact]
+        public void ShouldUseGeneratedSearchQueryOptions()
+        {
+            // Arrange
+            var expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,"https://graph.microsoft.com/v1.0/users?$search=\"displayName:wa\"&$orderby=displayName&$count=true");
+            requestPayload.Headers.Add("ConsistencyLevel","eventual");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel.Value);
+            // Act
+            var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
+            // Assert
+            var countParameter = "new QueryOption(\"$count\", \"true\")";  // the count query option
+            var searchParameter = "new QueryOption(\"$search\", \"\\\"displayName:wa\\\"\")";  // the search query option
+            var queryOptions = ".Request( queryOptions )";  // Adds the custom query options
+            Assert.Contains(countParameter, result);
+            Assert.Contains(searchParameter, result);
+            Assert.Contains(queryOptions, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.OData.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CommonGeneratorShould.cs
@@ -195,7 +195,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\r\n\t.Search(\"Irene McGowen\")", result);
+            Assert.Equal(string.Empty, result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection.OData.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/JavaGeneratorShould.cs
@@ -1129,5 +1129,22 @@ namespace CodeSnippetsReflection.Test
             var result = new JavaGenerator(_edmModel).GenerateCodeSnippet(snippetModel, expressions);
             Assert.Contains("UserGetMailTipsParameterSet", result);
         }
+        [Fact]
+        public void ShouldUseGeneratedSearchQueryOptions()
+        {
+            // Arrange
+            var expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,"https://graph.microsoft.com/v1.0/users?$search=\"displayName:wa\"&$orderby=displayName&$count=true");
+            requestPayload.Headers.Add("ConsistencyLevel","eventual");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            // Act
+            var result = new JavaGenerator(_edmModel).GenerateCodeSnippet(snippetModel, expressions);
+            // Assert
+            var searchParameter = "new QueryOption(\"$search\", \"\\\"displayName:wa\\\"\")";  // the search query option
+            var queryOptions = ".buildRequest( requestOptions )";  // Adds the custom query options
+            Assert.Contains(searchParameter, result);
+            Assert.Contains(queryOptions, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/CSharpGenerator.cs
@@ -900,6 +900,12 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
                 stringBuilder.Append($"\tnew QueryOption(\"$count\", \"{snippetModel.ODataUri.QueryCount.Value.ToString().ToLower()}\"),\r\n");
             }
 
+            //Append any $search present
+            if (!string.IsNullOrEmpty(snippetModel.SearchExpression))
+            {
+                stringBuilder.Append($"\tnew QueryOption(\"$search\", \"\\\"{snippetModel.SearchExpression}\\\"\"),\r\n");
+            }
+
             stringBuilder.Remove(stringBuilder.Length - 3, 1);//remove the trailing comma
             stringBuilder.Append("};\r\n\r\n");//closing brace
             //return custom query options section
@@ -914,8 +920,9 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
         {
             if (!snippetModel.CustomQueryOptions.Any()
                 && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken)
-                && !snippetModel.ODataUri.QueryCount.HasValue)
-                    return false;
+                && !snippetModel.ODataUri.QueryCount.HasValue
+                && string.IsNullOrEmpty(snippetModel.SearchExpression))
+                return false;
 
             return true;
         }
@@ -972,7 +979,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
     internal class CSharpExpressions : LanguageExpressions
     {
         public override string FilterExpression => "\r\n\t.Filter(\"{0}\")";
-        public override string SearchExpression => "\r\n\t.Search(\"{0}\")";
+        public override string SearchExpression => string.Empty;
         public override string ExpandExpression => "\r\n\t.Expand(\"{0}\")";
         public override string SelectExpression => "\r\n\t.Select(\"{0}\")";
         public override string OrderByExpression => "\r\n\t.OrderBy(\"{0}\")";

--- a/CodeSnippetsReflection.OData/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection.OData/LanguageGenerators/JavaGenerator.cs
@@ -689,7 +689,7 @@ namespace CodeSnippetsReflection.OData.LanguageGenerators
             //Append any search queries
             if (!string.IsNullOrEmpty(snippetModel.SearchExpression))
             {
-                stringBuilder.Append(string.Format(requestOptionsPattern, "$search", snippetModel.SearchExpression));
+                stringBuilder.Append(string.Format(requestOptionsPattern, "$search", $"\\\"{snippetModel.SearchExpression}\\\""));
             }
 
             //return request options section with a new line appended

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/CodeProperty.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/CodeProperty.cs
@@ -2,4 +2,4 @@
 
 namespace CodeSnippetsReflection.OpenAPI.ModelGraph;
 
-public record struct CodeProperty(string Name, string Value, List<CodeProperty> Children, PropertyType PropertyType = PropertyType.String, string TypeDefinition = null);
+public record struct CodeProperty(string Name, string Value, List<CodeProperty> Children, PropertyType PropertyType = PropertyType.String, string TypeDefinition = null, string NamespaceName = null);

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Web;
 using CodeSnippetsReflection.StringExtensions;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 
@@ -37,23 +38,39 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             {"uuid", PropertyType.Guid},
             {"date-time", PropertyType.Date}
         };
+        
+        private static readonly char NamespaceNameSeparator = '.';
+        
         public SnippetCodeGraph(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiUrlTreeNode treeNode) : this(new SnippetModel(requestPayload, serviceRootUrl, treeNode)) {}
 
         public SnippetCodeGraph(SnippetModel snippetModel)
         {
             ResponseSchema = snippetModel.ResponseSchema;
+            RequestSchema = snippetModel.RequestSchema;
             HttpMethod = snippetModel.Method;
             Nodes = snippetModel.PathNodes;
             Headers = parseHeaders(snippetModel);
             Options = Enumerable.Empty<CodeProperty>();
             Parameters = parseParameters(snippetModel);
             Body = parseBody(snippetModel);
+            ApiVersion = snippetModel.ApiVersion;
         }
 
         public OpenApiSchema ResponseSchema
         {
             get; set;
         }
+        
+        public OpenApiSchema RequestSchema
+        {
+            get; set;
+        }
+
+        public string ApiVersion
+        {
+            get; set;
+        }
+
         public HttpMethod HttpMethod
         {
             get; set;
@@ -202,12 +219,13 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
         private static string ComputeRequestBody(SnippetModel snippetModel)
         {
-            var name = snippetModel.RequestSchema?.Reference?.GetClassName() ?? snippetModel.ResponseSchema?.Reference?.GetClassName()?.Replace("ODataError","")?.Append("PostRequestBody");
+            var requestBodySuffix = $"{snippetModel.Method.Method.ToLower().ToFirstCharacterUpperCase()}RequestBody"; // calculate the suffix using the HttpMethod
+            var name = snippetModel.RequestSchema?.Reference?.GetClassName() ?? snippetModel.ResponseSchema?.Reference?.GetClassName()?.Replace("ODataError","")?.Append(requestBodySuffix);
 
             if(!string.IsNullOrEmpty(name))
                 return name?.ToFirstCharacterUpperCase();
 
-           var nodes = snippetModel.PathNodes;
+            var nodes = snippetModel.PathNodes;
             if (!(nodes?.Any() ?? false)) return string.Empty;
                 
             var nodeName = nodes.Where(x => !x.Segment.IsCollectionIndex())
@@ -226,7 +244,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             if (nodes.Last()?.Segment?.IsCollectionIndex() == true)
                 return singularNodeName;
             else
-                return nodeName?.Append("PostRequestBody");
+                return nodeName?.Append(requestBodySuffix);
         }
 
         private static CodeProperty TryParseBody(SnippetModel snippetModel)
@@ -237,10 +255,10 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             using var parsedBody = JsonDocument.Parse(snippetModel.RequestBody, new JsonDocumentOptions { AllowTrailingCommas = true });
             var schema = snippetModel.RequestSchema;
             var className = schema.GetSchemaTitle().ToFirstCharacterUpperCase() ?? ComputeRequestBody(snippetModel);
-            return parseJsonObjectValue(className, parsedBody.RootElement, schema);
+            return parseJsonObjectValue(className, parsedBody.RootElement, schema, snippetModel.EndPathNode);
         }
 
-        private static CodeProperty parseJsonObjectValue(String rootPropertyName, JsonElement value, OpenApiSchema schema)
+        private static CodeProperty parseJsonObjectValue(String rootPropertyName, JsonElement value, OpenApiSchema schema, OpenApiUrlTreeNode currentNode = null)
         {
             var children = new List<CodeProperty>();
 
@@ -266,14 +284,62 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                     children.Add(new CodeProperty { Name = "additionalData", PropertyType = PropertyType.Map, Children = additionalChildren });
             }
 
-            return new CodeProperty { Name = rootPropertyName, PropertyType = PropertyType.Object, Children = children, TypeDefinition = schema.GetSchemaTitle()?.ToFirstCharacterUpperCase() ?? rootPropertyName };
+            return new CodeProperty
+            {
+                Name = rootPropertyName, 
+                PropertyType = PropertyType.Object, 
+                Children = children, 
+                TypeDefinition = schema.GetSchemaTitle()?.ToFirstCharacterUpperCase() ?? GetComposedSchema(schema).GetSchemaTitle()?.ToFirstCharacterUpperCase() ?? rootPropertyName, 
+                NamespaceName = GetNamespaceFromSchema(schema) ??  currentNode.GetNodeNamespaceFromPath(string.Empty)
+            };
+        }
+
+        private static OpenApiSchema GetComposedSchema(OpenApiSchema schema)
+        {
+            if (schema == null)
+                return null;
+            
+            var typesCount = schema.AnyOf?.Count ?? schema.OneOf?.Count ?? 0;
+            if ((typesCount == 1 && schema.Nullable &&
+                 schema.IsAnyOf()) || // nullable on the root schema outside of anyOf
+                typesCount == 2 && schema.IsAnyOf() && schema.AnyOf.Any(static x => // nullable on a schema in the anyOf
+                    x.Nullable &&
+                    !x.Properties.Any() &&
+                    !x.IsOneOf() &&
+                    !x.IsAnyOf() &&
+                    !x.IsAllOf() &&
+                    !x.IsArray() &&
+                    !x.IsReferencedSchema())) // once openAPI 3.1 is supported, there will be a third case oneOf with Ref and type null.
+            {
+                return schema.AnyOf.FirstOrDefault(static x => !string.IsNullOrEmpty(x.GetSchemaTitle()));
+            }
+
+            return null;
+        }
+
+        private static string GetNamespaceFromSchema(OpenApiSchema schema)
+        {
+            if (schema == null)
+                return null;
+
+            return GetModelsNamespaceNameFromReferenceId(schema.IsReferencedSchema() ? schema.Reference?.Id : GetComposedSchema(schema)?.Reference?.Id);
         }
 
         private static String escapeSpecialCharacters(string value)
         {
             return value?.Replace("\"", "\\\"")?.Replace("\n", "\\n")?.Replace("\r", "\\r");
         }
-
+        
+        private static string GetModelsNamespaceNameFromReferenceId(string referenceId) {
+            if (string.IsNullOrEmpty(referenceId)) 
+                return referenceId;
+            
+            referenceId = referenceId.Trim(NamespaceNameSeparator);
+            var lastDotIndex = referenceId.LastIndexOf(NamespaceNameSeparator);
+            var namespaceSuffix = lastDotIndex != -1 ? $".{referenceId[..lastDotIndex]}" : string.Empty;
+            return $"models{namespaceSuffix}";
+        }
+        
         private static CodeProperty evaluateStringProperty(string propertyName, JsonElement value, OpenApiSchema propSchema)
         {
             if ((propSchema?.Type?.Equals("boolean", StringComparison.OrdinalIgnoreCase) ?? false))
@@ -286,7 +352,11 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                 return new CodeProperty { Name = propertyName, Value = escapeSpecialCharacters(value.GetString()), PropertyType = PropertyType.String, Children = new List<CodeProperty>() };
             enumSchema ??= propSchema;
             var propValue = String.IsNullOrWhiteSpace(value.GetString()) ? null : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.GetString().ToFirstCharacterUpperCase()}";
-            return new CodeProperty { Name = propertyName, Value = propValue, PropertyType = PropertyType.Enum, Children = new List<CodeProperty>() };
+            // Pass the list of options in the enum as children so that the language generators may use them for validation if need be, 
+            var enumValueOptions = enumSchema.Enum.Where(option => option is OpenApiString)
+                                                                .Select(option => new CodeProperty{Name = ((OpenApiString)option).Value,Value = ((OpenApiString)option).Value,PropertyType = PropertyType.String})
+                                                                .ToList();
+            return new CodeProperty { Name = propertyName, Value = propValue, PropertyType = PropertyType.Enum, Children = enumValueOptions ,NamespaceName = GetNamespaceFromSchema(enumSchema)};
         }
 
         private static CodeProperty evaluateNumericProperty(string propertyName, JsonElement value, OpenApiSchema propSchema)
@@ -336,7 +406,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         private static CodeProperty parseJsonArrayValue(string propertyName, JsonElement value, OpenApiSchema schema)
         {
             var alternativeType = schema?.Items?.AnyOf?.FirstOrDefault()?.AllOf?.LastOrDefault()?.Title;
-            var children = value.EnumerateArray().Select(item => parseProperty(schema.GetSchemaTitle() ?? alternativeType?.ToFirstCharacterUpperCase(), item, schema)).ToList();
+            var children = value.EnumerateArray().Select(item => parseProperty(schema.GetSchemaTitle() ?? alternativeType?.ToFirstCharacterUpperCase(), item, schema?.Items)).ToList();
             var genericType = schema.GetSchemaTitle().ToFirstCharacterUpperCase() ??
                               (value.EnumerateArray().Any() ?
                                   value.EnumerateArray().First().ValueKind.ToString() :

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -353,9 +353,9 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             enumSchema ??= propSchema;
             var propValue = String.IsNullOrWhiteSpace(value.GetString()) ? null : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.GetString().ToFirstCharacterUpperCase()}";
             // Pass the list of options in the enum as children so that the language generators may use them for validation if need be, 
-            var enumValueOptions = enumSchema.Enum.Where(option => option is OpenApiString)
+            var enumValueOptions = enumSchema?.Enum.Where(option => option is OpenApiString)
                                                                 .Select(option => new CodeProperty{Name = ((OpenApiString)option).Value,Value = ((OpenApiString)option).Value,PropertyType = PropertyType.String})
-                                                                .ToList();
+                                                                .ToList() ?? new List<CodeProperty>();
             return new CodeProperty { Name = propertyName, Value = propValue, PropertyType = PropertyType.Enum, Children = enumValueOptions ,NamespaceName = GetNamespaceFromSchema(enumSchema)};
         }
 

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -72,9 +72,9 @@ namespace CodeSnippetsReflection.OpenAPI
                     var operation = GetOperation(operationType);
                     if(operation != default)
                         _requestSchema = operation
-                                            .RequestBody
-                                            .Content
-                                            .TryGetValue(contentType, out var mediaType) ? mediaType.Schema : null;
+                                            .RequestBody?
+                                            .Content?
+                                            .TryGetValue(contentType, out var mediaType) ?? false ? mediaType.Schema : null;
                 }
                 return _requestSchema;
             }


### PR DESCRIPTION
This PR is part of https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1398 and closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/705

It resolves snippet generation failures on raptor validation of the snippet generator due to various reasons. 
Changes include : -

- Fixes snippet generation in Java and CSharp for URLs with `$search` to be properly escaped. #705
- Adds generated namespace information to the SnippetGodeGraph so that relevant language generators can take advantage of the information to resolve Type resolution in compilation
- Improves Enum member resolution to use spelling from metadata in CSharp
- Detect scenarios where request executors need a request payload even though the snippet has no body to provide default/null parameters using the RequestSchema
- Improves `SnippetCodeGraph` schema information to detect composed schemas as is done in Kiota to reduce type resolution failures.
- Adds tests to validate the above scenarios