### PR TITLE
Add specific error code for OutOfMemoryException exceptions

### DIFF
--- a/GraphWebApi/Middleware/ExceptionMiddleware.cs
+++ b/GraphWebApi/Middleware/ExceptionMiddleware.cs
@@ -53,6 +53,7 @@ namespace GraphWebApi.Middleware
                 InvalidOperationException => StatusCodes.Status400BadRequest,
                 ArgumentException => StatusCodes.Status404NotFound,
                 EntryPointNotFoundException => StatusCodes.Status404NotFound,
+                OutOfMemoryException => StatusCodes.Status507InsufficientStorage,
                 Exception => StatusCodes.Status500InternalServerError
             };
 


### PR DESCRIPTION
This PR:

- Adds error code 507 `HTTP_INSUFFICIENT_STORAGE` to the `OutOfMemoryExceptions`. This will help us customize Auto-Heal options in the DevX API app service when we encounter such errors.

![image](https://user-images.githubusercontent.com/40403681/188620681-8358896b-238b-41eb-b5f9-dd27fa996678.png)
The process will be killed and restarted if the above conditions are met. Restarting the app mitigates these errors.