### PR TITLE
Return a clone of OpenAPI document subset.

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -147,7 +147,7 @@ namespace OpenAPIService
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
 
-            return subset;
+            return CloneOpenApiDocument(subset);
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
This PR closes #1167 by ensuring we return a cloned copy of the OpenAPI document subset when slicing.