### PR TITLE
Generation fixes for Date/Time resolution

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -498,5 +498,51 @@ namespace CodeSnippetsReflection.OpenAPI.Test
 
             Assert.Contains("await graphClient.Teams[\"team-id\"].Archive.PostAsync(null);", result);
         }
+        
+        [Fact]
+        public async Task CorrectlyEvaluatesDatePropertyTypeRequestBodyParameter()
+        {
+            var bodyContent = @"{
+                ""subject"": ""Let's go for lunch"",
+                ""recurrence"": {
+                    ""range"": {
+                        ""type"": ""endDate"",
+                        ""startDate"": ""2017-09-04"",
+                        ""endDate"": ""2017-12-31""
+                    }
+                }
+            }";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/events")
+            {
+                Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("StartDate = new Date(DateTime.Parse(\"2017-09-04\")),", result);
+            Assert.Contains("EndDate = new Date(DateTime.Parse(\"2017-12-31\")),", result);
+        }
+        
+        [Fact]
+        public async Task CorrectlyEvaluatesOdataActionRequestBodyParameter()
+        {
+            var bodyContent = @"{
+                ""keyCredential"": {
+                        ""type"": ""AsymmetricX509Cert"",
+                        ""usage"": ""Verify"",
+                        ""key"": ""MIIDYDCCAki...""
+                    },
+                    ""passwordCredential"": null,
+                    ""proof"":""eyJ0eXAiOiJ...""
+                }";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/applications/{{id}}/addKey")
+            {
+                Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.AddKey.AddKeyPostRequestBody", result);
+        }
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -360,7 +360,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("NewPasswordCredentialPostRequestBody", result);
+            Assert.Contains("NewAddPasswordPostRequestBody", result);
         }
         
         [Fact]

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -99,7 +99,7 @@ public class PhpGeneratorTests
             };
         var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("PasswordCredentialPostRequestBody", result);
+        Assert.Contains("AddPasswordPostRequestBody", result);
     }
 
     [Fact]

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -202,13 +202,19 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                             var enumHint = x.Split('.').Last().Trim();
                             // the enum member may be invalid so default to generating the first value in case a look up fails.
                             var enumMember = codeProperty.Children.FirstOrDefault( member => member.Value.Equals(enumHint,StringComparison.OrdinalIgnoreCase)).Value ?? codeProperty.Children.FirstOrDefault().Value ?? enumHint;
-                            return $"{enumTypeString}.{enumMember.ToFirstCharacterUpperCase()}";
+                            return $"{enumTypeString.TrimEnd('?')}.{enumMember.ToFirstCharacterUpperCase()}";
                         })
                         .Aggregate((x, y) => $"{x} | {y}");
                     snippetBuilder.AppendLine($"{propertyAssignment}{enumValues}{assignmentSuffix}");
                     break;
-                case PropertyType.Date:
+                case PropertyType.DateTime:
                     snippetBuilder.AppendLine($"{propertyAssignment}DateTimeOffset.Parse(\"{codeProperty.Value}\"){assignmentSuffix}");
+                    break;
+                case PropertyType.DateOnly:
+                    snippetBuilder.AppendLine($"{propertyAssignment}new Date(DateTime.Parse(\"{codeProperty.Value}\")){assignmentSuffix}");
+                    break;
+                case PropertyType.TimeOnly:
+                    snippetBuilder.AppendLine($"{propertyAssignment}new Time(DateTime.Parse(\"{codeProperty.Value}\")){assignmentSuffix}");
                     break;
                 case PropertyType.Base64Url:
                     snippetBuilder.AppendLine($"{propertyAssignment}Convert.FromBase64String(\"{codeProperty.Value.EscapeQuotes()}\"){assignmentSuffix}");
@@ -258,7 +264,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 case PropertyType.String:
                     return "string";
                 case PropertyType.Enum:
-                    return $"{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{ReplaceIfReservedTypeName(typeString.Split('.').First())}";
+                    return $"{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{ReplaceIfReservedTypeName(typeString.Split('.').First())}?";
                 default:
                     return ReplaceIfReservedTypeName(typeString);
             }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -211,10 +211,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     snippetBuilder.AppendLine($"{propertyAssignment}DateTimeOffset.Parse(\"{codeProperty.Value}\"){assignmentSuffix}");
                     break;
                 case PropertyType.DateOnly:
-                    snippetBuilder.AppendLine($"{propertyAssignment}new Date(DateTime.Parse(\"{codeProperty.Value}\")){assignmentSuffix}");
-                    break;
                 case PropertyType.TimeOnly:
-                    snippetBuilder.AppendLine($"{propertyAssignment}new Time(DateTime.Parse(\"{codeProperty.Value}\")){assignmentSuffix}");
+                    snippetBuilder.AppendLine($"{propertyAssignment}new {GetTypeString(codeProperty, apiVersion)}(DateTime.Parse(\"{codeProperty.Value}\")){assignmentSuffix}");
                     break;
                 case PropertyType.Base64Url:
                     snippetBuilder.AppendLine($"{propertyAssignment}Convert.FromBase64String(\"{codeProperty.Value.EscapeQuotes()}\"){assignmentSuffix}");
@@ -265,6 +263,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     return "string";
                 case PropertyType.Enum:
                     return $"{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{ReplaceIfReservedTypeName(typeString.Split('.').First())}?";
+                case PropertyType.DateOnly:
+                    return "Date";
+                case PropertyType.TimeOnly:
+                    return "Time";
                 default:
                     return ReplaceIfReservedTypeName(typeString);
             }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -288,7 +288,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                         builder.AppendLine($"{indentManager.GetIndent()}{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}(&{propertyName}) ");
                     }
                     break;
-                case PropertyType.Date:
+                case PropertyType.DateTime:
                     builder.AppendLine($"{propertyName} , err := time.Parse(time.RFC3339, \"{child.Value}\")");
                     builder.AppendLine($"{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}(&{propertyName}) ");
                     break;

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -190,7 +190,7 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
             case PropertyType.Map:
                 WriteMapValue(payloadSb, propertyAssignment.ToFirstCharacterLowerCase(), parent, child, indentManager);
                 break;
-            case PropertyType.Date:
+            case PropertyType.DateTime:
                 WriteDateTimeValue(payloadSb, propertyAssignment.ToFirstCharacterLowerCase(), parent, child, indentManager);
                 break;
             case PropertyType.Duration:

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
@@ -190,6 +190,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                         builder.AppendLine($"{indentManager.GetIndent()}],");
 
                         break;
+                    case PropertyType.DateOnly:
                     case PropertyType.Guid:
                     case PropertyType.String:
                         var propName = codeProperty.PropertyType == PropertyType.Map ? $"\"{child.Name.ToFirstCharacterLowerCase()}\"" : NormalizeJsonName(child.Name.ToFirstCharacterLowerCase());
@@ -203,7 +204,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                             builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(child.Name.ToFirstCharacterLowerCase())} : {child.Value},");
                         }
                         break;
-                    case PropertyType.Date:
+                    case PropertyType.DateTime:
                         builder.AppendLine($"{indentManager.GetIndent()}{NormalizeJsonName(child.Name)} : new Date(\"{child.Value}\"),");
                         break;
                     case PropertyType.Base64Url:

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/PropertyType.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/PropertyType.cs
@@ -11,7 +11,7 @@ public enum PropertyType
     Float32,
     Float64,
     Double,
-    Date ,
+    DateTime ,
     Boolean ,
     Null,
     Enum ,
@@ -20,5 +20,7 @@ public enum PropertyType
     Binary,
     Array,
     Map,
-    Duration
+    Duration,
+    DateOnly,
+    TimeOnly
 }

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -36,7 +36,9 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             {"base64url", PropertyType.Base64Url},
             {"guid", PropertyType.Guid},
             {"uuid", PropertyType.Guid},
-            {"date-time", PropertyType.Date}
+            {"date-time", PropertyType.DateTime},
+            {"time", PropertyType.TimeOnly},
+            {"date", PropertyType.DateOnly}
         };
         
         private static readonly char NamespaceNameSeparator = '.';
@@ -220,7 +222,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         private static string ComputeRequestBody(SnippetModel snippetModel)
         {
             var requestBodySuffix = $"{snippetModel.Method.Method.ToLower().ToFirstCharacterUpperCase()}RequestBody"; // calculate the suffix using the HttpMethod
-            var name = snippetModel.RequestSchema?.Reference?.GetClassName() ?? snippetModel.ResponseSchema?.Reference?.GetClassName()?.Replace("ODataError","")?.Append(requestBodySuffix);
+            var name = snippetModel.RequestSchema?.Reference?.GetClassName();
 
             if(!string.IsNullOrEmpty(name))
                 return name?.ToFirstCharacterUpperCase();


### PR DESCRIPTION
This PR is related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1398

Changes include: -
- Update snippet generation to align to changes made in https://github.com/microsoft/kiota/pull/1603 to have Action request body names be name from the RequestBody schema e.g `PasswordCredentialPostRequestBody` becomes `AddPasswordPostRequestBody`
- Handle cases for `Date` and `Time` types in CSharp snippet generation
- Align enum generation to https://github.com/microsoft/kiota/issues/1845