### PR TITLE
Revert Microsoft.OpenApi.OData to 1.0.11

### DIFF
--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.1.0" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.11" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Overview
This PR reverts `Microsoft.OpenApi.OData` to `1.0.11` due to a breaking change in `1.1.0`. See https://github.com/microsoft/OpenAPI.NET.OData/issues/282 for more info on the breaking change.
