### PR TITLE
Bumps up `Microsoft.OpenApi.OData` lib version

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -404,7 +404,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     ""meetingDuration"": ""PT1H"",
                     ""maxCandidates"": ""100"",
                     ""isOrganizerOptional"": ""false"",
-                    ""minimumAttendeePercentage"": ""200""
+                    ""minimumAttendeePercentage"": 200
             }";
             
             using var requestPayload =

--- a/CodeSnippetsReflection.OpenAPI.Test/SnippetModelTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/SnippetModelTests.cs
@@ -104,7 +104,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             Assert.NotNull(snippetModel.ResponseSchema);
 
-            var properties = snippetModel.ResponseSchema.Properties ??
+            var properties = snippetModel.ResponseSchema.Properties.Any() ?
+                snippetModel.ResponseSchema.Properties :
                 (snippetModel.ResponseSchema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
                 .Union(snippetModel.ResponseSchema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
                 .Union(snippetModel.ResponseSchema.OneOf ?? Enumerable.Empty<OpenApiSchema>())

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -366,7 +366,8 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
              if(propSchema == null) 
                 return new CodeProperty { Name = propertyName, Value = $"{value}", PropertyType = PropertyType.Int32, Children = new List<CodeProperty>() };
 
-            var format = (propSchema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
+            var format = propSchema.Format ??
+                (propSchema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
                 .Union(propSchema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
                 .Union(propSchema.OneOf ?? Enumerable.Empty<OpenApiSchema>())
                 .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -365,14 +365,19 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         {
              if(propSchema == null) 
                 return new CodeProperty { Name = propertyName, Value = $"{value}", PropertyType = PropertyType.Int32, Children = new List<CodeProperty>() };
-                
+
+            var format = (propSchema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
+                .Union(propSchema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
+                .Union(propSchema.OneOf ?? Enumerable.Empty<OpenApiSchema>())
+                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;
+
             var (propertyType, propertyValue) = propSchema?.Type switch
             {
-                "integer" when propSchema.Format.Equals("int32") => (PropertyType.Int32 , value.GetInt32().ToString()),
-                "integer" when propSchema.Format.Equals("int64") => (PropertyType.Int64, value.GetInt64().ToString()),
-                _ when propSchema.Format.Equals("float") || propSchema.Format.Equals("float32") => (PropertyType.Float32, value.GetDecimal().ToString()),
-                _ when propSchema.Format.Equals("float64") => (PropertyType.Float64, value.GetDecimal().ToString()),
-                _ when propSchema.Format.Equals("double") => (PropertyType.Double, value.GetDouble().ToString()), //in MS Graph float & double are any of number, string and enum
+                "integer" when "int32".Equals(format) => (PropertyType.Int32 , value.GetInt32().ToString()),
+                "integer" when "int64".Equals(format) => (PropertyType.Int64, value.GetInt64().ToString()),
+                _ when "float".Equals(format) || "float32".Equals(format) => (PropertyType.Float32, value.GetDecimal().ToString()),
+                _ when "float64".Equals(format) => (PropertyType.Float64, value.GetDecimal().ToString()),
+                _ when "double".Equals(format) => (PropertyType.Double, value.GetDouble().ToString()), //in MS Graph float & double are any of number, string and enum
                 _ => (PropertyType.Int32, $"{value.GetInt32()}"),
             };
 

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.1.0" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview2" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -458,7 +458,7 @@ namespace OpenAPIService
                 if (styleOptions.InlineLocalReferences)
                 {
                     writer = new OpenApiYamlWriter(sr,
-                        new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
+                        new OpenApiWriterSettings { InlineLocalReferences = true });
                 }
                 else
                 {
@@ -470,7 +470,7 @@ namespace OpenAPIService
                 if (styleOptions.InlineLocalReferences)
                 {
                     writer = new OpenApiJsonWriter(sr,
-                        new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
+                        new OpenApiWriterSettings { InlineLocalReferences = true });
                 }
                 else
                 {
@@ -699,7 +699,8 @@ namespace OpenAPIService
                 EnableDerivedTypesReferencesForResponses = false,
                 ShowRootPath = true,
                 ShowLinks = true,
-                ExpandDerivedTypesNavigationProperties = false
+                ExpandDerivedTypesNavigationProperties = false,
+                RefBaseCollectionPaginationCountResponse = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1202

- Bumps up `Microsoft.OpenApi.OData` lib version
- Add new setting; refactor obsolete properties