### PR TITLE
Disable referencing OData annotations in responses

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -699,7 +699,8 @@ namespace OpenAPIService
                 EnableDerivedTypesReferencesForResponses = false,
                 ShowRootPath = true,
                 ShowLinks = true,
-                ExpandDerivedTypesNavigationProperties = false
+                ExpandDerivedTypesNavigationProperties = false,
+                EnableODataAnnotationReferencesForResponses = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 


### PR DESCRIPTION
- Setting this convert setting to `false` helps prevent breaking paging support for PowerShell.
- Issue reference: https://github.com/microsoft/OpenAPI.NET.OData/issues/282
- The initial setting was reverted with: https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1207/commits/adfd7eb96c8149dac08f73d2080ca5f947686ad0