### PR TITLE
Downgrades `Microsoft.OpenApi.OData` version

### DIFF
--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.3" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview2" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
   </ItemGroup>
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -700,7 +700,7 @@ namespace OpenAPIService
                 ShowRootPath = true,
                 ShowLinks = true,
                 ExpandDerivedTypesNavigationProperties = false,
-                EnableODataAnnotationReferencesForResponses = false
+                RefBaseCollectionPaginationCountResponse = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 


### PR DESCRIPTION
This PR temporarily addresses https://github.com/microsoft/OpenAPI.NET.OData/issues/297

- https://github.com/microsoft/OpenAPI.NET.OData/issues/120 was added in this [PR](https://github.com/microsoft/OpenAPI.NET.OData/pull/293) and released in `Microsoft.OpenApi.OData` `v1.2.0-preview3`.
`v1.2.0-preview2` is the last known good.
- Updates the conversion setting appropriately. The previous setting was introduced in `v1.2.0-preview4`

This downgrade is temporary until the above issue is resolved.