### PR TITLE
Updates conversion lib version

### DIFF
--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.3" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview5" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The `OpenApiSnippetsGeneratorTests` tests are failing because the generated OpenAPI files in the source metadata repo. have the issue as described [here](https://github.com/microsoft/OpenAPI.NET.OData/issues/297). This has been temporarily resolved by this [PR](https://github.com/microsoft/OpenAPI.NET.OData/pull/299) and will be corrected in the next refresh cycle, once this [PR](https://github.com/microsoft/OpenAPI.NET/pull/1047) is merged.