### PR TITLE
Fixes .NET version in snippet generation pipeline

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -63,9 +63,9 @@ steps:
     version: 5.x
 
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 6'
+  displayName: 'Install .NET Core SDK 7'
   inputs:
-    version: 6.0.x
+    version: 7.0.x
 
 - task: DotNetCoreCLI@2
   displayName: 'Build snippet generator'


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1241

Updates the pipeline to use NET 7 to allow for successful build of tool during snippet generation.