### PR TITLE
Eliminate cloning of Open API document generated from CSDL

### DIFF
--- a/OpenAPIService/CopyReferences.cs
+++ b/OpenAPIService/CopyReferences.cs
@@ -8,7 +8,7 @@ namespace OpenAPIService
     internal class CopyReferences : OpenApiVisitorBase
     {
         private readonly OpenApiDocument target;
-        public OpenApiComponents Components = new OpenApiComponents();
+        public OpenApiComponents Components = new();
 
         public CopyReferences(OpenApiDocument target)
         {

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -148,7 +148,7 @@ namespace OpenAPIService
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
 
-            return CloneOpenApiDocument(subset);
+            return subset;
         }
 
         /// <summary>
@@ -694,10 +694,6 @@ namespace OpenAPIService
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
             _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
-
-            // The output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance,
-            // so we write it out, and read it back in again to fix it up.
-            document = CloneOpenApiDocument(document);
 
             return document;
         }


### PR DESCRIPTION
## Overview
Fixes #1144 
Eliminate cloning of Open API document generated from CSDL

Awaiting update of OpenAPI.Net.OData library. 

## Testing Instructions
* Call DevX API endpoint to convert CSDL to Open API document e.g `https://localhost:44399/openapi?operationIds=applications.application.ListApplication&openApiVersion=3`
* The components section of the Open API document contains definitions of references made within operations
* No exceptions are thrown