### PR TITLE
Remove exception throwing and telemetry capture for every scopes description failure

### DIFF
--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -492,18 +492,11 @@ namespace PermissionsService
                 _telemetryClient?.TrackTrace(errMsg,
                                              SeverityLevel.Error,
                                              _permissionsTraceProperties);
-                throw new ArgumentException(errMsg);
             }
 
             var scopesInfo = scopes.Select(scope =>
             {
-                var success = scopesInformationDictionary[key].TryGetValue(scope, out var scopeInfo);
-                if (!success)
-                {
-                    _telemetryClient?.TrackTrace($"Unable to retrieve scope information for '{scope}' from {nameof(scopesInformationDictionary)}:[{key}]",
-                                             SeverityLevel.Error,
-                                             _permissionsTraceProperties);
-                }
+                scopesInformationDictionary[key].TryGetValue(scope, out var scopeInfo);                
                 return scopeInfo ?? new() { ScopeName = scope };
             }).ToList();
 


### PR DESCRIPTION
This PR:

- Removes telemetry capture and exception throwing for every scopes information failure. Throwing exceptions every time the `ScopesInformationDictionary` is empty is not feasible. We end up getting a lot of App Insights availability alerts and exceptions (which in turn trigger `sev1` alerts) with a high number of requests. Also, Graph Explorer (GE) does not display the permissions at all when the `ScopesInformationDictionary` is empty. At the very least, the permissions should be displayed in GE with missing scopes information data. Also capturing telemetry for every scope that doesn't have a permission description for every request for fetching all permissions could be spiking CPU usage, especially with a high number of request.
It is worth noting that the service is experiencing intermittent availability of the permissions descriptions. 
Given the example urls:
staging: https://graphexplorerapi-staging.azurewebsites.net/permissions?requestUrl=/me&method=GET
prod: https://graphexplorerapi.azurewebsites.net/permissions?requestUrl=/me&method=GET

You notice (upon repeated requests) that prod intermittently throws an exception on making a call to the above endpoint, whereas staging works okay. This also cannot be replicated locally, pointing to a possible infra issue with prod. Potentially high CPU or memory usage.