### PR TITLE
Update go header and inline body name generation

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -228,7 +228,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
         }
         [Fact]
-        public async Task GeneratesSelectQueryParameters() {
+        public async Task GeneratesSelectQueryParameters()
+        {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me?$select=displayName,id");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
@@ -240,6 +241,20 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("requestParameters :=", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
             Assert.Contains("result, err := graphClient.Me().Get(context.Background(), configuration)", result);
+        }
+        [Fact]
+        public async Task GeneratesNestedParameterNames()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/{{id}}?$select=displayName,givenName,postalCode,identities");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Select: [] string {\"displayName\",\"givenName\",\"postalCode\",\"identities\"}", result);
+            Assert.Contains("QueryParameters: ", result);
+            Assert.Contains("&graphconfig.UserItemRequestBuilderGetQueryParameters", result);
+            Assert.Contains("&graphconfig.UserItemRequestBuilderGetRequestConfiguration", result);
+            Assert.Contains("configuration :=", result);
+            Assert.Contains("requestParameters :=", result);
+            Assert.Contains("result, err := graphClient.UsersById(\"user-id\").Get(context.Background(), configuration)", result);
         }
         [Fact]
         public async Task GeneratesCountBooleanQueryParameters() {
@@ -279,7 +294,9 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("\"ConsistencyLevel\": \"eventual\"", result);
+            Assert.Contains("headers := abstractions.NewRequestHeaders()", result);
+            Assert.Contains("headers.Add(\"ConsistencyLevel\", \"eventual\")", result);
+            Assert.Contains("graphconfig.GroupsRequestBuilderGetRequestConfiguration", result);
             Assert.Contains("Headers: headers", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
             Assert.Contains("result, err := graphClient.Groups().Get(context.Background(), configuration)", result);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -154,7 +154,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (!(nodes?.Any() ?? false)) return string.Empty;
             // if the first element is a collection index skip it
             var fileterdNodes = (nodes.First().Segment.IsCollectionIndex()) ? nodes.Skip(1) : nodes;
-            return fileterdNodes.Select(x =>
+            return fileterdNodes.Select(static x =>
             {
                 if (x.Segment.IsCollectionIndex())
                     return "Item";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -161,7 +161,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 else
                     return x.Segment.ToFirstCharacterUpperCase();
             })
-                        .Aggregate((x, y) =>
+                        .Aggregate(static (x, y) =>
                         {
                             var w = x.EndsWith("s") && y.Equals("Item") ? x.Remove(x.Length - 1, 1) : x;
                             return $"{w}{y}";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -9,6 +9,7 @@ using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
+using System.ComponentModel.DataAnnotations;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -71,7 +72,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             WriteOptions(codeGraph, builder, indentManager);
             WriteParameters(codeGraph, builder, indentManager);
 
-            var className = $"graphconfig.{codeGraph.Nodes.Last().GetClassName("RequestBuilder").ToFirstCharacterUpperCase()}{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}RequestConfiguration";
+            var className = $"graphconfig.{GetNestedObjectName(codeGraph.Nodes)}RequestBuilder{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}RequestConfiguration";
             builder.AppendLine($"{requestConfigurationVarName} := &{className}{{");
             indentManager.Indent();
 
@@ -92,12 +93,12 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             if (!codeGraph.HasHeaders()) return;
 
-            builder.AppendLine($"{indentManager.GetIndent()}{requestHeadersVarName} := map[string]string{{");
-            indentManager.Indent();
+            builder.AppendLine($"{indentManager.GetIndent()}{requestHeadersVarName} := abstractions.NewRequestHeaders()");
+
             foreach (var param in codeGraph.Headers)
-                builder.AppendLine($"{indentManager.GetIndent()}\"{param.Name}\": \"{param.Value.EscapeQuotes()}\",");
-            indentManager.Unindent();
-            builder.AppendLine($"{indentManager.GetIndent()}}}");
+                builder.AppendLine($"{indentManager.GetIndent()}{requestHeadersVarName}.Add(\"{param.Name}\", \"{param.Value.EscapeQuotes()}\")");
+
+            builder.AppendLine($"{indentManager.GetIndent()}");
         }
 
         private static void WriteOptions(SnippetCodeGraph codeGraph, StringBuilder builder, IndentManager indentManager)
@@ -129,7 +130,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (nonArrayParams.Any())
                 builder.AppendLine(string.Empty);
 
-            var className = $"graphconfig.{codeGraph.Nodes.Last().GetClassName("RequestBuilder").ToFirstCharacterUpperCase()}{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}QueryParameters";
+            var className = $"graphconfig.{GetNestedObjectName(codeGraph.Nodes)}RequestBuilder{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}QueryParameters";
             builder.AppendLine($"{indentManager.GetIndent()}{requestParametersVarName} := &{className}{{");
             indentManager.Indent();
 
@@ -146,6 +147,25 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             }
             indentManager.Unindent();
             builder.AppendLine($"{indentManager.GetIndent()}}}");
+        }
+
+        private static string GetNestedObjectName(IEnumerable<OpenApiUrlTreeNode> nodes)
+        {
+            if (!(nodes?.Any() ?? false)) return string.Empty;
+            // if the first element is a collection index skip it
+            var fileterdNodes = (nodes.First().Segment.IsCollectionIndex()) ? nodes.Skip(1) : nodes;
+            return fileterdNodes.Select(x =>
+            {
+                if (x.Segment.IsCollectionIndex())
+                    return "Item";
+                else
+                    return x.Segment.ToFirstCharacterUpperCase();
+            })
+                        .Aggregate((x, y) =>
+                        {
+                            var w = x.EndsWith("s") && y.Equals("Item") ? x.Remove(x.Length - 1, 1) : x;
+                            return $"{w}{y}";
+                        });
         }
 
         private static string evaluateParameter(CodeProperty param)


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1295

Update Go snippet generation to use nested parameter names and update header generation 

Parameter names change from 
```go
requestParameters := &graphconfig.UserRequestBuilderGetQueryParameters`
```

To:
```go
requestParameters := &graphconfig.UserItemRequestBuilderGetQueryParameters`
```

changes headers from 
```go
        headers := map[string]string{
            "ConsistencyLevel": "eventual",
        }
```

to
```go
headers := abstractions.NewRequestHeaders()
headers.Add("ConsistencyLevel", "eventual")
```

