### PR TITLE
additional telemetry to diagnose permission caching issue

### DIFF
--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -316,6 +316,18 @@ namespace PermissionsService
                                          SeverityLevel.Information,
                                          _permissionsTracePropertiesWithSanitizeIgnore);
 
+            if (delegatedScopesInfoTable.Count == 0 && applicationScopesInfoTable.Count == 0)
+            {
+                // sneak-peak into the scopes JSON if we didn't get any scopes
+                const int maxCharsToLog = 100;
+                var scopesInfoJsonToLog = scopesInfoJson[0..int.Max(maxCharsToLog, scopesInfoJson.Length)]
+                                                .Replace("\r", string.Empty, StringComparison.OrdinalIgnoreCase)
+                                                .Replace("\n", string.Empty, StringComparison.OrdinalIgnoreCase);
+                _telemetryClient?.TrackTrace($"Scopes information is empty. ScopesInfoJson start: {scopesInfoJsonToLog}",
+                                             SeverityLevel.Error,
+                                             _permissionsTracePropertiesWithSanitizeIgnore);
+            }
+
             return new Dictionary<string, IDictionary<string, ScopeInformation>>
             {
                 { Delegated, delegatedScopesInfoTable },

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -305,7 +305,7 @@ namespace PermissionsService
 
             _telemetryClient?.TrackTrace($"DelegatedScopesList count: {scopesInformationList.DelegatedScopesList.Count}, ApplicationScopesList count: {scopesInformationList.ApplicationScopesList.Count}",
                                          SeverityLevel.Information,
-                                         _permissionsTraceProperties);
+                                         _permissionsTracePropertiesWithSanitizeIgnore);
 
             var delegatedScopesInfoTable = scopesInformationList.DelegatedScopesList.ToDictionary(x => x.ScopeName);
             var applicationScopesInfoTable = scopesInformationList.ApplicationScopesList.ToDictionary(x => x.ScopeName);
@@ -525,8 +525,8 @@ namespace PermissionsService
             }).ToList();
 
             _telemetryClient?.TrackTrace($"scopesInformationDictionary hash code is: {scopesInformationDictionary.GetHashCode()}",
-                                                scopeInfoMissing ? SeverityLevel.Error : SeverityLevel.Information,
-                                                _permissionsTraceProperties);
+                                                scopeInfoMissing && !getAllPermissions ? SeverityLevel.Error : SeverityLevel.Information,
+                                                _permissionsTracePropertiesWithSanitizeIgnore);
 
             if (getAllPermissions)
             {

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -498,11 +498,23 @@ namespace PermissionsService
                                              _permissionsTraceProperties);
             }
 
+            var scopeInfoMissing = false;
             var scopesInfo = scopes.Select(scope =>
             {
-                scopesInformationDictionary[key].TryGetValue(scope, out var scopeInfo);                
-                return scopeInfo ?? new() { ScopeName = scope };
+                if (scopesInformationDictionary[key].TryGetValue(scope, out var scopeInfo))
+                {
+                    return scopeInfo;
+                }
+                else
+                {
+                    scopeInfoMissing = true;
+                    return new() { ScopeName = scope };
+                }
             }).ToList();
+
+            _telemetryClient?.TrackTrace($"scopesInformationDictionary hash code is: {scopesInformationDictionary.GetHashCode()}",
+                                                scopeInfoMissing ? SeverityLevel.Error : SeverityLevel.Information,
+                                                _permissionsTraceProperties);
 
             if (getAllPermissions)
             {

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -206,7 +206,7 @@ namespace PermissionsService
 
                         // Get file contents from source
                         string scopesInfoJson = _fileUtility.ReadFromFile(relativeScopesInfoPath).GetAwaiter().GetResult();
-                        _telemetryClient?.TrackTrace($"Successfully seeded permissions for locale '{locale}' from Azure blob resource",
+                        _telemetryClient?.TrackTrace($"Successfully seeded permissions for locale '{locale}' from Azure blob resource, file length: {scopesInfoJson.Length}",
                                                      SeverityLevel.Information,
                                                      _permissionsTraceProperties);
 
@@ -302,6 +302,11 @@ namespace PermissionsService
                                          _permissionsTraceProperties);
 
             var scopesInformationList = JsonConvert.DeserializeObject<ScopesInformationList>(scopesInfoJson);
+
+            _telemetryClient?.TrackTrace($"DelegatedScopesList count: {scopesInformationList.DelegatedScopesList.Count}, ApplicationScopesList count: {scopesInformationList.ApplicationScopesList.Count}",
+                                         SeverityLevel.Information,
+                                         _permissionsTraceProperties);
+
             var delegatedScopesInfoTable = scopesInformationList.DelegatedScopesList.ToDictionary(x => x.ScopeName);
             var applicationScopesInfoTable = scopesInformationList.ApplicationScopesList.ToDictionary(x => x.ScopeName);
 


### PR DESCRIPTION
## Overview

- Additional telemetry to diagnose whether seeding JSON object is not read correctly.
- Additional telemetry to watch changing dictionary location
- partial #1263 