### PR TITLE
Snippets Generation Updates

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -206,7 +206,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
         [Fact]
         public async Task GeneratesFilterParameters() {
-            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$filter=Department eq 'Finance'&$orderby=displayName&$select=id,displayName,department");
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$filter=Department eq 'Finance'&$orderBy=displayName&$select=id,displayName,department");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestConfiguration.QueryParameters.Count", result);
@@ -434,7 +434,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             // Assert `Directory` is replaced with `DirectoryObject`
-            Assert.Contains("await graphClient.DirectoryObject.AdministrativeUnits[\"administrativeUnit-id\"].ScopedRoleMembers.GetAsync()", result);
+            Assert.Contains("await graphClient.Directory.AdministrativeUnits[\"administrativeUnit-id\"].ScopedRoleMembers.GetAsync()", result);
         }
         
         [Fact]
@@ -543,6 +543,25 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.AddKey.AddKeyPostRequestBody", result);
+        }
+        [Fact]
+        public async Task CorrectlyEvaluatesGuidInRequestBodyParameter()
+        {
+            var bodyContent = @"{
+                  ""principalId"": ""cde330e5-2150-4c11-9c5b-14bfdc948c79"",
+                  ""resourceId"": ""8e881353-1735-45af-af21-ee1344582a4d"",
+                  ""appRoleId"": ""00000000-0000-0000-0000-000000000000""
+                }";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/users/{{id}}/appRoleAssignments")
+            {
+                Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("Guid.Parse(\"cde330e5-2150-4c11-9c5b-14bfdc948c79\")", result);
+            Assert.Contains("Guid.Parse(\"8e881353-1735-45af-af21-ee1344582a4d\")", result);
+            Assert.Contains("Guid.Parse(\"00000000-0000-0000-0000-000000000000\")", result);
         }
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -134,7 +134,7 @@ public class PhpGeneratorTests
         Assert.Contains("$queryParameters->count = true;", result);
         Assert.Contains("$queryParameters->filter", result);
         Assert.Contains("$queryParameters->select", result);
-        Assert.Contains("$queryParameters->orderBy", result);
+        Assert.Contains("$queryParameters->orderby", result);
     }
     
     [Fact]

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -140,8 +140,8 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         private static List<CodeProperty> parseParameters(SnippetModel snippetModel)
         {
 
-            var ArrayParameters = ImmutableHashSet.Create("select", "expand", "orderby");
-            var NumberParameters = ImmutableHashSet.Create("skip", "top");
+            var ArrayParameters = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,"select", "expand", "orderby");
+            var NumberParameters = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,"skip", "top");
 
             var parameters = new List<CodeProperty>();
             if (!string.IsNullOrEmpty(snippetModel.QueryString))
@@ -151,18 +151,18 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 foreach (String key in queryCollection.AllKeys)
                 {
-                    var name = NormalizeQueryParameterName(key);
+                    var name = NormalizeQueryParameterName(key).Trim();
                     var value = GetQueryParameterValue(queryCollection[key], replacements);
-                    if(ArrayParameters.Contains(name.ToLower().Trim())){
+                    if(ArrayParameters.Contains(name)){
                         var children = splitCommasExcludingBracketsRegex.Split(value)
                             .Where(x => !String.IsNullOrEmpty(x) && !x.StartsWith("(") && !x.Equals(","))
                             .Select(x => new CodeProperty() { Name = null, Value = x, PropertyType = PropertyType.String }).ToList();
 
-                        parameters.Add(new() { Name = name, Value = null, PropertyType = PropertyType.Array , Children = children});
+                        parameters.Add(new() { Name = name.ToLower(), Value = null, PropertyType = PropertyType.Array , Children = children});
                     }else if (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value.Equals("false", StringComparison.OrdinalIgnoreCase)){
-                        parameters.Add(new() { Name = name, Value = value, PropertyType = PropertyType.Boolean });
-                    }else if (NumberParameters.Contains(name.ToLower().Trim())){
-                        parameters.Add(new() { Name = name, Value = value, PropertyType = PropertyType.Int32 });
+                        parameters.Add(new() { Name = name.ToLower(), Value = value, PropertyType = PropertyType.Boolean });
+                    }else if (NumberParameters.Contains(name)){
+                        parameters.Add(new() { Name = name.ToLower(), Value = value, PropertyType = PropertyType.Int32 });
                     }else{
                         parameters.Add(new() { Name = name, Value = value, PropertyType = PropertyType.String });
                     }

--- a/pipelines/unused-snippets.yml
+++ b/pipelines/unused-snippets.yml
@@ -35,6 +35,13 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
+- pwsh: |
+    # override branch prefix incase the run is manually triggered
+    $branchPrefix = if ($env:BUILD_REASON -eq 'Manual') { "preview-snippet-generation" } else { "snippet-generation" }
+    Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
+    Write-Host "Branch prefix is $branchPrefix"
+  displayName: 'Evaluate branch prefix to use'
+  
 - template: templates/git-config.yml
 
 - pwsh: $(Build.SourcesDirectory)/microsoft-graph-devx-api/scripts/cleanupUnusedSnippets.ps1


### PR DESCRIPTION
Part of https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1398

Changes include: 
- Update snippet genearation to align to Reserved Names changes in https://github.com/microsoft/kiota/pull/2031
- Update snippet genearation to align using Guid Type from string types
- Update `SnippetCodeGraph` to use consistent casing for known query parameters
- Fixes `unused-snippets` pipeline failing due to missing branch name environment variable.
- Updates tests to align