### PR TITLE
Resolve PowerShell Snippet 'OR' positional parameter issue

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -233,7 +233,27 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("-Search \"displayName:Megan\"", result);
+            Assert.Contains("-Search '\"displayName:Megan\"'", result);
+            Assert.Contains("-ConsistencyLevel eventual", result);
+        }
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithSearchQueryOptionWithORLogicalConjuction()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" OR \"displayName:al\"");
+            requestPayload.Headers.Add("ConsistencyLevel", "eventual");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("-Search '\"displayName:di\" OR \"displayName:al\"'", result);
+            Assert.Contains("-ConsistencyLevel eventual", result);
+        }
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithSearchQueryOptionWithANDLogicalConjuction()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" AND \"displayName:al\"");
+            requestPayload.Headers.Add("ConsistencyLevel", "eventual");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("-Search '\"displayName:di\" AND \"displayName:al\"'", result);
             Assert.Contains("-ConsistencyLevel eventual", result);
         }
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -176,13 +176,21 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 return originalValue.ToLowerInvariant();
             else if (int.TryParse(originalValue, out var intValue))
                 return intValue.ToString();
-            else {
+            else if (originalValue.Contains("+OR+"))
+                return NestedValueWithORSeparator(originalValue);
+            else
+            {
                 var valueWithNested = originalValue.Split(',')
                                                     .Select(v => replacements.ContainsKey(v) ? v + replacements[v] : v)
                                                     .Aggregate((a, b) => $"{a},{b}");
                 // Replace '$' with '`$' since '$' is a reserved character in powershell.
                 return $"\"{valueWithNested.Replace("$", "`$")}\"";
             }
+        }
+        private static string NestedValueWithORSeparator(string originalValue)
+        {
+            originalValue = originalValue.Replace("+", " ");
+            return $"'\"{originalValue.Replace("$", "`$")}\"'";
         }
         private static string NormalizeQueryParameterName(string queryParam)
         {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -171,13 +171,12 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             if (normalizedParameterName.Equals("CountVariable"))
                 return "CountVar";
-
+            if (normalizedParameterName.Equals("Search") & originalValue.Contains("+"))
+                return $"'\"{originalValue.Replace("+", " ")}\"'";
             if (originalValue.Equals("true", StringComparison.OrdinalIgnoreCase) || originalValue.Equals("false", StringComparison.OrdinalIgnoreCase))
                 return originalValue.ToLowerInvariant();
             else if (int.TryParse(originalValue, out var intValue))
                 return intValue.ToString();
-            else if (originalValue.Contains("+OR+"))
-                return NestedValueWithORSeparator(originalValue);
             else
             {
                 var valueWithNested = originalValue.Split(',')
@@ -186,11 +185,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 // Replace '$' with '`$' since '$' is a reserved character in powershell.
                 return $"\"{valueWithNested.Replace("$", "`$")}\"";
             }
-        }
-        private static string NestedValueWithORSeparator(string originalValue)
-        {
-            originalValue = originalValue.Replace("+", " ");
-            return $"'\"{originalValue.Replace("$", "`$")}\"'";
         }
         private static string NormalizeQueryParameterName(string queryParam)
         {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -171,7 +171,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             if (normalizedParameterName.Equals("CountVariable"))
                 return "CountVar";
-            if (normalizedParameterName.Equals("Search") & originalValue.Contains("+"))
+            if (normalizedParameterName.Equals("Search"))
                 return $"'\"{originalValue.Replace("+", " ")}\"'";
             if (originalValue.Equals("true", StringComparison.OrdinalIgnoreCase) || originalValue.Equals("false", StringComparison.OrdinalIgnoreCase))
                 return originalValue.ToLowerInvariant();

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -12,7 +12,7 @@ pr:
     - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-latest'
 
 variables:
   solution: '**/*.sln'

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -11,8 +11,7 @@ pr:
     - dev
     - master
 
-pool:
-  vmImage: 'ubuntu-latest'
+pool: 1es-windows-latest
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION

## Overview

This PR prevents the OR separator inside parameter values from appearing as a positional parameter when executing a PowerShell snippet. The issue is described [here](https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1350).

### Demo
<img width="636" alt="image" src="https://user-images.githubusercontent.com/10947120/216085391-61718bc1-73dd-4d5b-bd36-59b7f6aa256c.png">


## Testing Instructions

* Check out the branch associated with this PR.
* Build and run 'GraphWebApi' project
* Use [this postman collection](https://api.postman.com/collections/3669426-ac10c1c8-d60f-43b5-8d1e-3f9a14a8b90c?access_key=PMAT-01GR6SKZW1HCKYN490M9ZH7CB3) to run the request.
* Copy and execute the snippet in a PowerShell session
* <img width="860" alt="image" src="https://user-images.githubusercontent.com/10947120/216088746-fd4f9d4f-58e2-49e5-93aa-9d10e2380316.png">