### PR TITLE
Fix generation of special properties starting with @ in Go

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -8,7 +7,7 @@ using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
 using Microsoft.OpenApi.Services;
 using Xunit;
 
-namespace CodeSnippetsReflection.OpenAPI.Test.LanguageGenerators
+namespace CodeSnippetsReflection.OpenAPI.Test
 {
     public class GoGeneratorTests {
         private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
@@ -224,7 +223,6 @@ namespace CodeSnippetsReflection.OpenAPI.Test.LanguageGenerators
             Assert.Contains("map[string]interface{}{", result);
             Assert.Contains("[]string {", result);
             Assert.Contains("SetAdditionalData", result);
-            Assert.Contains("members", result); // property name hasn't been changed
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
         }
         [Fact]

--- a/CodeSnippetsReflection.OpenAPI.Test/LanguageGenerators/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/LanguageGenerators/GoGeneratorTests.cs
@@ -8,7 +8,7 @@ using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
 using Microsoft.OpenApi.Services;
 using Xunit;
 
-namespace CodeSnippetsReflection.OpenAPI.Test
+namespace CodeSnippetsReflection.OpenAPI.Test.LanguageGenerators
 {
     public class GoGeneratorTests {
         private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -401,7 +401,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                     .Aggregate(static (a, b) => $"{a}{b}") + "().";
                 return x.Segment.ToFirstCharacterUpperCase() + "().";
             })
-                        .Aggregate((x, y) =>
+                        .Aggregate(static (x, y) =>
                         {
                             return $"{x}{y.Replace("$", string.Empty, StringComparison.OrdinalIgnoreCase).ToFirstCharacterUpperCase()}";
                         })

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -403,7 +403,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             })
                         .Aggregate((x, y) =>
                         {
-                            return $"{x}{y.Replace("$","").ToFirstCharacterUpperCase()}";
+                            return $"{x}{y.Replace("$", string.Empty, StringComparison.OrdinalIgnoreCase).ToFirstCharacterUpperCase()}";
                         })
                         .Replace("().ById(", "ById(")
                         .Replace("()()", "()");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -182,7 +182,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string NormalizeJsonName(string Name)
         {
-            if ((!String.IsNullOrWhiteSpace(Name) && Name.Substring(1) != "\"") && (Name.Contains('.') || Name.Contains('-')))
+            if ((!String.IsNullOrWhiteSpace(Name) && !Name.Substring(1).Equals("\"", StringComparison.OrdinalIgnoreCase)) && (Name.Contains('.') || Name.Contains('-')))
             {
                 var propertyMatch = PropertyNameRegex.Match(Name);
                 return propertyMatch.Success ? string.Join("",propertyMatch.Groups[1].Value.Split(".").Select(x => x.ToFirstCharacterUpperCase())).ToFirstCharacterLowerCase() : $"\"{Name}\"";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Immutable;
-using System.ComponentModel.Design;
 using System.Text;
 using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
@@ -27,7 +26,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         
         private static IImmutableSet<string> NativeTypes = GetNativeTypes();
 
-        private static readonly Regex PropertyNameRegex = new Regex(@"@(.*)", RegexOptions.Compiled);
+        private static readonly Regex PropertyNameRegex = new Regex(@"@(.*)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
 
         static IImmutableSet<string> GetNativeTypes()
         {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Immutable;
+using System.ComponentModel.Design;
 using System.Text;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
-using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -28,6 +26,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static IImmutableSet<string> specialProperties = ImmutableHashSet.Create("@odata.type");
         
         private static IImmutableSet<string> NativeTypes = GetNativeTypes();
+
+        private static readonly Regex PropertyNameRegex = new Regex(@"@(.*)", RegexOptions.Compiled);
 
         static IImmutableSet<string> GetNativeTypes()
         {
@@ -182,7 +182,13 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string NormalizeJsonName(string Name)
         {
-            return (!String.IsNullOrWhiteSpace(Name) && Name.Substring(1) != "\"") && (Name.Contains('.') || Name.Contains('-')) ? $"\"{Name}\"" : Name;
+            if ((!String.IsNullOrWhiteSpace(Name) && Name.Substring(1) != "\"") && (Name.Contains('.') || Name.Contains('-')))
+            {
+                var propertyMatch = PropertyNameRegex.Match(Name);
+                return propertyMatch.Success ? string.Join("",propertyMatch.Groups[1].Value.Split(".").Select(x => x.ToFirstCharacterUpperCase())).ToFirstCharacterLowerCase() : $"\"{Name}\"";
+            }
+
+            return Name;
         }
 
         private static void WriteExecutionStatement(SnippetCodeGraph codeGraph, StringBuilder builder, params string[] parameters)
@@ -395,7 +401,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                     .Aggregate(static (a, b) => $"{a}{b}") + "().";
                 return x.Segment.ToFirstCharacterUpperCase() + "().";
             })
-                        .Aggregate(static (x, y) => $"{x}{y}")
+                        .Aggregate((x, y) =>
+                        {
+                            return $"{x}{y.Replace("$","").ToFirstCharacterUpperCase()}";
+                        })
                         .Replace("().ById(", "ById(")
                         .Replace("()()", "()");
         }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -185,7 +185,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if ((!String.IsNullOrWhiteSpace(Name) && !Name.Substring(1).Equals("\"", StringComparison.OrdinalIgnoreCase)) && (Name.Contains('.') || Name.Contains('-')))
             {
                 var propertyMatch = PropertyNameRegex.Match(Name);
-                return propertyMatch.Success ? string.Join("",propertyMatch.Groups[1].Value.Split(".").Select(x => x.ToFirstCharacterUpperCase())).ToFirstCharacterLowerCase() : $"\"{Name}\"";
+                return propertyMatch.Success ? string.Join("",propertyMatch.Groups[1].Value.Split(".").Select(static x => x.ToFirstCharacterUpperCase())).ToFirstCharacterLowerCase() : $"\"{Name}\"";
             }
 
             return Name;


### PR DESCRIPTION
## Overview

Fixes Go Snippet Generation
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/357
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/356

### Current Snippet
```go
"@odata.id" := "https://graph.microsoft.com/v1.0/directoryObjects/{id}"
requestBody.Set"@odata.id"(&"@odata.id")

graphClient.GroupsById("group-id").Members().$ref().Post(context.Background(), requestBody, nil)
```

Fixed Snippet
```go
graphClient := msgraphsdk.NewGraphServiceClient(requestAdapter)

requestBody := graphmodels.NewReferenceCreate()
odataId := "https://graph.microsoft.com/v1.0/directoryObjects/{id}"
requestBody.SetOdataId(&odataId) 

graphClient.GroupsById("group-id").Members().Ref().Post(context.Background(), requestBody, nil)

``` 