### PR TITLE
[dotnet] Aligns snippet generation to namespace and request builder changes

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -383,7 +383,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("var requestBody = new Microsoft.Graph.Users.Item.SendMail.SendMailPostRequestBody", result);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Users.Item.MicrosoftGraphSendMail.SendMailPostRequestBody", result);
             Assert.Contains("ToRecipients = new List<Recipient>", result);
         }
         
@@ -496,7 +496,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("await graphClient.Teams[\"team-id\"].Archive.PostAsync(null);", result);
+            Assert.Contains("await graphClient.Teams[\"team-id\"].MicrosoftGraphArchive.PostAsync(null);", result);
         }
         
         [Fact]
@@ -542,7 +542,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.AddKey.AddKeyPostRequestBody", result);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.MicrosoftGraphAddKey.AddKeyPostRequestBody", result);
         }
         [Fact]
         public async Task CorrectlyEvaluatesGuidInRequestBodyParameter()

--- a/CodeSnippetsReflection.OpenAPI/KiotaOpenApiUrlTreeNodeExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/KiotaOpenApiUrlTreeNodeExtensions.cs
@@ -64,7 +64,7 @@ namespace CodeSnippetsReflection.OpenAPI {
                     ?.Select(replaceSingleParameterSegmentByItem)
                     ?.Select(static x => CleanupParametersFromPath((x ?? string.Empty).Split('.', StringSplitOptions.RemoveEmptyEntries)
                         ?.Select(static x => x.TrimStart('$').ToFirstCharacterUpperCase()) //$ref from OData
-                        .Aggregate((x,y) => $"{x}{y}")))
+                        .Aggregate(static (x,y) => $"{x}{y}")))
                     ?.Select(static x => x.CleanupSymbolName())
                     ?.Aggregate(string.Empty, 
                         static (x, y) => $"{x}{GetDotIfBothNotNullOfEmpty(x, y)}{y}") :

--- a/CodeSnippetsReflection.OpenAPI/KiotaOpenApiUrlTreeNodeExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/KiotaOpenApiUrlTreeNodeExtensions.cs
@@ -63,8 +63,8 @@ namespace CodeSnippetsReflection.OpenAPI {
                     ?.Split(pathNameSeparator, StringSplitOptions.RemoveEmptyEntries)
                     ?.Select(replaceSingleParameterSegmentByItem)
                     ?.Select(static x => CleanupParametersFromPath((x ?? string.Empty).Split('.', StringSplitOptions.RemoveEmptyEntries)
-                        ?.Select(static x => x.TrimStart('$')) //$ref from OData
-                        .Last()))
+                        ?.Select(static x => x.TrimStart('$').ToFirstCharacterUpperCase()) //$ref from OData
+                        .Aggregate((x,y) => $"{x}{y}")))
                     ?.Select(static x => x.CleanupSymbolName())
                     ?.Aggregate(string.Empty, 
                         static (x, y) => $"{x}{GetDotIfBothNotNullOfEmpty(x, y)}{y}") :

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -321,7 +321,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                         if(x.Segment.IsCollectionIndex())
                                             return x.Segment.Replace("{", "[\"").Replace("}", "\"]");
                                         if (x.Segment.IsFunction())
-                                            return x.Segment.Split('.').Last().ToFirstCharacterUpperCase();
+                                            return x.Segment.Split('.')
+                                                .Select(static s => s.ToFirstCharacterUpperCase())
+                                                .Aggregate((a, b) => $"{a}{b}");
                                         return x.Segment.ReplaceValueIdentifier().TrimStart('$').ToFirstCharacterUpperCase();
                                       })
                                 .Aggregate((x, y) =>

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -323,7 +323,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                         if (x.Segment.IsFunction())
                                             return x.Segment.Split('.')
                                                 .Select(static s => s.ToFirstCharacterUpperCase())
-                                                .Aggregate((a, b) => $"{a}{b}");
+                                                .Aggregate(static (a, b) => $"{a}{b}");
                                         return x.Segment.ReplaceValueIdentifier().TrimStart('$').ToFirstCharacterUpperCase();
                                       })
                                 .Aggregate((x, y) =>


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota/pull/2213

Aligns namespace name generation and path segment generation to updates made in Kiota.