### PR TITLE
[Go,TypeScript,Php] Aligns snippet generation to namespace and request builder changes

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -54,7 +54,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").Checkin().", result);
+            Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").MicrosoftGraphCheckin().", result);
         }
         [Fact]
         public async Task IgnoreOdataTypeWhenGenerating() {
@@ -360,7 +360,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.Directory().DeletedItems().Group().Get(context.Background(), nil)", result);
+            Assert.Contains("graphClient.Directory().DeletedItems().MicrosoftGraphGroup().Get(context.Background(), nil)", result);
         }
         [Fact]
         public async Task DoesntFailOnTerminalSlash() {

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -109,7 +109,7 @@ public class PhpGeneratorTests
             $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("$graphServiceClient->directory()->deletedItems()->group()->get()", result);
+        Assert.Contains("$graphServiceClient->directory()->deletedItems()->microsoftGraphGroup()->get()", result);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class PhpGeneratorTests
         using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/activities/recent");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("->me()->activities()->recent()->get()", result);
+        Assert.Contains("->me()->activities()->microsoftGraphRecent()->get()", result);
     }
 
     [Fact /*(Skip = "Should fail by default.")*/]

--- a/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
@@ -68,7 +68,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
 
             const result = async () => {
-	            await graphServiceClient.identityGovernance.accessReviews.definitionsById(""accessReviewScheduleDefinition-id"").instancesById(""accessReviewInstance-id"").batchRecordDecisions.post(requestBody);
+	            await graphServiceClient.identityGovernance.accessReviews.definitionsById(""accessReviewScheduleDefinition-id"").instancesById(""accessReviewInstance-id"").microsoftGraphBatchRecordDecisions.post(requestBody);
             }
             ";
 
@@ -271,7 +271,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
 
             const result = async () => {
-	            await graphServiceClient.me.findMeetingTimes.post(requestBody);
+	            await graphServiceClient.me.microsoftGraphFindMeetingTimes.post(requestBody);
             }
             ";
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -88,8 +88,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string GetActionParametersList(params string[] parameters)
         {
-            var nonEmptyParameters = parameters.Where(p => !string.IsNullOrEmpty(p));
-            return nonEmptyParameters.Any() ? string.Join(", ", nonEmptyParameters.Aggregate((a, b) => $"{a}, {b}")) : string.Empty;
+            var nonEmptyParameters = parameters.Where(static p => !string.IsNullOrEmpty(p));
+            return nonEmptyParameters.Any() ? string.Join(", ", nonEmptyParameters.Aggregate(static (a, b) => $"{a}, {b}")) : string.Empty;
         }
 
         private static void WriteRequestHeaders(SnippetCodeGraph snippetCodeGraph, IndentManager indentManager, StringBuilder stringBuilder)
@@ -131,7 +131,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 case PropertyType.Float64:
                     return queryParam.Value; // Numbers stay as is 
                 case PropertyType.Array:
-                    return $"new string []{{ {string.Join(",", queryParam.Children.Select(x =>  $"\"{x.Value}\"" ).ToList())} }}"; // deconstruct arrays
+                    return $"new string []{{ {string.Join(",", queryParam.Children.Select(static x =>  $"\"{x.Value}\"" ).ToList())} }}"; // deconstruct arrays
                 default:
                     return $"\"{queryParam.Value.EscapeQuotes()}\"";
             }
@@ -223,7 +223,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                             var enumMember = codeProperty.Children.FirstOrDefault( member => member.Value.Equals(enumHint,StringComparison.OrdinalIgnoreCase)).Value ?? codeProperty.Children.FirstOrDefault().Value ?? enumHint;
                             return $"{enumTypeString.TrimEnd('?')}.{enumMember.ToFirstCharacterUpperCase()}";
                         })
-                        .Aggregate((x, y) => $"{x} | {y}");
+                        .Aggregate(static (x, y) => $"{x} | {y}");
                     snippetBuilder.AppendLine($"{propertyAssignment}{enumValues}{assignmentSuffix}");
                     break;
                 case PropertyType.DateTime:
@@ -300,8 +300,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             namespaceName = namespaceName.Replace(DefaultNamespace,string.Empty, StringComparison.OrdinalIgnoreCase);
             
             var normalizedNameSpaceName = namespaceName.TrimStart('.').Split('.',StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => ReplaceIfReservedTypeName(x, "Namespace").ToFirstCharacterUpperCase())
-                .Aggregate((z, y) => z + '.' + y);
+                .Select(static x => ReplaceIfReservedTypeName(x, "Namespace").ToFirstCharacterUpperCase())
+                .Aggregate(static (z, y) => z + '.' + y);
 
             return $"{GetDefaultNamespaceName(apiVersion)}.{normalizedNameSpaceName}.";
         }
@@ -317,7 +317,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if(!(nodes?.Any() ?? false)) 
                 return string.Empty;
 
-            return nodes.Select(x => {
+            return nodes.Select(static x => {
                                         if(x.Segment.IsCollectionIndex())
                                             return x.Segment.Replace("{", "[\"").Replace("}", "\"]");
                                         if (x.Segment.IsFunction())
@@ -326,7 +326,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                                 .Aggregate(static (a, b) => $"{a}{b}");
                                         return x.Segment.ReplaceValueIdentifier().TrimStart('$').ToFirstCharacterUpperCase();
                                       })
-                                .Aggregate((x, y) =>
+                                .Aggregate(static (x, y) =>
                                 {
                                     var dot = y.StartsWith("[") ? string.Empty : ".";
                                     return $"{x}{dot}{y}";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -117,7 +117,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             if (!codeGraph.HasParameters()) return;
 
-            var nonArrayParams = codeGraph.Parameters.Where(x => x.PropertyType != PropertyType.Array);
+            var nonArrayParams = codeGraph.Parameters.Where(static x => x.PropertyType != PropertyType.Array);
 
             if (nonArrayParams.Any())
                 builder.AppendLine(string.Empty);
@@ -171,7 +171,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static string evaluateParameter(CodeProperty param)
         {
             if (param.PropertyType == PropertyType.Array)
-                return $"[] string {{{string.Join(",", param.Children.Select(x => $"\"{x.Value}\"").ToList())}}}";
+                return $"[] string {{{string.Join(",", param.Children.Select(static x => $"\"{x.Value}\"").ToList())}}}";
             else if (param.PropertyType == PropertyType.Boolean)
                 return param.Value;
             else if (param.PropertyType == PropertyType.Int32)
@@ -212,9 +212,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         }
         private static string GetActionParametersList(params string[] parameters)
         {
-            var nonEmptyParameters = parameters.Where(p => !string.IsNullOrEmpty(p));
+            var nonEmptyParameters = parameters.Where(static p => !string.IsNullOrEmpty(p));
             if (nonEmptyParameters.Any())
-                return string.Join(", ", nonEmptyParameters.Aggregate((a, b) => $"{a}, {b}"));
+                return string.Join(", ", nonEmptyParameters.Aggregate(static (a, b) => $"{a}, {b}"));
             else return string.Empty;
         }
 
@@ -303,7 +303,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 case PropertyType.Enum:
                     if (!String.IsNullOrWhiteSpace(child.Value))
                     {
-                        var enumProperties = string.Join("_", child.Value.Split('.').Reverse().Select(x => x.ToUpper()));
+                        var enumProperties = string.Join("_", child.Value.Split('.').Reverse().Select(static x => x.ToUpper()));
                         builder.AppendLine($"{indentManager.GetIndent()}{propertyName} := graphmodels.{enumProperties} ");
                         builder.AppendLine($"{indentManager.GetIndent()}{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}(&{propertyName}) ");
                     }
@@ -378,25 +378,24 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static void WriteCodePropertyObject(string propertyAssignment, StringBuilder builder, CodeProperty codeProperty, IndentManager indentManager)
         {
             var childPosition = 0;
-            foreach (var child in codeProperty.Children.Where(x => !specialProperties.Contains(x.Name.Trim())))
+            foreach (var child in codeProperty.Children.Where(static x => !specialProperties.Contains(x.Name.Trim())))
                 WriteCodeProperty(propertyAssignment, builder, codeProperty, child, indentManager, childPosition++);
         }
 
         private static string GetFluentApiPath(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
             if (!(nodes?.Any() ?? false)) return string.Empty;
-            return nodes.Select(x =>
+            return nodes.Select(static x =>
             {
                 if (x.Segment.IsCollectionIndex())
                     return $"ById{x.Segment.Replace("{", "(\"").Replace("}", "\")")}.";
                 else if (x.Segment.IsFunction())
-                    return x.Segment.Split('.').Last().ToFirstCharacterUpperCase() + "().";
+                    return x.Segment.Split('.')
+                                    .Select(static s => s.ToFirstCharacterUpperCase())
+                                    .Aggregate(static (a, b) => $"{a}{b}") + "().";
                 return x.Segment.ToFirstCharacterUpperCase() + "().";
             })
-                        .Aggregate((x, y) =>
-                        {
-                            return $"{x}{y}";
-                        })
+                        .Aggregate(static (x, y) => $"{x}{y}")
                         .Replace("().ById(", "ById(")
                         .Replace("()()", "()");
         }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -70,7 +70,7 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
         return param.PropertyType switch
         {
             PropertyType.Array =>
-                $"[{string.Join(",", param.Children.Select(x => $"\"{x.Value}\"").ToList())}]",
+                $"[{string.Join(",", param.Children.Select(static x => $"\"{x.Value}\"").ToList())}]",
             PropertyType.Boolean or PropertyType.Int32 or PropertyType.Double or PropertyType.Float32 or PropertyType.Float64 or PropertyType.Int64 => param.Value,
             _ => $"\"{param.Value.EscapeQuotes()}\""
         };
@@ -98,16 +98,16 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
         return (payloadSb.Length > 0 ? payloadSb.ToString() : default);
     }
     private static string GetActionParametersList(params string[] parameters) {
-        var nonEmptyParameters = parameters.Where(p => !string.IsNullOrEmpty(p));
+        var nonEmptyParameters = parameters.Where(static p => !string.IsNullOrEmpty(p));
         var emptyParameters = nonEmptyParameters.ToList();
         if(emptyParameters.Any())
-            return string.Join(", ", emptyParameters.Select(x => $"${x}").Aggregate((a, b) => $"{a}, {b}"));
+            return string.Join(", ", emptyParameters.Select(static x => $"${x}").Aggregate(static (a, b) => $"{a}, {b}"));
         return string.Empty;
     }
     
     private static string GetRequestHeaders(SnippetCodeGraph snippetModel, IndentManager indentManager) {
         var payloadSb = new StringBuilder();
-        var filteredHeaders = snippetModel.Headers?.Where(h => !h.Name.Equals("Host", StringComparison.OrdinalIgnoreCase))
+        var filteredHeaders = snippetModel.Headers?.Where(static h => !h.Name.Equals("Host", StringComparison.OrdinalIgnoreCase))
             .ToList();
         if(filteredHeaders != null && filteredHeaders.Any()) {
             payloadSb.AppendLine($"{indentManager.GetIndent()}${RequestHeadersVarName} = [");
@@ -332,15 +332,17 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
     {
         var openApiUrlTreeNodes = nodes.ToList();
         if (!(openApiUrlTreeNodes?.Any() ?? false)) return string.Empty;
-        var result = openApiUrlTreeNodes.Select(x =>
+        var result = openApiUrlTreeNodes.Select(static x =>
             {
                 if (x.Segment.IsCollectionIndex())
                     return $"ById{x.Segment.Replace("{", "('").Replace("}", "')")}";
                 if (x.Segment.IsFunction())
-                    return x.Segment.Split('.').Last().ToFirstCharacterLowerCase()+"()";
+                    return x.Segment.Split('.')
+                            .Select(static s => s.ToFirstCharacterUpperCase())
+                            .Aggregate(static (a, b) => $"{a}{b}").ToFirstCharacterLowerCase() + "()";
                 return x.Segment.ToFirstCharacterLowerCase()+"()";
             })
-            .Aggregate((x, y) =>
+            .Aggregate(static (x, y) =>
             {
                 var dot = y.StartsWith("ById") ? string.Empty : "->";
                 return $"{x.Trim('$')}{dot}{y.Trim('$')}";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/TypeScriptGenerator.cs
@@ -114,7 +114,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string evaluateParameter(CodeProperty param){
             if(param.PropertyType == PropertyType.Array)
-                return $"[{string.Join(",", param.Children.Select(x =>  $"\"{x.Value}\"" ).ToList())}]";
+                return $"[{string.Join(",", param.Children.Select(static x =>  $"\"{x.Value}\"" ).ToList())}]";
             else if (param.PropertyType == PropertyType.Boolean || param.PropertyType == PropertyType.Int32)
                 return param.Value;
             else
@@ -219,23 +219,25 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string GetActionParametersList(params string[] parameters)
         {
-            var nonEmptyParameters = parameters.Where(p => !string.IsNullOrEmpty(p));
+            var nonEmptyParameters = parameters.Where(static p => !string.IsNullOrEmpty(p));
             if (nonEmptyParameters.Any())
-                return string.Join(", ", nonEmptyParameters.Aggregate((a, b) => $"{a}, {b}"));
+                return string.Join(", ", nonEmptyParameters.Aggregate(static (a, b) => $"{a}, {b}"));
             else return string.Empty;
         }
 
         private static string GetFluentApiPath(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
             if (!(nodes?.Any() ?? false)) return string.Empty;
-            return nodes.Select(x => {
+            return nodes.Select(static x => {
                 if (x.Segment.IsCollectionIndex())
                     return $"ById{x.Segment.Replace("{", "(\"").Replace("}", "\")")}";
                 else if (x.Segment.IsFunction())
-                    return x.Segment.Split('.').Last().ToFirstCharacterLowerCase();
+                    return x.Segment.Split('.')
+                            .Select(static s => s.ToFirstCharacterUpperCase())
+                            .Aggregate(static (a, b) => $"{a}{b}").ToFirstCharacterLowerCase();
                 return x.Segment.ToFirstCharacterLowerCase();
             })
-                        .Aggregate((x, y) => {
+                        .Aggregate(static (x, y) => {
                             var dot = y.StartsWith("ById") ?
                                             string.Empty :
                                             ".";


### PR DESCRIPTION
This PR is a follow up to https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1364 and related to https://github.com/microsoft/kiota/pull/2213

In summary changes include :- 
- Aligns namespace name generation and path segment generation to updates made in Kiota in Go, Typescript and Php
- Updates a number of anonymous functions in touched files to be static anonymous functions where applicable