### PR TITLE
Update snippet generation pipelines to use .NET 6

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -58,9 +58,9 @@ steps:
 - template: templates/git-config.yml
 
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 5'
+  displayName: 'Install .NET Core SDK 6'
   inputs:
-    version: 5.x
+    version: 6.x
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK 7'


### PR DESCRIPTION
## Overview

API Doctor got upgraded to .NET 6. This PR updates the snippets generation pipeline to use .NET 6.

