### PR TITLE
[dotnet] Removes curly braces from generated snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -563,5 +563,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("Guid.Parse(\"8e881353-1735-45af-af21-ee1344582a4d\")", result);
             Assert.Contains("Guid.Parse(\"00000000-0000-0000-0000-000000000000\")", result);
         }
+        [Fact]
+        public async Task CorrectlyHandlesOdataFunction()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/delta?$select=displayName,jobTitle,mobilePhone");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.Users.MicrosoftGraphDelta.GetAsync", result);
+            Assert.Contains("requestConfiguration.QueryParameters.Select = new string []{ \"displayName\",\"jobTitle\",\"mobilePhone\" };", result);
+        }
     }
 }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -321,7 +321,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                         if(x.Segment.IsCollectionIndex())
                                             return x.Segment.Replace("{", "[\"").Replace("}", "\"]");
                                         if (x.Segment.IsFunction())
-                                            return x.Segment.Split('.')
+                                            return x.Segment.TrimEnd('(',')').Split('.')
                                                 .Select(static s => s.ToFirstCharacterUpperCase())
                                                 .Aggregate(static (a, b) => $"{a}{b}");
                                         return x.Segment.ReplaceValueIdentifier().TrimStart('$').ToFirstCharacterUpperCase();


### PR DESCRIPTION
Updates .Net snippet generation to fix for Odata functions with no function parameters to remove the curly braces.

previously
```cs
await graphClient.Users.MicrosoftGraphDelta().GetAsync();
```

which should now be
```cs
await graphClient.Users.MicrosoftGraphDelta.GetAsync();
```