### PR TITLE
Change go client factory to use credentials and scope

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -79,7 +79,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient := msgraphsdk.NewGraphServiceClient(requestAdapter)", result);
+            Assert.Contains("graphClient := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)", result);
         }
         [Fact]
         public async Task GeneratesTheGetMethodCall() {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -16,8 +16,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
     public class GoGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
     {
         private const string clientVarName = "graphClient";
-        private const string clientVarType = "GraphServiceClient";
-        private const string httpCoreVarName = "requestAdapter";
+        private const string clientVarType = "GraphServiceClientWithCredentials";
+        private const string clientFactoryVariables = "cred, scopes";
         private const string requestBodyVarName = "requestBody";
         private const string requestHeadersVarName = "headers";
         private const string optionsParameterVarName = "options";
@@ -41,7 +41,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var codeGraph = new SnippetCodeGraph(snippetModel);
             var snippetBuilder = new StringBuilder(
                                     "//THE GO SDK IS IN PREVIEW. NON-PRODUCTION USE ONLY" + Environment.NewLine +
-                                    $"{clientVarName} := msgraphsdk.New{clientVarType}({httpCoreVarName}){Environment.NewLine}{Environment.NewLine}");
+                                    $"{clientVarName} := msgraphsdk.New{clientVarType}({clientFactoryVariables}){Environment.NewLine}{Environment.NewLine}");
 
             writeSnippet(codeGraph, snippetBuilder);
 

--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -24,7 +24,7 @@ namespace CodeSnippetsReflection.OpenAPI
         private readonly SimpleLazy<OpenApiUrlTreeNode> _betaOpenApiDocument;
         private readonly SimpleLazy<OpenApiUrlTreeNode> _customOpenApiDocument;
         public OpenApiSnippetsGenerator(
-            string v1OpenApiDocumentUrl = "C:/Users/ronaldkudoyi/Code/openapi.yaml",
+            string v1OpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml",
             string betaOpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml",
             string customOpenApiPathOrUrl = default,
             TelemetryClient telemetryClient = null)

--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -24,7 +24,7 @@ namespace CodeSnippetsReflection.OpenAPI
         private readonly SimpleLazy<OpenApiUrlTreeNode> _betaOpenApiDocument;
         private readonly SimpleLazy<OpenApiUrlTreeNode> _customOpenApiDocument;
         public OpenApiSnippetsGenerator(
-            string v1OpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml",
+            string v1OpenApiDocumentUrl = "C:/Users/ronaldkudoyi/Code/openapi.yaml",
             string betaOpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml",
             string customOpenApiPathOrUrl = default,
             TelemetryClient telemetryClient = null)


### PR DESCRIPTION
Resolves https://github.com/microsoftgraph/microsoft-graph-docs/issues/20376

Changes Go client factory 
from `graphClient := msgraphsdk.NewGraphServiceClient(requestAdapter)` 
to `graphClient := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)`