### PR TITLE
Fixes tests

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -27,7 +27,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains(".Me.Messages[\"message-id\"]", result);
+            Assert.Contains(".Me.Messages[\"{message-id}\"]", result);
         }
         [Fact]
         public async Task GeneratesTheSnippetHeader() {
@@ -385,7 +385,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("await graphClient.Users[\"user-id\"].SendMail.PostAsync(requestBody);", result);
+            Assert.Contains("await graphClient.Users[\"{user-id}\"].SendMail.PostAsync(requestBody);", result);
             Assert.Contains("var requestBody = new Microsoft.Graph.Users.Item.SendMail.SendMailPostRequestBody", result);
             Assert.Contains("ToRecipients = new List<Recipient>", result);
         }
@@ -437,7 +437,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             // Assert `Directory` is replaced with `DirectoryObject`
-            Assert.Contains("await graphClient.Directory.AdministrativeUnits[\"administrativeUnit-id\"].ScopedRoleMembers.GetAsync()", result);
+            Assert.Contains("await graphClient.Directory.AdministrativeUnits[\"{administrativeUnit-id}\"].ScopedRoleMembers.GetAsync()", result);
         }
         
         [Fact]
@@ -499,7 +499,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("await graphClient.Teams[\"team-id\"].Archive.PostAsync(null);", result);
+            Assert.Contains("await graphClient.Teams[\"{team-id}\"].Archive.PostAsync(null);", result);
         }
         
         [Fact]

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -348,8 +348,10 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("LocationEmailAddress = \"conf32room1368@imgeek.onmicrosoft.com\",", result);
         }
         
-                [Fact]
-        public async Task FullyQualifiesActionRequestBodyType()
+        [Theory]
+        [InlineData("sendMail")]
+        [InlineData("microsoft.graph.sendMail")]
+        public async Task FullyQualifiesActionRequestBodyType(string sendMailString)
         {
             var bodyContent = @"{
                     ""message"": {
@@ -376,14 +378,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 ""saveToSentItems"": ""false""
             }";
 
-            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/users/{{id}}/sendMail")
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/users/{{id}}/{sendMailString}")
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("var requestBody = new Microsoft.Graph.Users.Item.MicrosoftGraphSendMail.SendMailPostRequestBody", result);
+            Assert.Contains("await graphClient.Users[\"user-id\"].SendMail.PostAsync(requestBody);", result);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Users.Item.SendMail.SendMailPostRequestBody", result);
             Assert.Contains("ToRecipients = new List<Recipient>", result);
         }
         
@@ -496,7 +499,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("await graphClient.Teams[\"team-id\"].MicrosoftGraphArchive.PostAsync(null);", result);
+            Assert.Contains("await graphClient.Teams[\"team-id\"].Archive.PostAsync(null);", result);
         }
         
         [Fact]
@@ -542,7 +545,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.MicrosoftGraphAddKey.AddKeyPostRequestBody", result);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.AddKey.AddKeyPostRequestBody", result);
         }
         [Fact]
         public async Task CorrectlyEvaluatesGuidInRequestBodyParameter()
@@ -570,7 +573,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
-            Assert.Contains("await graphClient.Users.MicrosoftGraphDelta.GetAsync", result);
+            Assert.Contains("await graphClient.Users.Delta.GetAsync", result);
             Assert.Contains("requestConfiguration.QueryParameters.Select = new string []{ \"displayName\",\"jobTitle\",\"mobilePhone\" };", result);
         }
     }

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -54,7 +54,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").MicrosoftGraphCheckin().", result);
+            Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").Checkin().", result);
         }
         [Fact]
         public async Task IgnoreOdataTypeWhenGenerating() {
@@ -360,7 +360,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.Directory().DeletedItems().MicrosoftGraphGroup().Get(context.Background(), nil)", result);
+            Assert.Contains("graphClient.Directory().DeletedItems().GraphGroup().Get(context.Background(), nil)", result);
         }
         [Fact]
         public async Task DoesntFailOnTerminalSlash() {

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -109,7 +109,7 @@ public class PhpGeneratorTests
             $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("$graphServiceClient->directory()->deletedItems()->microsoftGraphGroup()->get()", result);
+        Assert.Contains("$graphServiceClient->directory()->deletedItems()->graphGroup()->get()", result);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class PhpGeneratorTests
         using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/activities/recent");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("->me()->activities()->microsoftGraphRecent()->get()", result);
+        Assert.Contains("->me()->activities()->recent()->get()", result);
     }
 
     [Fact /*(Skip = "Should fail by default.")*/]

--- a/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
@@ -68,7 +68,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
 
             const result = async () => {
-	            await graphServiceClient.identityGovernance.accessReviews.definitionsById(""accessReviewScheduleDefinition-id"").instancesById(""accessReviewInstance-id"").microsoftGraphBatchRecordDecisions.post(requestBody);
+	            await graphServiceClient.identityGovernance.accessReviews.definitionsById(""accessReviewScheduleDefinition-id"").instancesById(""accessReviewInstance-id"").batchRecordDecisions.post(requestBody);
             }
             ";
 
@@ -271,7 +271,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
 
             const result = async () => {
-	            await graphServiceClient.me.microsoftGraphFindMeetingTimes.post(requestBody);
+	            await graphServiceClient.me.findMeetingTimes.post(requestBody);
             }
             ";
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -319,10 +319,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                         if(x.Segment.IsCollectionIndex())
                                             return x.Segment.Replace("{", "[\"").Replace("}", "\"]");
                                         if (x.Segment.IsFunction())
-                                            return x.Segment.TrimEnd('(',')').Split('.')
+                                            return x.Segment.RemoveFunctionBraces().Split('.')
                                                 .Select(static s => s.ToFirstCharacterUpperCase())
                                                 .Aggregate(static (a, b) => $"{a}{b}");
-                                        return x.Segment.ReplaceValueIdentifier().TrimStart('$').ToFirstCharacterUpperCase();
+                                        return x.Segment.ReplaceValueIdentifier().TrimStart('$').RemoveFunctionBraces().ToFirstCharacterUpperCase();
                                       })
                                 .Aggregate(static (x, y) =>
                                 {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -317,7 +317,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
             return nodes.Select(static x => {
                                         if(x.Segment.IsCollectionIndex())
-                                            return x.Segment.Replace("{", "[\"").Replace("}", "\"]");
+                                            return x.Segment.Replace("{", "[\"{").Replace("}", "}\"]");
                                         if (x.Segment.IsFunction())
                                             return x.Segment.RemoveFunctionBraces().Split('.')
                                                 .Select(static s => s.ToFirstCharacterUpperCase())

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -143,15 +143,15 @@ namespace CodeSnippetsReflection.OpenAPI
                 LoadNextNode(childNode, pathSegments);
                 return;
             }
-            if (node.Children.Keys.Any(x => x.Equals(pathSegment, StringComparison.OrdinalIgnoreCase)))
+            if (node.Children.Keys.Any(x => x.RemoveFunctionBraces().Equals(pathSegment, StringComparison.OrdinalIgnoreCase)))
             { // the casing in the description might be different than the casing in the snippet and this dictionary is CS
-                var caseChildNode = node.Children.First(x => x.Key.Equals(pathSegment, StringComparison.OrdinalIgnoreCase)).Value;
+                var caseChildNode = node.Children.First(x => x.Key.RemoveFunctionBraces().Equals(pathSegment, StringComparison.OrdinalIgnoreCase)).Value;
                 LoadNextNode(caseChildNode, pathSegments);
                 return;
             }
-            if (node.Children.Keys.Any(x => x.IsFunction()))
+            if (node.Children.Keys.Any(x => x.IsFunction()) || pathSegment.IsFunction())
             {
-                var actionChildNode = node.Children.FirstOrDefault(x => x.Key.Split('.').Last().Equals(pathSegment, StringComparison.OrdinalIgnoreCase));
+                var actionChildNode = node.Children.FirstOrDefault(x => x.Key.Split('.').Last().Equals(pathSegment.Split('.').Last(), StringComparison.OrdinalIgnoreCase));
                 if(actionChildNode.Value != null)
                 {
                     LoadNextNode(actionChildNode.Value, pathSegments);

--- a/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
@@ -10,6 +10,7 @@ internal static class StringExtensions
     internal static bool IsCollectionIndex(this string pathSegment) =>
         !string.IsNullOrEmpty(pathSegment) && pathSegment.StartsWith('{') && pathSegment.EndsWith('}');
     internal static bool IsFunction(this string pathSegment) => !string.IsNullOrEmpty(pathSegment) && pathSegment.Contains('.');
+    internal static string RemoveFunctionBraces(this string pathSegment) => pathSegment.TrimEnd('(',')');
     internal static string ReplaceValueIdentifier(this string original) =>
         original?.Replace("$value", "Content");
    


### PR DESCRIPTION
This PR fixes tests on the dev branch after the change in openAPI document structure to unblock these PRs

- https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1394 
- https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1393

It also updates snippet generation for C# to have curly braces on identifiers for raptor to match and replace ids effectively. 
