### PR TITLE
Feature: change open api gen process [Restore]

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -33,7 +33,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly IOpenApiService _openApiService;
- 
+
         public OpenApiController(IConfiguration configuration, IOpenApiService openApiService)
         {
             ArgumentNullException.ThrowIfNull(openApiService, nameof(openApiService));
@@ -46,16 +46,16 @@ namespace GraphWebApi.Controllers
         [Route("$openapi")]
         [HttpGet]
         public async Task<IActionResult> Get(
-                                    [FromQuery]string operationIds = null,
-                                    [FromQuery]string tags = null,
-                                    [FromQuery]string url = null,
-                                    [FromQuery]string openApiVersion = null,
-                                    [FromQuery]string title = "Partial Graph API",
-                                    [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                    [FromQuery]string format = null,
-                                    [FromQuery]string graphVersion = null,
-                                    [FromQuery]bool includeRequestBody = false,
-                                    [FromQuery]bool forceRefresh = false)
+                                    [FromQuery] string operationIds = null,
+                                    [FromQuery] string tags = null,
+                                    [FromQuery] string url = null,
+                                    [FromQuery] string openApiVersion = null,
+                                    [FromQuery] string title = "Partial Graph API",
+                                    [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                    [FromQuery] string format = null,
+                                    [FromQuery] string graphVersion = null,
+                                    [FromQuery] bool includeRequestBody = false,
+                                    [FromQuery] bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -72,11 +72,11 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi/operations")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery]string graphVersion = null,
-                                             [FromQuery]string openApiVersion = null,
-                                             [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                             [FromQuery]string format = null,
-                                             [FromQuery]bool forceRefresh = false)
+        public async Task<IActionResult> Get([FromQuery] string graphVersion = null,
+                                             [FromQuery] string openApiVersion = null,
+                                             [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                             [FromQuery] string format = null,
+                                             [FromQuery] bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -129,11 +129,11 @@ namespace GraphWebApi.Controllers
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
-            
+
             Response.ContentType = "application/json";
             Response.StatusCode = 200;
             await Response.StartAsync();
-            
+
             var writer = new Utf8JsonWriter(Response.BodyWriter, new JsonWriterOptions() { Indented = false });
             OpenApiService.ConvertOpenApiUrlTreeNodeToJson(writer, rootNode);
             await writer.FlushAsync();

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -14,8 +14,8 @@
   },
   "AllowedHosts": "*",
   "GraphMetadata": {
-    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsv1.0.xml",
-    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsAndAnnotationsbeta.xml"
+    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0",
+    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta"
   },
   "BlobStorage": {
     "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -55,6 +55,7 @@ namespace OpenAPIService
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
+        Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>();
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)
         {
@@ -62,7 +63,12 @@ namespace OpenAPIService
                ?? throw new ArgumentNullException(nameof(configuration), $"Value cannot be null: {nameof(configuration)}");
             _defaultForceRefreshTime = FileServiceHelper.GetFileCacheRefreshTime(_configuration[CacheRefreshTimeConfig]);
             _telemetryClient = telemetryClient;
-            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));            
+            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));
+
+            fileNames.Add(OpenApiStyle.GEAutocomplete, "graphexplorer");
+            fileNames.Add(OpenApiStyle.Plain, "openapi");
+            fileNames.Add(OpenApiStyle.PowerShell, "powershell");
+            fileNames.Add(OpenApiStyle.PowerPlatform, "openapi");
         }
 
         /// <summary>
@@ -573,8 +579,8 @@ namespace OpenAPIService
                 _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
                 _graphUriQueue.Enqueue(graphUri);
-
-                graphUri += "/openapi.yaml";
+                
+                graphUri += $"/{fileNames[openApiStyle]}.yaml";
 
                 OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
                 _OpenApiDocuments[cachedDoc] = source;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -582,7 +582,7 @@ namespace OpenAPIService
                 
                 graphUri += $"/{fileNames[openApiStyle]}.yaml";
 
-                OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
+                OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri));
                 _OpenApiDocuments[cachedDoc] = source;
                 _OpenApiDocumentsDateCreated[cachedDoc] = DateTime.UtcNow;
                 return source;
@@ -660,13 +660,13 @@ namespace OpenAPIService
             return subsetOpenApiDocument;
         }
 
-        private async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref, OpenApiStyle openApiStyle)
+        private async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref)
         {
             var stopwatch = new Stopwatch();
             var httpClient = CreateHttpClient();
 
             stopwatch.Start();
-            Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+            using Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
             stopwatch.Stop();
 
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -57,9 +57,9 @@ namespace OpenAPIService
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
         private static readonly Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>() {
             { OpenApiStyle.GEAutocomplete, "graphexplorer"},
-            { OpenApiStyle.Plain, "openapi"},
+            { OpenApiStyle.Plain, "default"},
             { OpenApiStyle.PowerShell, "powershell"},
-            { OpenApiStyle.PowerPlatform, "openapi"},
+            { OpenApiStyle.PowerPlatform, "default"},
          };
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -69,11 +69,6 @@ namespace OpenAPIService
             _defaultForceRefreshTime = FileServiceHelper.GetFileCacheRefreshTime(_configuration[CacheRefreshTimeConfig]);
             _telemetryClient = telemetryClient;
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));
-
-            fileNames.Add(OpenApiStyle.GEAutocomplete, "graphexplorer");
-            fileNames.Add(OpenApiStyle.Plain, "openapi");
-            fileNames.Add(OpenApiStyle.PowerShell, "powershell");
-            fileNames.Add(OpenApiStyle.PowerPlatform, "openapi");
         }
 
         /// <summary>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -573,6 +573,9 @@ namespace OpenAPIService
                 _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
                 _graphUriQueue.Enqueue(graphUri);
+
+                graphUri += "/openapi.yaml";
+
                 OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
                 _OpenApiDocuments[cachedDoc] = source;
                 _OpenApiDocumentsDateCreated[cachedDoc] = DateTime.UtcNow;
@@ -657,7 +660,7 @@ namespace OpenAPIService
             var httpClient = CreateHttpClient();
 
             stopwatch.Start();
-            Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+            Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
             stopwatch.Stop();
 
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
@@ -666,7 +669,7 @@ namespace OpenAPIService
                                          _openApiTraceProperties);
             _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
-            OpenApiDocument document = await ConvertCsdlToOpenApiAsync(csdl, GetOpenApiConvertSettings(openApiStyle));
+            OpenApiDocument document = new OpenApiStreamReader().Read(stream, out var diagnostic);
 
             return document;
         }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -55,7 +55,12 @@ namespace OpenAPIService
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
-        Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>();
+        private static readonly Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>() {
+            { OpenApiStyle.GEAutocomplete, "graphexplorer"},
+            { OpenApiStyle.Plain, "openapi"},
+            { OpenApiStyle.PowerShell, "powershell"},
+            { OpenApiStyle.PowerPlatform, "openapi"},
+         };
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)
         {


### PR DESCRIPTION
## Overview

Closes #1392 
Uses the yaml files in the metadata API to return pre-generated open api documents that have already been converted using the conversion settings


It is a restoration of the work done in #1393