### PR TITLE
Feature: change open api gen process 

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -142,6 +142,7 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi")]
         [HttpPost]
+        [Obsolete("No longer supported")]
         public async Task<IActionResult> Post([FromQuery] string operationIds = null,
                                               [FromQuery] string tags = null,
                                               [FromQuery] string url = null,
@@ -153,14 +154,8 @@ namespace GraphWebApi.Controllers
                                               [FromQuery] bool forceRefresh = false,
                                               [FromQuery] bool includeRequestBody = false)
         {
-            var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
-
-            var openApiConvertSettings = _openApiService.GetOpenApiConvertSettings(style);
-
-            var source = await _openApiService.ConvertCsdlToOpenApiAsync(Request.Body, openApiConvertSettings);
-
-            return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody);
-        }
+            throw new NotImplementedException();
+        }        
 
         private FileStreamResult CreateSubsetOpenApiDocument(string operationIds, string tags,
                                                              string url, OpenApiDocument source,

--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -33,7 +33,7 @@ namespace GraphWebApi.Controllers
     {
         private readonly IConfiguration _configuration;
         private readonly IOpenApiService _openApiService;
- 
+
         public OpenApiController(IConfiguration configuration, IOpenApiService openApiService)
         {
             ArgumentNullException.ThrowIfNull(openApiService, nameof(openApiService));
@@ -46,16 +46,16 @@ namespace GraphWebApi.Controllers
         [Route("$openapi")]
         [HttpGet]
         public async Task<IActionResult> Get(
-                                    [FromQuery]string operationIds = null,
-                                    [FromQuery]string tags = null,
-                                    [FromQuery]string url = null,
-                                    [FromQuery]string openApiVersion = null,
-                                    [FromQuery]string title = "Partial Graph API",
-                                    [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                    [FromQuery]string format = null,
-                                    [FromQuery]string graphVersion = null,
-                                    [FromQuery]bool includeRequestBody = false,
-                                    [FromQuery]bool forceRefresh = false)
+                                    [FromQuery] string operationIds = null,
+                                    [FromQuery] string tags = null,
+                                    [FromQuery] string url = null,
+                                    [FromQuery] string openApiVersion = null,
+                                    [FromQuery] string title = "Partial Graph API",
+                                    [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                    [FromQuery] string format = null,
+                                    [FromQuery] string graphVersion = null,
+                                    [FromQuery] bool includeRequestBody = false,
+                                    [FromQuery] bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -72,11 +72,11 @@ namespace GraphWebApi.Controllers
 
         [Route("openapi/operations")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery]string graphVersion = null,
-                                             [FromQuery]string openApiVersion = null,
-                                             [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                             [FromQuery]string format = null,
-                                             [FromQuery]bool forceRefresh = false)
+        public async Task<IActionResult> Get([FromQuery] string graphVersion = null,
+                                             [FromQuery] string openApiVersion = null,
+                                             [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                             [FromQuery] string format = null,
+                                             [FromQuery] bool forceRefresh = false)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -129,11 +129,11 @@ namespace GraphWebApi.Controllers
             }
 
             var rootNode = _openApiService.CreateOpenApiUrlTreeNode(sources);
-            
+
             Response.ContentType = "application/json";
             Response.StatusCode = 200;
             await Response.StartAsync();
-            
+
             var writer = new Utf8JsonWriter(Response.BodyWriter, new JsonWriterOptions() { Indented = false });
             OpenApiService.ConvertOpenApiUrlTreeNodeToJson(writer, rootNode);
             await writer.FlushAsync();

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -14,8 +14,8 @@
   },
   "AllowedHosts": "*",
   "GraphMetadata": {
-    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsv1.0.xml",
-    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsAndAnnotationsbeta.xml"
+    "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0",
+    "Beta": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta"
   },
   "BlobStorage": {
     "AzureConnectionString": "ENTER_AZURE_STORAGE_CONNECTION_STRING",

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,15 +2,20 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Writers;
 using OpenAPIService.Interfaces;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 
 namespace OpenAPIService.Test
 {
@@ -36,6 +41,17 @@ namespace OpenAPIService.Test
                                                     .Build();
 
             return new OpenApiService(configuration);
+        }
+
+        private OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument)
+        {
+            var stream = new MemoryStream();
+            var writer = new OpenApiYamlWriter(new StreamWriter(stream));
+            openApiDocument.SerializeAsV3(writer);
+            writer.Flush();
+            stream.Position = 0;
+            var reader = new OpenApiStreamReader();
+            return reader.Read(stream, out _); ;
         }
 
         /// <summary>
@@ -1216,7 +1232,7 @@ namespace OpenAPIService.Test
                 }
             };
 
-            return _openApiService.CloneOpenApiDocument(document);
+            return CloneOpenApiDocument(document);
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -627,39 +627,6 @@ namespace OpenAPIService.Test
             Assert.Equal("double", defaultPriceProperty.Format);
         }
 
-        [Theory]
-        [InlineData(OpenApiStyle.GEAutocomplete)]
-        [InlineData(OpenApiStyle.PowerPlatform)]
-        [InlineData(OpenApiStyle.PowerShell)]
-        public void ReturnsCorrectOpenApiConvertSettingsForStyle(OpenApiStyle openApiStyle)
-        {
-            var defaultSettings = _openApiService.GetOpenApiConvertSettings();
-            
-            // Act
-            var styleSettings = _openApiService.GetOpenApiConvertSettings(openApiStyle);
-
-            // Assert
-            if (openApiStyle == OpenApiStyle.PowerShell)
-            {
-                Assert.NotEqual(defaultSettings.EnablePagination, styleSettings.EnablePagination);
-                Assert.Equal(defaultSettings.TagDepth, styleSettings.TagDepth);
-                Assert.Equal(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
-            }
-            else if (openApiStyle == OpenApiStyle.PowerPlatform)
-            {
-                Assert.NotEqual(defaultSettings.TagDepth, styleSettings.TagDepth);
-                Assert.Equal(defaultSettings.EnablePagination, styleSettings.EnablePagination);
-                Assert.Equal(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
-
-            }
-            else if (openApiStyle == OpenApiStyle.GEAutocomplete)
-            {
-                Assert.NotEqual(defaultSettings.ExpandDerivedTypesNavigationProperties, styleSettings.ExpandDerivedTypesNavigationProperties);
-                Assert.Equal(defaultSettings.EnablePagination, styleSettings.EnablePagination);
-                Assert.Equal(defaultSettings.TagDepth, styleSettings.TagDepth);
-            }
-        }
-
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)
         {
             Assert.NotNull(node);

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -30,8 +30,6 @@ namespace OpenAPIService.Interfaces
 
         OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false);
 
-        OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument);
-
         OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain);
     }
 }

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -30,8 +30,6 @@ namespace OpenAPIService.Interfaces
 
         OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false);
 
-        Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl, OpenApiConvertSettings settings);
-
         OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument);
 
         OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain);

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -29,7 +29,5 @@ namespace OpenAPIService.Interfaces
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 
         OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false);
-
-        OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain);
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -55,7 +55,7 @@ namespace OpenAPIService
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
-        private static readonly Dictionary<OpenApiStyle, string> fileNames = new() {
+        private static readonly Dictionary<OpenApiStyle, string> _fileNames = new() {
             { OpenApiStyle.GEAutocomplete, "graphexplorer"},
             { OpenApiStyle.Plain, "default"},
             { OpenApiStyle.PowerShell, "powershell"},
@@ -154,7 +154,7 @@ namespace OpenAPIService
                                          SeverityLevel.Information,
                                          _openApiTraceProperties);
 
-            return CloneOpenApiDocument(subset);
+            return new OpenApiDocument(subset);
         }
 
         /// <summary>
@@ -580,7 +580,7 @@ namespace OpenAPIService
 
                 _graphUriQueue.Enqueue(graphUri);
                 
-                graphUri += $"/{fileNames[openApiStyle]}.yaml";
+                graphUri += $"/{_fileNames[openApiStyle]}.yaml";
 
                 OpenApiDocument source = await GetOpenApiDocumentAsync(new Uri(graphUri));
                 _OpenApiDocuments[cachedDoc] = source;
@@ -678,29 +678,6 @@ namespace OpenAPIService
             OpenApiDocument document = new OpenApiStreamReader().Read(stream, out var diagnostic);
 
             return document;
-        }
-
-        public OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain)
-        {
-            var globalConvertSettings = new OpenApiConvertSettings()
-            {
-                AddSingleQuotesForStringParameters = true,
-                AddEnumDescriptionExtension = true,
-                EnableKeyAsSegment = true,
-                EnableOperationId = true,
-                PrefixEntityTypeNameBeforeKey = true,
-                TagDepth = 2,
-                EnablePagination = true,
-                EnableDiscriminatorValue = false,
-                EnableDerivedTypesReferencesForRequestBody = false,
-                EnableDerivedTypesReferencesForResponses = false,
-                ShowRootPath = false,
-                ShowLinks = true,
-                ExpandDerivedTypesNavigationProperties = false
-            };
-
-            _configuration.GetSection($"OpenAPI:ConvertSettings:{style}").Bind(globalConvertSettings);
-            return globalConvertSettings;
         }
 
         private static IList<SearchResult> FindOperations(OpenApiDocument graphOpenApi, Func<OpenApiOperation, bool> predicate)

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -55,6 +55,7 @@ namespace OpenAPIService
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
+        Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>();
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)
         {
@@ -62,7 +63,12 @@ namespace OpenAPIService
                ?? throw new ArgumentNullException(nameof(configuration), $"Value cannot be null: {nameof(configuration)}");
             _defaultForceRefreshTime = FileServiceHelper.GetFileCacheRefreshTime(_configuration[CacheRefreshTimeConfig]);
             _telemetryClient = telemetryClient;
-            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));            
+            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));
+
+            fileNames.Add(OpenApiStyle.GEAutocomplete, "graphexplorer");
+            fileNames.Add(OpenApiStyle.Plain, "openapi");
+            fileNames.Add(OpenApiStyle.PowerShell, "powershell");
+            fileNames.Add(OpenApiStyle.PowerPlatform, "openapi");
         }
 
         /// <summary>
@@ -573,8 +579,8 @@ namespace OpenAPIService
                 _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
                 _graphUriQueue.Enqueue(graphUri);
-
-                graphUri += "/openapi.yaml";
+                
+                graphUri += $"/{fileNames[openApiStyle]}.yaml";
 
                 OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
                 _OpenApiDocuments[cachedDoc] = source;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -680,37 +680,6 @@ namespace OpenAPIService
             return document;
         }
 
-        /// <summary>
-        /// Converts CSDL to OpenAPI
-        /// </summary>
-        /// <param name="csdl">The CSDL stream.</param>
-        /// <returns>An OpenAPI document.</returns>
-        public async Task<OpenApiDocument> ConvertCsdlToOpenApiAsync(Stream csdl, OpenApiConvertSettings settings)
-        {
-            _telemetryClient?.TrackTrace("Converting CSDL stream to an OpenApi document.",
-                                         SeverityLevel.Information,
-                                         _openApiTraceProperties);
-
-            using var reader = new StreamReader(csdl);
-            var csdlTxt = await reader.ReadToEndAsync();
-            var edmModel = CsdlReader.Parse(XElement.Parse(csdlTxt).CreateReader());
-
-            OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
-
-            _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
-            _telemetryClient?.TrackTrace("Finished converting CSDL stream to an OpenApi document. " +
-                                        $"No. of paths: {document.Paths.Count}",
-                                         SeverityLevel.Information,
-                                         _openApiTraceProperties);
-            _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
-
-            // The output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance,
-            // so we write it out, and read it back in again to fix it up.
-            document = CloneOpenApiDocument(document);
-
-            return document;
-        }
-
         public OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument)
         {
             _telemetryClient?.TrackTrace("Cloning OpenAPI document.",

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -582,7 +582,7 @@ namespace OpenAPIService
                 
                 graphUri += $"/{fileNames[openApiStyle]}.yaml";
 
-                OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
+                OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri));
                 _OpenApiDocuments[cachedDoc] = source;
                 _OpenApiDocumentsDateCreated[cachedDoc] = DateTime.UtcNow;
                 return source;
@@ -660,13 +660,13 @@ namespace OpenAPIService
             return subsetOpenApiDocument;
         }
 
-        private async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref, OpenApiStyle openApiStyle)
+        private async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref)
         {
             var stopwatch = new Stopwatch();
             var httpClient = CreateHttpClient();
 
             stopwatch.Start();
-            Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+            using Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
             stopwatch.Stop();
 
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -57,9 +57,9 @@ namespace OpenAPIService
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
         private static readonly Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>() {
             { OpenApiStyle.GEAutocomplete, "graphexplorer"},
-            { OpenApiStyle.Plain, "openapi"},
+            { OpenApiStyle.Plain, "default"},
             { OpenApiStyle.PowerShell, "powershell"},
-            { OpenApiStyle.PowerPlatform, "openapi"},
+            { OpenApiStyle.PowerPlatform, "default"},
          };
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -680,27 +680,6 @@ namespace OpenAPIService
             return document;
         }
 
-        public OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument)
-        {
-            _telemetryClient?.TrackTrace("Cloning OpenAPI document.",
-                                         SeverityLevel.Information,
-                                         _openApiTraceProperties);
-
-            var stream = _streamManager.GetStream($"{nameof(OpenApiService)}.{nameof(CloneOpenApiDocument)}");
-            var writer = new OpenApiYamlWriter(new StreamWriter(stream));
-            openApiDocument.SerializeAsV3(writer);
-            writer.Flush();
-            stream.Position = 0;
-            var reader = new OpenApiStreamReader();
-            var doc = reader.Read(stream, out _);
-
-            _telemetryClient?.TrackTrace("Finished cloning OpenAPI document.",
-                                         SeverityLevel.Information,
-                                         _openApiTraceProperties);
-
-            return doc;
-        }
-
         public OpenApiConvertSettings GetOpenApiConvertSettings(OpenApiStyle style = OpenApiStyle.Plain)
         {
             var globalConvertSettings = new OpenApiConvertSettings()

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -69,11 +69,6 @@ namespace OpenAPIService
             _defaultForceRefreshTime = FileServiceHelper.GetFileCacheRefreshTime(_configuration[CacheRefreshTimeConfig]);
             _telemetryClient = telemetryClient;
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_OpenApi, nameof(OpenApiService));
-
-            fileNames.Add(OpenApiStyle.GEAutocomplete, "graphexplorer");
-            fileNames.Add(OpenApiStyle.Plain, "openapi");
-            fileNames.Add(OpenApiStyle.PowerShell, "powershell");
-            fileNames.Add(OpenApiStyle.PowerPlatform, "openapi");
         }
 
         /// <summary>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -573,6 +573,9 @@ namespace OpenAPIService
                 _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
                 _graphUriQueue.Enqueue(graphUri);
+
+                graphUri += "/openapi.yaml";
+
                 OpenApiDocument source = await CreateOpenApiDocumentAsync(new Uri(graphUri), openApiStyle);
                 _OpenApiDocuments[cachedDoc] = source;
                 _OpenApiDocumentsDateCreated[cachedDoc] = DateTime.UtcNow;
@@ -657,7 +660,7 @@ namespace OpenAPIService
             var httpClient = CreateHttpClient();
 
             stopwatch.Start();
-            Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
+            Stream stream = await httpClient.GetStreamAsync(csdlHref.OriginalString);
             stopwatch.Stop();
 
             _openApiTraceProperties.TryAdd(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(OpenApiService));
@@ -666,7 +669,7 @@ namespace OpenAPIService
                                          _openApiTraceProperties);
             _openApiTraceProperties.TryRemove(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, out string _);
 
-            OpenApiDocument document = await ConvertCsdlToOpenApiAsync(csdl, GetOpenApiConvertSettings(openApiStyle));
+            OpenApiDocument document = new OpenApiStreamReader().Read(stream, out var diagnostic);
 
             return document;
         }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -55,7 +55,12 @@ namespace OpenAPIService
         private readonly int _defaultForceRefreshTime; // time span for allowable forceRefresh of the OpenAPI document
         private readonly Queue<string> _graphUriQueue = new();
         private static readonly RecyclableMemoryStreamManager _streamManager = new();
-        Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>();
+        private static readonly Dictionary<OpenApiStyle, string> fileNames = new Dictionary<OpenApiStyle, string>() {
+            { OpenApiStyle.GEAutocomplete, "graphexplorer"},
+            { OpenApiStyle.Plain, "openapi"},
+            { OpenApiStyle.PowerShell, "powershell"},
+            { OpenApiStyle.PowerPlatform, "openapi"},
+         };
 
         public OpenApiService(IConfiguration configuration, TelemetryClient telemetryClient = null)
         {


### PR DESCRIPTION
## Overview

Closes #1392 
Uses the yaml files in the metadata API to return pre-generated open api documents that have already been converted using the conversion settings


It is a restoration of the work done in #1393

## Notes

Makes sure all the comments on this [PR comment ](https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1406#issuecomment-1456813052) by @irvinesunday  have been addressed