### PR TITLE
[Feature] Singularizes and deduplicates `operationIds` for PowerShell style

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -1025,6 +1025,25 @@ namespace OpenAPIService.Test
                                 }
                             }
                         }
+                    },
+                    ["/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.activate"] = new OpenApiPathItem
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Post, new OpenApiOperation
+                                {
+                                    Tags = new List<OpenApiTag>
+                                    {
+                                        new OpenApiTag()
+                                        {
+                                            Name = "identityGovernance.Actions"
+                                        }
+                                    },
+                                    OperationId = "identityGovernance.lifecycleWorkflows.workflows.workflow.activate"                                    
+                                }
+                            }
+                        }
                     }
                 },
                 Components = new OpenApiComponents

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -203,13 +203,15 @@ namespace OpenAPIService
             if (string.IsNullOrEmpty(operationId))
                 return operationId;
 
+            // Plurality is assumed to be words ending in 's'/'S'.
+            char[] plurals = { 's', 'S' };
+
             var segments = operationId.Split('.').ToList();
 
             // The last segment is ignored as a rule.
             for (int x = segments.Count - 2; x >= 0; x--)
             {
-                // Plurality is assumed to be words ending in 's'.
-                var segment = segments[x].TrimEnd('s');
+                var segment = segments[x].TrimEnd(plurals);
                 segments[x] = segment;
 
                 // If a segment name is contained in another segment,


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1408

This PR:
- Adds a function in the `PowerShellFormatter.cs` class that singularizes and deduplicates operation ids for PowerShell style.
- Adds and updates tests to validate the above.