### PR TITLE
Flatten anyOf to unblock AutoREST.PowerShell  v2 builds

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -2,16 +2,16 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
-using Microsoft.OpenApi;
-using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
-using OpenAPIService.Interfaces;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+using OpenAPIService.Interfaces;
 using UtilityService;
 using Xunit;
 
@@ -618,8 +618,7 @@ namespace OpenAPIService.Test
             var defaultPriceProperty = subsetOpenApiDocument.Components.Schemas["microsoft.graph.networkInterface"].Properties["defaultPrice"];
 
             Assert.Null(averageAudioDegradationProperty.AnyOf);
-            Assert.NotNull(averageAudioDegradationProperty.AllOf);
-            Assert.Equal("number", averageAudioDegradationProperty.AllOf.First().Type);
+            Assert.Equal("number", averageAudioDegradationProperty.Type);
             Assert.Equal("float", averageAudioDegradationProperty.Format);
             Assert.True(averageAudioDegradationProperty.Nullable);
             Assert.Null(defaultPriceProperty.OneOf);
@@ -634,7 +633,7 @@ namespace OpenAPIService.Test
         public void ReturnsCorrectOpenApiConvertSettingsForStyle(OpenApiStyle openApiStyle)
         {
             var defaultSettings = _openApiService.GetOpenApiConvertSettings();
-            
+
             // Act
             var styleSettings = _openApiService.GetOpenApiConvertSettings(openApiStyle);
 

--- a/OpenAPIService/AnyOfOneOfRemover.cs
+++ b/OpenAPIService/AnyOfOneOfRemover.cs
@@ -2,10 +2,9 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenAPIService
 {
@@ -13,11 +12,11 @@ namespace OpenAPIService
     {
         public override void Visit(OpenApiSchema schema)
         {
-            // Replace AnyOf with AllOf
             if (schema.AnyOf?.Any() ?? false)
             {
-                schema.AllOf = new List<OpenApiSchema>(schema.AnyOf); 
+                var newSchema = schema.AnyOf.FirstOrDefault();
                 schema.AnyOf = null;
+                FlattenSchema(schema, newSchema);
             }
 
             if (schema.OneOf?.Any() ?? false)


### PR DESCRIPTION
## Overview

This PR flattens anyOf to unblock AutoREST.PowerShell v2 builds. AllOf is only supported in AutoREST.PowerShell v3. PR #1416 replaces AnyOf with AllOf in DevXTest API, which is used for AutoREST.PowerShell v3 builds.