### PR TITLE
Add reporting into snippet generation process

### DIFF
--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
@@ -1,0 +1,67 @@
+﻿namespace CodeSnippetsPipeline.Test;
+
+[TestFixture]
+public class CodeSnippetsPipeline
+{
+    public static IEnumerable<TestCaseData> TestData => GetTestData();
+
+    private static IEnumerable<TestCaseData> GetTestData()
+    {
+        var getEnv = (string name) => Environment.GetEnvironmentVariable(name) ?? throw new ArgumentNullException($"env:{name}");
+
+        // enumerate all HTTP snippets in the folder
+        var snippetsPath = getEnv("SNIPPETS_PATH");
+        var language = getEnv("SNIPPET_LANGUAGE");
+        var version = getEnv("GRAPH_VERSION");
+        var snippets = Directory.EnumerateFiles(snippetsPath, $"*{version}-httpSnippet*", SearchOption.AllDirectories);
+
+        foreach(var snippetFullPath in snippets)
+        {
+            var snippetName = Path.GetFileNameWithoutExtension(snippetFullPath).Replace("-httpSnippet", "");
+            var testCase = new TestCaseData(snippetFullPath, language);
+            testCase.SetName(snippetName);
+            yield return testCase;
+        }
+    }
+
+    [Test]
+    [TestCaseSource(typeof(CodeSnippetsPipeline), nameof(TestData))]
+    public void Test(string httpSnippetFilePath, string language)
+    {
+        var fileName = Path.GetFileName(httpSnippetFilePath);
+        if (language == "http")
+        {
+            if (fileName.EndsWith("-httpSnippet"))
+            {
+                Assert.Pass();
+            }
+            else
+            {
+                Assert.Fail(File.ReadAllText(httpSnippetFilePath));
+            }
+        }
+        else
+        {
+            var expectedLanguageSnippetFileFullPath = string.Concat(httpSnippetFilePath.AsSpan(0, httpSnippetFilePath.LastIndexOf("-httpSnippet")), $"---{language}");
+            if (File.Exists(expectedLanguageSnippetFileFullPath))
+            {
+                Assert.Pass();
+            }
+            else
+            {
+                var expectedLanguageSnippetErrorFileFullPath = string.Concat(expectedLanguageSnippetFileFullPath, "-error");
+                if (File.Exists(expectedLanguageSnippetErrorFileFullPath))
+                {
+                    var message = "Original HTTP Snippet:" + Environment.NewLine + 
+                        File.ReadAllText(httpSnippetFilePath).TrimStart() + Environment.NewLine +
+                        File.ReadAllText(expectedLanguageSnippetErrorFileFullPath);
+                    Assert.Fail(message);
+                }
+                else
+                {
+                    Assert.Fail("Snippet file is not generated and exception message is not captured");
+                }
+            }
+        }
+    }
+}

--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
@@ -11,7 +11,7 @@ public class CodeSnippetsPipeline
 
         // enumerate all HTTP snippets in the folder
         var snippetsPath = getEnv("SNIPPETS_PATH");
-        var language = getEnv("SNIPPET_LANGUAGE");
+        var language = getEnv("SNIPPET_LANGUAGE").ToLowerInvariant();
         var version = getEnv("GRAPH_VERSION");
         var snippets = Directory.EnumerateFiles(snippetsPath, $"*{version}-httpSnippet*", SearchOption.AllDirectories);
 

--- a/CodeSnippetsPipeline.Test/Usings.cs
+++ b/CodeSnippetsPipeline.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29025.244
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33414.496
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphWebApi", "GraphWebApi\GraphWebApi.csproj", "{9B8D74F3-26AE-4B0E-BFB2-0D9CFF6327C1}"
 EndProject
@@ -59,7 +59,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FileService.Test", "FileSer
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TourStepsService", "TourStepsService\TourStepsService.csproj", "{FAA70974-DB8A-4BD0-BE55-CE45F1F27035}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TourStepsService.Test", "TourStepsService.Test\TourStepsService.Test.csproj", "{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TourStepsService.Test", "TourStepsService.Test\TourStepsService.Test.csproj", "{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeSnippetsPipeline.Test", "CodeSnippetsPipeline.Test\CodeSnippetsPipeline.Test.csproj", "{A2B71AE5-AA99-4D73-A6B9-41F2CA921F83}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -183,6 +185,10 @@ Global
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A22BF10-32DE-4F74-B0AD-1C8F5EC29143}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2B71AE5-AA99-4D73-A6B9-41F2CA921F83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2B71AE5-AA99-4D73-A6B9-41F2CA921F83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2B71AE5-AA99-4D73-A6B9-41F2CA921F83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2B71AE5-AA99-4D73-A6B9-41F2CA921F83}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -130,10 +130,10 @@ stages:
           GRAPH_VERSION: 'beta'
         ${{ each language in parameters.snippetLanguages }}:
           '${{ language }} v1':
-            SNIPPET_LANGUAGE: lower(${{ language }})
+            SNIPPET_LANGUAGE: ${{ lower(language) }})
             GRAPH_VERSION: 'v1'
           '${{ language }} beta':
-            SNIPPET_LANGUAGE: lower(${{ language }})
+            SNIPPET_LANGUAGE: ${{ lower(language) }})
             GRAPH_VERSION: 'beta'
 
     steps:

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -95,8 +95,15 @@ steps:
     $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
     Write-Host "Path to apidoctor tool: $apidoctorPath"
 
-    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "/bin/git"
+    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --temp-output-path $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets --lang $(snippetLanguages) --git-path "/bin/git"
   displayName: 'Generate snippets'
   workingDirectory: microsoft-graph-docs
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish snippets as artifact'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Snippets'
+    ArtifactName: 'Snippets'
+    publishLocation: 'Container'
 
 - template: templates/commit-changes.yml

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -127,7 +127,7 @@ stages:
         HttpBeta:
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-        - ${{ each language in parameters.snippetLanguages }}:
+        - ${{ each language in parameters.snippetLanguages.split(',') }}:
             - ${{ language }}V1:
               SNIPPET_LANGUAGE: ${{ language }}
               GRAPH_VERSION: 'v1'

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -130,10 +130,10 @@ stages:
           GRAPH_VERSION: 'beta'
         ${{ each language in parameters.snippetLanguages }}:
           '${{ language }} v1':
-            SNIPPET_LANGUAGE: ${{ lower(language) }})
+            SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'v1'
           '${{ language }} beta':
-            SNIPPET_LANGUAGE: ${{ lower(language) }})
+            SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'beta'
 
     steps:

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -105,5 +105,6 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/Snippets'
     ArtifactName: 'Snippets'
     publishLocation: 'Container'
+    StoreAsTar: true
 
 - template: templates/commit-changes.yml

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -127,12 +127,14 @@ stages:
         HttpBeta:
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-        CSharpV1:
-          SNIPPET_LANGUAGE: 'c#'
-          GRAPH_VERSION: 'v1'
-        CSharpBeta:
-          SNIPPET_LANGUAGE: 'c#'
-          GRAPH_VERSION: 'beta'
+        - ${{ each language in parameters.snippetLanguages }}:
+            - ${{ language }}V1:
+              SNIPPET_LANGUAGE: ${{ language }}
+              GRAPH_VERSION: 'v1'
+            - ${{ language }}Beta:
+              SNIPPET_LANGUAGE: ${{ language }}
+              GRAPH_VERSION: 'beta'
+
     steps:
     - template: templates/run-tests.yml
     

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -27,18 +27,15 @@ pool:
 
 parameters:
   - name: snippetLanguages
-    default: 'C#,JavaScript,Java,Go,PowerShell,PHP'
-    displayName: 'Languages to generate snippets (comma separated list)'
-  - name: languagesArray
     type: object
     default: ['C#', 'JavaScript', 'Java', 'Go', 'PowerShell', 'PHP']
-    displayName: 'Languages to generate snippets (array)'
+    displayName: 'Languages to generate snippets for'
 
 variables:
   buildConfiguration: 'Release'
   apidoctorPath: 'microsoft-graph-devx-api/apidoctor'
   apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
-  snippetLanguages: ${{ parameters.snippetLanguages }}
+  snippetLanguages: ${{ join(',' parameters.snippetLanguages) }}
 
 stages:
 - stage: GenerateSnippets

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -128,7 +128,7 @@ stages:
         HttpBeta:
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-        ${{ each language in languagesArray }}:
+        ${{ each language in parameters.snippetLanguages }}:
           ${{ language }}V1:
             SNIPPET_LANGUAGE: ${{ language }}
             GRAPH_VERSION: 'v1'

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -29,6 +29,10 @@ parameters:
   - name: snippetLanguages
     default: 'C#,JavaScript,Java,Go,PowerShell,PHP'
     displayName: 'Languages to generate snippets (comma separated list)'
+  - name: languagesArray
+    type: object
+    default: ['C#', 'JavaScript', 'Java', 'Go', 'PowerShell', 'PHP']
+    displayName: 'Languages to generate snippets (array)'
 
 variables:
   buildConfiguration: 'Release'
@@ -127,13 +131,13 @@ stages:
         HttpBeta:
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-        - ${{ each language in parameters.snippetLanguages.split(',') }}:
-            - ${{ language }}V1:
-              SNIPPET_LANGUAGE: ${{ language }}
-              GRAPH_VERSION: 'v1'
-            - ${{ language }}Beta:
-              SNIPPET_LANGUAGE: ${{ language }}
-              GRAPH_VERSION: 'beta'
+        ${{ each language in languagesArray }}:
+          ${{ language }}V1:
+            SNIPPET_LANGUAGE: ${{ language }}
+            GRAPH_VERSION: 'v1'
+          ${{ language }}Beta:
+            SNIPPET_LANGUAGE: ${{ language }}
+            GRAPH_VERSION: 'beta'
 
     steps:
     - template: templates/run-tests.yml

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -119,6 +119,20 @@ stages:
   displayName: Run tests
   jobs:
   - job: RunTests
+    strategy:
+      matrix:
+        HttpV1:
+          SNIPPET_LANGUAGE: 'http'
+          GRAPH_VERSION: 'v1'
+        HttpBeta:
+          SNIPPET_LANGUAGE: 'http'
+          GRAPH_VERSION: 'beta'
+        CSharpV1:
+          SNIPPET_LANGUAGE: 'c#'
+          GRAPH_VERSION: 'v1'
+        CSharpBeta:
+          SNIPPET_LANGUAGE: 'c#'
+          GRAPH_VERSION: 'beta'
     steps:
     - template: templates/run-tests.yml
     

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -122,19 +122,17 @@ stages:
   - job: RunTests
     strategy:
       matrix:
-        HttpV1:
+        'HTTP v1':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'v1'
-        HttpBeta:
+        'HTTP beta':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
         ${{ each language in parameters.snippetLanguages }}:
-          ${{ language }}V1:
-            SNIPPET_LANGUAGE: ${{ language }}
-            GRAPH_VERSION: 'v1'
-          ${{ language }}Beta:
-            SNIPPET_LANGUAGE: ${{ language }}
-            GRAPH_VERSION: 'beta'
+          ${{ each version in ['v1', 'beta'] }}:
+            '${{ language }} ${{ version }}':
+              SNIPPET_LANGUAGE: lower(${{ language }})
+              GRAPH_VERSION: ${{ version }}
 
     steps:
     - template: templates/run-tests.yml

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -129,10 +129,12 @@ stages:
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
         ${{ each language in parameters.snippetLanguages }}:
-          ${{ each version in ['v1', 'beta'] }}:
-            '${{ language }} ${{ version }}':
-              SNIPPET_LANGUAGE: lower(${{ language }})
-              GRAPH_VERSION: ${{ version }}
+          '${{ language }} v1':
+            SNIPPET_LANGUAGE: lower(${{ language }})
+            GRAPH_VERSION: 'v1'
+          '${{ language }} beta':
+            SNIPPET_LANGUAGE: lower(${{ language }})
+            GRAPH_VERSION: 'beta'
 
     steps:
     - template: templates/run-tests.yml

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -36,75 +36,91 @@ variables:
   apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
   snippetLanguages: ${{ parameters.snippetLanguages }}
 
-steps:
-- checkout: self
-  displayName: checkout GE api
-  fetchDepth: 1
-  submodules: recursive
-  persistCredentials: true
+stages:
+- stage: GenerateSnippets
+  displayName: Generate snippets
+  jobs:
+  - job: GenerateSnippets
+    displayName: Generate snippets
+    steps:
+    - checkout: self
+      displayName: checkout GE api
+      fetchDepth: 1
+      submodules: recursive
+      persistCredentials: true
 
-- checkout: microsoft-graph-docs
-  displayName: checkout docs
-  fetchDepth: 1
-  persistCredentials: true
+    - checkout: microsoft-graph-docs
+      displayName: checkout docs
+      fetchDepth: 1
+      persistCredentials: true
 
-- pwsh: |
-    # override branch prefix incase the run is manually triggered
-    $branchPrefix = if ($env:BUILD_REASON -eq 'Manual') { "preview-snippet-generation" } else { "snippet-generation" }
-    Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
-    Write-Host "Branch prefix is $branchPrefix"
-  displayName: 'Evaluate branch prefix to use'
+    - pwsh: |
+        # override branch prefix incase the run is manually triggered
+        $branchPrefix = if ($env:BUILD_REASON -eq 'Manual') { "preview-snippet-generation" } else { "snippet-generation" }
+        Write-Host "##vso[task.setvariable variable=branchPrefix]$branchPrefix"
+        Write-Host "Branch prefix is $branchPrefix"
+      displayName: 'Evaluate branch prefix to use'
 
-- template: templates/git-config.yml
+    - template: templates/git-config.yml
 
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 6'
-  inputs:
-    version: 6.x
+    - task: UseDotNet@2
+      displayName: 'Install .NET Core SDK 6'
+      inputs:
+        version: 6.x
 
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 7'
-  inputs:
-    version: 7.0.x
+    - task: UseDotNet@2
+      displayName: 'Install .NET Core SDK 7'
+      inputs:
+        version: 7.0.x
 
-- task: DotNetCoreCLI@2
-  displayName: 'Build snippet generator'
-  inputs:
-    command: 'build'
-    projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj'
-    arguments: '--configuration $(buildConfiguration)'
+    - task: DotNetCoreCLI@2
+      displayName: 'Build snippet generator'
+      inputs:
+        command: 'build'
+        projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj'
+        arguments: '--configuration $(buildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Restore packages for APIDoctor'
-  inputs:
-    command: 'restore'
-    projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
+    - task: DotNetCoreCLI@2
+      displayName: 'Restore packages for APIDoctor'
+      inputs:
+        command: 'restore'
+        projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Build APIDoctor'
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
-    arguments: '--configuration $(buildConfiguration)'
+    - task: DotNetCoreCLI@2
+      displayName: 'Build APIDoctor'
+      inputs:
+        command: 'build'
+        projects: '$(Build.SourcesDirectory)/$(apidoctorProjects)'
+        arguments: '--configuration $(buildConfiguration)'
 
-- pwsh: |
-    # release folder can change based on .NET core version, so search recursively in bin folder
-    $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
-    Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
+    - pwsh: |
+        # release folder can change based on .NET core version, so search recursively in bin folder
+        $snippetGeneratorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/CodeSnippetsReflection.App/bin/Release *App -Recurse).FullName
+        Write-Host "Path to snippet generator tool: $snippetGeneratorPath"
 
-    $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
-    Write-Host "Path to apidoctor tool: $apidoctorPath"
+        $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release apidoc -Recurse).FullName
+        Write-Host "Path to apidoctor tool: $apidoctorPath"
 
-    . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --temp-output-path $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets --lang $(snippetLanguages) --git-path "/bin/git"
-  displayName: 'Generate snippets'
-  workingDirectory: microsoft-graph-docs
+        . $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --temp-output-path $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets --lang $(snippetLanguages) --git-path "/bin/git"
+      displayName: 'Generate snippets'
+      workingDirectory: microsoft-graph-docs
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish snippets as artifact'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Snippets'
-    ArtifactName: 'Snippets'
-    publishLocation: 'Container'
-    StoreAsTar: true
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish snippets as artifact'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)/Snippets'
+        ArtifactName: 'Snippets'
+        publishLocation: 'Container'
+        StoreAsTar: true
 
-- template: templates/commit-changes.yml
+    - template: templates/commit-changes.yml
+- stage: RunTests
+  dependsOn: GenerateSnippets
+  displayName: Run tests
+  jobs:
+  - job: RunTests
+    steps:
+    - template: templates/run-tests.yml
+    
+    
+    

--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -35,7 +35,7 @@ variables:
   buildConfiguration: 'Release'
   apidoctorPath: 'microsoft-graph-devx-api/apidoctor'
   apidoctorProjects: '$(apidoctorPath)/**/*.csproj'
-  snippetLanguages: ${{ join(',' parameters.snippetLanguages) }}
+  snippetLanguages: ${{ join(',',parameters.snippetLanguages) }}
 
 stages:
 - stage: GenerateSnippets

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -29,6 +29,9 @@ steps:
     projects: '**/CodeSnippetsPipeline.Test.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
+- pwsh: |
+    Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
+
 - task: DotNetCoreCLI@2
   displayName: 'Run CodeSnippetsPipeline.Test'
   inputs:
@@ -44,6 +47,5 @@ steps:
   inputs:
     testResultsFormat: 'VSTest'
     testResultsFiles: '**/TestResults.trx'
-    searchFolder: '$(Build.SourcesDirectory)/microsoft-graph-devx-api/CodeSnippetsReflection.Test'
-    mergeTestResults: true
+    mergeTestResults: false
     failTaskOnFailedTests: true

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -37,7 +37,7 @@ steps:
 
 - pwsh: |
     Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
-    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger trx;logfilename=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
+    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger "trx;logfilename=TestResults.trx" --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
   displayName: 'Run CodeSnippetsPipeline.Test'
   env:
     BUILD_CONFIGURATION: '$(buildConfiguration)'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -31,13 +31,14 @@ steps:
 
 - pwsh: |
     Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
+    ls $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets
 
 - task: DotNetCoreCLI@2
   displayName: 'Run CodeSnippetsPipeline.Test'
   inputs:
     command: 'test'
     projects: '**/CodeSnippetsPipeline.Test.csproj'
-    arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx'
+    arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx --results-directory $(Build.ArtifactStagingDirectory)/TestResults'
     publishTestResults: true
   env:
     SNIPPETS_PATH: '$(Build.ArtifactStagingDirectory)/Snippets'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -1,0 +1,51 @@
+steps:
+- checkout: self
+  displayName: checkout GE api
+  fetchDepth: 1
+  submodules: recursive
+  persistCredentials: true
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download snippets artifact'
+  inputs:
+    artifact: 'Snippets'
+    path: '$(Build.ArtifactStagingDirectory)/Snippets'
+    extractTars: true
+
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK 6'
+  inputs:
+    version: 6.x
+
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK 7'
+  inputs:
+    version: 7.0.x
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build CodeSnippetsPipeline.Test'
+  inputs:
+    command: 'build'
+    projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.Test/CodeSnippetsPipeline.Test.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run CodeSnippetsPipeline.Test'
+  inputs:
+    command: 'test'
+    projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.Test/CodeSnippetsPipeline.Test.csproj'
+    arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx'
+    publishTestResults: true
+  env:
+    SNIPPETS_PATH: '$(Build.ArtifactStagingDirectory)/Snippets'
+    SNIPPET_LANGUAGE: 'http'
+    GRAPH_VERSION: 'v1'
+
+- task: PublishTestResults@2
+  displayName: 'Publish test results'
+  inputs:
+    testResultsFormat: 'VSTest'
+    testResultsFiles: '**/TestResults.trx'
+    searchFolder: '$(Build.SourcesDirectory)/microsoft-graph-devx-api/CodeSnippetsReflection.Test'
+    mergeTestResults: true
+    failTaskOnFailedTests: true

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -26,20 +26,18 @@ steps:
   displayName: 'Build CodeSnippetsPipeline.Test'
   inputs:
     command: 'build'
-    projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.Test/CodeSnippetsPipeline.Test.csproj'
+    projects: 'microsoft-graph-devx-api/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run CodeSnippetsPipeline.Test'
   inputs:
     command: 'test'
-    projects: 'microsoft-graph-devx-api/CodeSnippetsReflection.Test/CodeSnippetsPipeline.Test.csproj'
+    projects: 'microsoft-graph-devx-api/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj'
     arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx'
     publishTestResults: true
   env:
     SNIPPETS_PATH: '$(Build.ArtifactStagingDirectory)/Snippets'
-    SNIPPET_LANGUAGE: 'http'
-    GRAPH_VERSION: 'v1'
 
 - task: PublishTestResults@2
   displayName: 'Publish test results'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -10,7 +10,13 @@ steps:
   inputs:
     artifact: 'Snippets'
     path: '$(Build.ArtifactStagingDirectory)/Snippets'
-    extractTars: true
+
+- task: ExtractFiles@1
+  displayName: 'Extract snippets artifact'
+  inputs:
+    archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/Snippets/*.tar'
+    destinationFolder: '$(Build.ArtifactStagingDirectory)/Snippets'
+    cleanDestinationFolder: false
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK 6'
@@ -32,15 +38,10 @@ steps:
 - pwsh: |
     Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
     ls $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets
-
-- task: DotNetCoreCLI@2
+    dotnet test --configuration $env:BUILD_CONFIGURATION --logger trx;LogFileName=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
   displayName: 'Run CodeSnippetsPipeline.Test'
-  inputs:
-    command: 'test'
-    projects: '**/CodeSnippetsPipeline.Test.csproj'
-    arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx --results-directory $(Build.ArtifactStagingDirectory)/TestResults'
-    publishTestResults: true
   env:
+    BUILD_CONFIGURATION: '$(buildConfiguration)'
     SNIPPETS_PATH: '$(Build.ArtifactStagingDirectory)/Snippets'
 
 - task: PublishTestResults@2
@@ -48,5 +49,6 @@ steps:
   inputs:
     testResultsFormat: 'VSTest'
     testResultsFiles: '**/TestResults.trx'
+    searchFolder: '$(Build.ArtifactStagingDirectory)/TestResults'
     mergeTestResults: false
     failTaskOnFailedTests: true

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -37,12 +37,12 @@ steps:
 
 - pwsh: |
     Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
-    ls $env:BUILD_ARTIFACTSTAGINGDIRECTORY/Snippets
-    dotnet test --configuration $env:BUILD_CONFIGURATION --logger trx;LogFileName=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
+    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger trx;LogFileName=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
   displayName: 'Run CodeSnippetsPipeline.Test'
   env:
     BUILD_CONFIGURATION: '$(buildConfiguration)'
     SNIPPETS_PATH: '$(Build.ArtifactStagingDirectory)/Snippets'
+  continueOnError: true
 
 - task: PublishTestResults@2
   displayName: 'Publish test results'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -37,7 +37,7 @@ steps:
 
 - pwsh: |
     Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION"
-    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger trx;LogFileName=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
+    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger trx;logfilename=TestResults.trx --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
   displayName: 'Run CodeSnippetsPipeline.Test'
   env:
     BUILD_CONFIGURATION: '$(buildConfiguration)'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -19,14 +19,9 @@ steps:
     cleanDestinationFolder: false
 
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 6'
+  displayName: 'Install .NET SDK 7'
   inputs:
-    version: 6.x
-
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 7'
-  inputs:
-    version: 7.0.x
+    version: 7.x
 
 - task: DotNetCoreCLI@2
   displayName: 'Build CodeSnippetsPipeline.Test'

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -26,14 +26,14 @@ steps:
   displayName: 'Build CodeSnippetsPipeline.Test'
   inputs:
     command: 'build'
-    projects: 'microsoft-graph-devx-api/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj'
+    projects: '**/CodeSnippetsPipeline.Test.csproj'
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run CodeSnippetsPipeline.Test'
   inputs:
     command: 'test'
-    projects: 'microsoft-graph-devx-api/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.Test.csproj'
+    projects: '**/CodeSnippetsPipeline.Test.csproj'
     arguments: '--configuration $(buildConfiguration) --logger trx;LogFileName=TestResults.trx'
     publishTestResults: true
   env:

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -44,6 +44,7 @@ steps:
   inputs:
     testResultsFormat: 'VSTest'
     testResultsFiles: '**/TestResults.trx'
+    testRunTitle: 'Snippet Generation $(SNIPPET_LANGUAGE) $(GRAPH_VERSION)'
     searchFolder: '$(Build.ArtifactStagingDirectory)/TestResults'
     mergeTestResults: false
-    failTaskOnFailedTests: true
+    failTaskOnFailedTests: false


### PR DESCRIPTION
## Overview

- adds analysis into snippet generation failures
- makes the main snippet generation process a separate stage which outputs temp snippet files into build artifacts
- adds stages per language/version pairs to evaluate failures and report them as test failures
- adds http evaluation stages which report on naming collisions (which is a broken assumption in naming examples in docs)
- auto generates stages from the languages input to the pipeline
- uses consistent naming for test runs so that we can query and run analysis on them using Azure DevOps analytics endpoints.
- fixes https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/1702

### Demo
[Snippet Generation Azure DevOps Dashboard](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_dashboards/dashboard/3e5453b0-06f8-4ecd-a7f2-34c22ae6496a)

[Example pipeline run](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=109138&view=results)
