### PR TITLE
adds go import statements

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -35,6 +35,17 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains(".Me().Messages()", result);
         }
         [Fact]
+        public async Task GeneratesMeImportFromUserPackage()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages?$select=sender,subject");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("import", result);
+            Assert.Contains("graphconfig \"github.com/microsoftgraph/msgraph-sdk-go/users\"", result);
+            Assert.Contains("msgraphsdk \"github.com/microsoftgraph/msgraph-sdk-go\"", result);
+            Assert.Contains(".Me().Messages()", result);
+        }
+        [Fact]
         public async Task GeneratesTheCorrectFluentAPIPathForIndexedCollections() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
@@ -311,6 +322,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("import", result);
+            Assert.Contains("abstractions \"github.com/microsoft/kiota-abstractions-go\"", result);
             Assert.Contains("headers := abstractions.NewRequestHeaders()", result);
             Assert.Contains("headers.Add(\"ConsistencyLevel\", \"eventual\")", result);
             Assert.Contains("graphconfig.GroupsRequestBuilderGetRequestConfiguration", result);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -123,7 +123,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static Boolean searchProperty(IEnumerable<CodeProperty> properties, PropertyType propertyType)
         {
-            return properties != null && propertyType == properties.FirstOrDefault(x => searchProperty(x, propertyType))?.PropertyType;
+            return properties != null && propertyType == properties.FirstOrDefault(x => searchProperty(x, propertyType)).PropertyType;
         }
 
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -123,7 +123,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static Boolean searchProperty(IEnumerable<CodeProperty> properties, PropertyType propertyType)
         {
-            return properties != null && propertyType == properties.FirstOrDefault(x => searchProperty(x, propertyType)).PropertyType;
+            return properties != null && propertyType == properties.FirstOrDefault(x => searchProperty(x, propertyType))?.PropertyType;
         }
 
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Immutable;
@@ -7,6 +7,8 @@ using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Services;
 using System.Text.RegularExpressions;
+using Microsoft.OpenApi.Expressions;
+using System.Diagnostics.Metrics;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -21,9 +23,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private const string requestOptionsVarName = "options";
         private const string requestParametersVarName = "requestParameters";
         private const string requestConfigurationVarName = "configuration";
-        
+
         private static IImmutableSet<string> specialProperties = ImmutableHashSet.Create("@odata.type");
-        
+
         private static IImmutableSet<string> NativeTypes = GetNativeTypes();
 
         private static readonly Regex PropertyNameRegex = new Regex(@"@(.*)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
@@ -38,17 +40,106 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (snippetModel == null) throw new ArgumentNullException("Argument snippetModel cannot be null");
 
             var codeGraph = new SnippetCodeGraph(snippetModel);
-            var snippetBuilder = new StringBuilder(
-                                    "//THE GO SDK IS IN PREVIEW. NON-PRODUCTION USE ONLY" + Environment.NewLine +
-                                    $"{clientVarName} := msgraphsdk.New{clientVarType}({clientFactoryVariables}){Environment.NewLine}{Environment.NewLine}");
+            var snippetBuilder = new StringBuilder("//THE GO SDK IS IN PREVIEW. NON-PRODUCTION USE ONLY");
+            snippetBuilder.AppendLine("");
 
+            writeImportStatements(codeGraph, snippetBuilder);
             writeSnippet(codeGraph, snippetBuilder);
 
             return snippetBuilder.ToString();
         }
 
+        private static void writeImportStatements(SnippetCodeGraph codeGraph, StringBuilder builder)
+        {
+            var apiVersion = codeGraph.ApiVersion == "v1.0" ? "msgraph-sdk-go" : "msgraph-beta-sdk-go";
+            builder.AppendLine("import (");
+            builder.AppendLine("\t  \"context\""); // default
+
+
+            if (hasPropertyOfType(codeGraph, PropertyType.DateTime))
+                builder.AppendLine("\t  \"time\""); // conditional time import
+
+            if (hasPropertyOfType(codeGraph, PropertyType.Guid))
+                builder.AppendLine("\t  \"github.com/google/uuid\""); // conditional uuid import
+
+            if (codeGraph.HasHeaders() || hasPropertyOfType(codeGraph, PropertyType.Duration))
+                builder.AppendLine($"\t  abstractions \"github.com/microsoft/kiota-abstractions-go\""); // conditional abstractions import
+
+            builder.AppendLine($"\t  msgraphsdk \"github.com/microsoftgraph/{apiVersion}\""); // api version
+
+            var modelPath = evaluateModelPath(codeGraph);
+            if (!String.IsNullOrWhiteSpace(modelPath))
+                builder.AppendLine($"\t  graphmodels \"github.com/microsoftgraph/{apiVersion}/{modelPath}\"");
+
+            var configPath = evaluateConfigPath(codeGraph);
+            if (!String.IsNullOrWhiteSpace(configPath))
+                builder.AppendLine($"\t  graphconfig \"github.com/microsoftgraph/{apiVersion}/{configPath}\"");
+
+            builder.AppendLine("\t  //other-imports"); // models version
+            builder.AppendLine(")");
+            builder.AppendLine("");
+        }
+
+        private static string evaluateConfigPath(SnippetCodeGraph codeGraph)
+        {
+            if (codeGraph.RequiresRequestConfig())
+            {
+                var path = codeGraph.Nodes.First().Segment.ToLower();
+                return path.Equals("me") ? "users" : path;
+            }
+
+            return string.Empty;
+        }
+
+
+        private static string evaluateModelPath(SnippetCodeGraph codeGraph)
+        {
+            if (codeGraph.HasJsonBody())
+            {
+                var path = codeGraph.Body.NamespaceName.Replace("microsoft.graph", "").Replace(".", "/");
+                return path.EndsWith("/") ? path.Remove(path.Length - 1, 1) : path;
+            }
+
+            return string.Empty;
+        }
+
+        private static Boolean hasPropertyOfType(SnippetCodeGraph codeGraph, PropertyType propertyType)
+        {
+            if (codeGraph.HasBody())
+                return searchProperty(codeGraph.Body, propertyType);
+
+            if (codeGraph.HasHeaders())
+                return searchProperty(codeGraph.Headers, propertyType);
+
+            if (codeGraph.HasParameters())
+                return searchProperty(codeGraph.Parameters, propertyType);
+
+            if (codeGraph.HasOptions())
+                return searchProperty(codeGraph.Options, propertyType);
+
+            return false;
+        }
+
+
+        private static Boolean searchProperty(IEnumerable<CodeProperty> properties, PropertyType propertyType)
+        {
+            return properties != null && properties.Select(x => searchProperty(x, propertyType)).Where(x => true).FirstOrDefault();
+        }
+
+
+        private static Boolean searchProperty(CodeProperty property, PropertyType propertyType)
+        {
+            if (property.Children != null && property.Children.Any())
+            {
+                var inchildren = property.Children.Select(x => x.PropertyType == propertyType).Where(x => true).FirstOrDefault();
+                if (inchildren) return true;
+            }
+            return property.PropertyType == propertyType;
+        }
+
         private static void writeSnippet(SnippetCodeGraph codeGraph, StringBuilder builder)
         {
+            builder.AppendLine($"{clientVarName} := msgraphsdk.New{clientVarType}({clientFactoryVariables}){Environment.NewLine}{Environment.NewLine}");
             writeHeadersAndOptions(codeGraph, builder);
             WriteBody(codeGraph, builder);
             builder.AppendLine("");
@@ -163,6 +254,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                         .Aggregate(static (x, y) =>
                         {
                             var w = x.EndsWith("s") && y.Equals("Item") ? x.Remove(x.Length - 1, 1) : x;
+                            w = w.Equals("Me") ? "Item" : w;
                             return $"{w}{y}";
                         });
         }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -51,7 +51,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static void writeImportStatements(SnippetCodeGraph codeGraph, StringBuilder builder)
         {
-            var apiVersion = codeGraph.ApiVersion == "v1.0" ? "msgraph-sdk-go" : "msgraph-beta-sdk-go";
+            var apiVersion = "v1.0".Equals(codeGraph.ApiVersion) ? "msgraph-sdk-go" : "msgraph-beta-sdk-go";
             builder.AppendLine("import (");
             builder.AppendLine("\t  \"context\""); // default
 
@@ -85,7 +85,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (codeGraph.RequiresRequestConfig())
             {
                 var path = codeGraph.Nodes.First().Segment.ToLower();
-                return path.Equals("me") ? "users" : path;
+                return path.Equals("me", StringComparison.OrdinalIgnoreCase) ? "users" : path;
             }
 
             return string.Empty;
@@ -123,7 +123,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static Boolean searchProperty(IEnumerable<CodeProperty> properties, PropertyType propertyType)
         {
-            return properties != null && properties.Select(x => searchProperty(x, propertyType)).Where(x => true).FirstOrDefault();
+            return properties != null && propertyType == properties.FirstOrDefault(x => searchProperty(x, propertyType)).PropertyType;
         }
 
 
@@ -131,8 +131,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             if (property.Children != null && property.Children.Any())
             {
-                var inchildren = property.Children.Select(x => x.PropertyType == propertyType).Where(x => true).FirstOrDefault();
-                if (inchildren) return true;
+                var existingChild = property.Children.FirstOrDefault(x => x.PropertyType == propertyType);
+                return propertyType == existingChild.PropertyType;
             }
             return property.PropertyType == propertyType;
         }
@@ -254,7 +254,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                         .Aggregate(static (x, y) =>
                         {
                             var w = x.EndsWith("s") && y.Equals("Item") ? x.Remove(x.Length - 1, 1) : x;
-                            w = w.Equals("Me") ? "Item" : w;
+                            w = "Me".Equals(w, StringComparison.Ordinal) ? "Item" : w;
                             return $"{w}{y}";
                         });
         }

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Web;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 
@@ -125,6 +126,14 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
         public Boolean HasReturnedBody(){
             return !(ResponseSchema == null || (ResponseSchema.Properties.Count == 1 && ResponseSchema.Properties.First().Key.Equals("error", StringComparison.OrdinalIgnoreCase)));
+        }
+        public Boolean RequiresRequestConfig()
+        {
+            return HasHeaders() || HasOptions() || HasParameters();
+        }
+
+        public Boolean HasJsonBody(){
+            return HasBody() && Body.PropertyType != PropertyType.Binary;
         }
 
         ///


### PR DESCRIPTION
1. Adds import statements to go generated snippets.
2. Fixes Me path objects after shim me.

Updated snippet has all necessary imports and resolves wrong imports for shim me path

Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/442
Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/920

```go
//THE GO SDK IS IN PREVIEW. NON-PRODUCTION USE ONLY
import (
	  "context"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphconfig "github.com/microsoftgraph/msgraph-sdk-go/users"
	  //other-imports
)

graphClient := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)


requestParameters := &graphconfig.ItemMessagesRequestBuilderGetQueryParameters{
	Select: [] string {"sender","subject"},
}
configuration := &graphconfig.ItemMessagesRequestBuilderGetRequestConfiguration{
	QueryParameters: requestParameters,
}

result, err := graphClient.Me().Messages().Get(context.Background(), configuration)

```