### PR TITLE
Adds query param to override the default OpenAPI file name for a given style

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -44,17 +44,18 @@ namespace GraphWebApi.Controllers
         [Route("$openapi")]
         [HttpGet]
         public async Task<IActionResult> Get(
-                                    [FromQuery]string operationIds = null,
-                                    [FromQuery]string tags = null,
-                                    [FromQuery]string url = null,
-                                    [FromQuery]string openApiVersion = null,
-                                    [FromQuery]string title = "Partial Graph API",
-                                    [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                    [FromQuery]string format = null,
-                                    [FromQuery]string graphVersion = null,
-                                    [FromQuery]bool includeRequestBody = false,
-                                    [FromQuery]bool forceRefresh = false,
-                                    [FromQuery]bool singularizeOperationIds = false)
+                                    [FromQuery] string operationIds = null,
+                                    [FromQuery] string tags = null,
+                                    [FromQuery] string url = null,
+                                    [FromQuery] string openApiVersion = null,
+                                    [FromQuery] string title = "Partial Graph API",
+                                    [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                    [FromQuery] string format = null,
+                                    [FromQuery] string graphVersion = null,
+                                    [FromQuery] bool includeRequestBody = false,
+                                    [FromQuery] bool forceRefresh = false,
+                                    [FromQuery] bool singularizeOperationIds = false,
+                                    [FromQuery] string fileName = null)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -65,18 +66,19 @@ namespace GraphWebApi.Controllers
                 throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
             }
 
-            var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh);
+            var source = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh, fileName);
             return CreateSubsetOpenApiDocument(operationIds, tags, url, source, title, styleOptions, forceRefresh, includeRequestBody, singularizeOperationIds);
         }
 
         [Route("openapi/operations")]
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery]string graphVersion = null,
-                                             [FromQuery]string openApiVersion = null,
-                                             [FromQuery]OpenApiStyle style = OpenApiStyle.Plain,
-                                             [FromQuery]string format = null,
-                                             [FromQuery]bool forceRefresh = false,
-                                             [FromQuery] bool singularizeOperationIds = false)
+        public async Task<IActionResult> Get([FromQuery] string graphVersion = null,
+                                             [FromQuery] string openApiVersion = null,
+                                             [FromQuery] OpenApiStyle style = OpenApiStyle.Plain,
+                                             [FromQuery] string format = null,
+                                             [FromQuery] bool forceRefresh = false,
+                                             [FromQuery] bool singularizeOperationIds = false,
+                                             [FromQuery] string fileName = null)
         {
             var styleOptions = new OpenApiStyleOptions(style, openApiVersion, graphVersion, format);
 
@@ -87,7 +89,7 @@ namespace GraphWebApi.Controllers
                 throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
             }
 
-            var graphOpenApi = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh);
+            var graphOpenApi = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh, fileName);
             await WriteIndex(Request.Scheme + "://" + Request.Host.Value, styleOptions.GraphVersion, styleOptions.OpenApiVersion, styleOptions.OpenApiFormat,
                 graphOpenApi, Response.Body, styleOptions.Style, singularizeOperationIds);
 

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -778,3 +778,10 @@ components:
         default: v1.0 and beta
       required: false
       description: The target Microsoft Graph API version. # Ex: ?graphVersions=v1.0 / ?graphVersions=beta / or ?graphVersions=* (for both)
+    fileName:
+      name: fileName
+      in: query
+      schema:
+        type: string
+      required: false
+      description: Overrides the OpenAPI file name for the specified OpenApi style.

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -408,6 +408,7 @@ paths:
         - $ref: '#/components/parameters/format'
         - $ref: '#/components/parameters/forceRefresh'
         - $ref: '#/components/parameters/singularizeOperationIds'
+        - $ref: '#/components/parameters/fileName'
       responses:
         "200":
           description: List of operations associated to a tag/operationIds/url
@@ -429,6 +430,7 @@ paths:
         - $ref: '#/components/parameters/format'
         - $ref: '#/components/parameters/forceRefresh'
         - $ref: '#/components/parameters/singularizeOperationIds'
+        - $ref: '#/components/parameters/fileName'
       responses:
         "200":
           description: OK

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -21,7 +21,7 @@ namespace OpenAPIService.Interfaces
 
         MemoryStream SerializeOpenApiDocument(OpenApiDocument subset, OpenApiStyleOptions styleOptions);
 
-        Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, OpenApiStyle openApiStyle, bool forceRefresh);
+        Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, OpenApiStyle openApiStyle, bool forceRefresh, string fileName = null);
 
         OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(ConcurrentDictionary<string, OpenApiDocument> sources);
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -516,7 +516,14 @@ namespace OpenAPIService
             {
                 fileName = _fileNames[openApiStyle];
             }
-            
+            else
+            {
+                if (!UtilityFunctions.IsUrlSafe(fileName))
+                {
+                    throw new ArgumentException("The value is not URL-safe", nameof(fileName));
+                }
+            }
+
             var cachedDoc = $"{graphUri}/{openApiStyle}/{fileName}";
             if (!forceRefresh && _OpenApiDocuments.TryGetValue(cachedDoc, out OpenApiDocument doc))
             {

--- a/UtilityService.Test/UtilityFunctionsShould.cs
+++ b/UtilityService.Test/UtilityFunctionsShould.cs
@@ -15,6 +15,7 @@ namespace UtilityService.Test
         [InlineData("hello!", false)]
         [InlineData("file://C:/hello", false)]
         [InlineData("hello?", false)]
+        [InlineData("hello%20", false)]
         public void CheckWhetherInputIsUrlSafe(string input, bool expected)
         {
             // Arrange and Act

--- a/UtilityService.Test/UtilityFunctionsShould.cs
+++ b/UtilityService.Test/UtilityFunctionsShould.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace UtilityService.Test
+{
+    public class UtilityFunctionsShould
+    {
+        [Theory]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        [InlineData("hello", true)]
+        [InlineData("hello!", false)]
+        [InlineData("file://C:/hello", false)]
+        [InlineData("hello?", false)]
+        public void CheckWhetherInputIsUrlSafe(string input, bool expected)
+        {
+            // Arrange and Act
+            var actual = UtilityFunctions.IsUrlSafe(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/UtilityService/UtilityFunctions.cs
+++ b/UtilityService/UtilityFunctions.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Text.RegularExpressions;
 
 namespace UtilityService
 {
@@ -32,6 +33,22 @@ namespace UtilityService
         public static string CheckArgumentNullOrEmpty(string value, string parameterName)
         {
             return string.IsNullOrEmpty(value) ? throw new ArgumentNullException(parameterName, $"Value cannot be null or empty: {parameterName}") : value;
+        }
+
+        /// <summary>
+        /// Validates whether an input string has URL-safe characters.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>True whether the input string does not contain URL-safe characters.</returns>
+        public static bool IsUrlSafe(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return true;
+            }
+
+            const string pattern = @"[^a-zA-Z0-9\-._~]";
+            return !Regex.IsMatch(input, pattern);
         }
     }
 }

--- a/UtilityService/UtilityFunctions.cs
+++ b/UtilityService/UtilityFunctions.cs
@@ -12,6 +12,8 @@ namespace UtilityService
     /// </summary>
     public static class UtilityFunctions
     {
+        private static readonly Regex _unsafeUrlRegex = new(@"[^a-zA-Z0-9\-._~]", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+        
         /// <summary>
         /// Check whether the input argument value is null or not.
         /// </summary>
@@ -39,7 +41,7 @@ namespace UtilityService
         /// Validates whether an input string has URL-safe characters.
         /// </summary>
         /// <param name="input">The input string.</param>
-        /// <returns>True whether the input string does not contain URL-safe characters.</returns>
+        /// <returns>true when the input string contains URL-safe characters, otherwise false.</returns>
         public static bool IsUrlSafe(string input)
         {
             if (string.IsNullOrEmpty(input))
@@ -47,8 +49,7 @@ namespace UtilityService
                 return true;
             }
 
-            const string pattern = @"[^a-zA-Z0-9\-._~]";
-            return !Regex.IsMatch(input, pattern);
+            return !_unsafeUrlRegex.IsMatch(input);
         }
     }
 }


### PR DESCRIPTION
Currently PowerShell uses the endpoint http://devxapitest.azurewebsites.net/ to test for v2. This endpoint uses [powershell_v2.yaml](https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/powershell_v2.yaml) for its OpenAPI document. This document has been converted using PowerShell v2 specific [OpenAPIConvert settings.](https://github.com/microsoftgraph/msgraph-metadata/blob/master/conversion-settings/powershell_v2.json) DevX API prod uses [powershell.yaml](https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/powershell.yaml). 
Instead of supporting 2 different endpoints for PowerShell cmdlet generation, this query param `fileName` can be used for both scenarios:
- PowerShell v1: https://graphexplorerapi.azurewebsites.net/openapi/operations?style=PowerShell
- PowerShell v2: https://graphexplorerapi.azurewebsites.net/openapi/operations?style=PowerShell&fileName=powershell_v2

Both documents will also be cached separately in the DevX API. 
This fix will allow us to switch off the devxapi test endpoint when not in use and help reduce COGS.