### PR TITLE
Generate case-insensitive PowerShell hashtable for request bodies

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -279,8 +279,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
-                $"DisplayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
-                $"City = \"Seattle\"{Environment.NewLine}}}";
+                $"displayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
+                $"city = \"Seattle\"{Environment.NewLine}}}";
             Assert.Contains(expectedParams, result);
             Assert.Contains("-BodyParameter $params", result);
         }
@@ -302,8 +302,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
-                $"DisplayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
-                $"City = \"Seattle\"{Environment.NewLine}\t" +
+                $"displayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
+                $"city = \"Seattle\"{Environment.NewLine}\t" +
                 $"PasswordProfile = @{{{Environment.NewLine}\t\t" +
                 $"Password = \"2d79ba3a-b03a-9ed5-86dc-79544e262664\"{Environment.NewLine}\t\t" +
                 $"ForceChangePasswordNextSignIn = $false{Environment.NewLine}\t" +
@@ -326,8 +326,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
-                $"DisplayName = \"Library Assist\"{Environment.NewLine}\t" +
-                $"GroupTypes = @({Environment.NewLine}\t\t" +
+                $"displayName = \"Library Assist\"{Environment.NewLine}\t" +
+                $"groupTypes = @({Environment.NewLine}\t\t" +
                 $"\"Unified\"{Environment.NewLine}\t\t" +
                 $"\"DynamicMembership\"{Environment.NewLine}\t" +
                 $"){Environment.NewLine}" +

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -22,14 +22,15 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private const string modulePrefix = "Microsoft.Graph";
         private const string mgCommandMetadataUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/src/Authentication/Authentication/custom/common/MgCommandMetadata.json";
         private readonly Lazy<IList<PowerShellCommandInfo>> psCommands = new(
-            () => {
+            () =>
+            {
                 using var httpClient = new HttpClient();
                 using var stream = httpClient.GetStreamAsync(mgCommandMetadataUrl).GetAwaiter().GetResult();
                 return JsonSerializer.Deserialize<IList<PowerShellCommandInfo>>(stream);
             },
             LazyThreadSafetyMode.PublicationOnly
         );
-        private static Regex meSegmentRegex = new("^/me($|(?=/))", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex meSegmentRegex = new("^/me($|(?=/))", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
             var indentManager = new IndentManager();
@@ -59,7 +60,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 var commandParameters = GetCommandParameters(snippetModel, payloadVarName);
                 if (!string.IsNullOrEmpty(commandParameters))
                     snippetBuilder.Append($"{commandParameters}");
-                if (RequiresMIMEContentOutPut(snippetModel,path))
+                if (RequiresMIMEContentOutPut(snippetModel, path))
                 {
                     //Allows genration of an output file for MIME content of the message
                     snippetBuilder.Append($" -OutFile $outFileId");
@@ -189,7 +190,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static string NormalizeQueryParameterName(string queryParam)
         {
             string psParameterName = queryParam.TrimStart('$').ToLower().ToFirstCharacterUpperCase();
-            return psParameterName switch {
+            return psParameterName switch
+            {
                 "Select" => "Property",
                 "Expand" => "ExpandProperty",
                 "Count" => "CountVariable",
@@ -198,7 +200,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             };
         }
 
-        private static Regex nestedStatementRegex = new(@"(\w+|\w+\/\w+)(\([^)]+\))", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex nestedStatementRegex = new(@"(\w+|\w+\/\w+)(\([^)]+\))", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static (string, Dictionary<string, string>) ReplaceNestedOdataQueryParameters(string queryParams)
         {
             var replacements = new Dictionary<string, string>();
@@ -214,7 +216,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             return (queryParams, replacements);
         }
 
-        private static Regex keyIndexRegex = new(@"(?<={)(.*?)(?=})", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex keyIndexRegex = new(@"(?<={)(.*?)(?=})", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private IList<PowerShellCommandInfo> GetCommandForRequest(string path, string method, string apiVersion)
         {
             if (psCommands.Value.Count == 0)
@@ -258,7 +260,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                             .Select(x => new Tuple<JsonProperty, OpenApiSchema>(x, schema?.GetPropertySchema(x.Name)));
             foreach (var propertyAndSchema in propertiesAndSchema)
             {
-                var propertyName = propertyAndSchema.Item1.Name.ToFirstCharacterUpperCase();
+                var propertyName = propertyAndSchema.Item1.Name;
                 // Enclose in quotes if property name contains a non-word character.
                 if (Regex.IsMatch(propertyName, "\\W", RegexOptions.None, TimeSpan.FromSeconds(5))) { propertyName = $"\"{propertyName}\""; }
                 var propertyAssignment = includePropertyAssignment ? $"{indentManager.GetIndent()}{propertyName} = " : string.Empty;


### PR DESCRIPTION
## Overview

This PR fixes #1459 by ensuring we maintain the casing used in the HTTP request examples for request bodies when generating PowerShell snippets. This is needed due to https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1418#issuecomment-1194255374.

Some Intune APIs such as https://learn.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageassignmentrequests?view=graph-rest-beta&tabs=powershell#example-2-user-requests-a-package-and-answers-questions-for-approval are case-sensitive.