### PR TITLE
Replaces copy constructors with cloning and adds missing param

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -91,7 +91,7 @@ namespace GraphWebApi.Controllers
 
             var graphOpenApi = await _openApiService.GetGraphOpenApiDocumentAsync(graphUri, style, forceRefresh, fileName);
             await WriteIndex(Request.Scheme + "://" + Request.Host.Value, styleOptions.GraphVersion, styleOptions.OpenApiVersion, styleOptions.OpenApiFormat,
-                graphOpenApi, Response.Body, styleOptions.Style, singularizeOperationIds);
+                graphOpenApi, Response.Body, styleOptions.Style, singularizeOperationIds, fileName);
 
             return new EmptyResult();
         }
@@ -174,7 +174,8 @@ namespace GraphWebApi.Controllers
             OpenApiDocument graphOpenApi,
             Stream stream,
             OpenApiStyle style,
-            bool singularizeOperationIds)
+            bool singularizeOperationIds,
+            string fileName = null)
 
         {
             using var sw = new StreamWriter(stream);
@@ -190,14 +191,16 @@ namespace GraphWebApi.Controllers
                                 "<b/>" + Environment.NewLine +
                                 "<ul>" + Environment.NewLine);
 
+            string fileNameParam = !string.IsNullOrEmpty(fileName) ? "&fileName=" + fileName : null;
+
             foreach (var item in indexSearch.Index)
             {
-                var target = $"{baseUrl}/openapi?tags={item.Key.Name}&openApiVersion={openApiVersion}&graphVersion={graphVersion}&format={format}&style={style}&singularizeOperationIds={singularizeOperationIds}";
+                var target = $"{baseUrl}/openapi?tags={item.Key.Name}&openApiVersion={openApiVersion}&graphVersion={graphVersion}&format={format}&style={style}&singularizeOperationIds={singularizeOperationIds}{fileNameParam}";
                 await sw.WriteAsync($"<li>{item.Key.Name} [<a href='{target}'>OpenApi</a>]   [<a href='/swagger/index.html#url={target}'>Swagger UI</a>]</li>{Environment.NewLine}<ul>{Environment.NewLine}");
                 foreach (var op in item.Value)
                 {
                     await sw.WriteLineAsync($"<li>{op.OperationId}  [<a href='../../openapi?operationIds={op.OperationId}&openApiVersion={openApiVersion}&graphVersion={graphVersion}" +
-                        $"&format={format}&style={style}'>OpenAPI</a>]</li>");
+                        $"&format={format}&style={style}&singularizeOperationIds={singularizeOperationIds}{fileNameParam}'>OpenAPI</a>]</li>");
                 }
                 await sw.WriteLineAsync("</ul>");
             }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,20 +2,14 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Writers;
 using OpenAPIService.Interfaces;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 
 namespace OpenAPIService.Test
 {
@@ -31,7 +25,7 @@ namespace OpenAPIService.Test
         public OpenApiDocumentCreatorMock(IOpenApiService openApiService)
         {
             _openApiService = openApiService
-                ?? throw new ArgumentNullException(nameof(openApiService), $"{ NullValueError }: { nameof(openApiService) }");
+                ?? throw new ArgumentNullException(nameof(openApiService), $"{NullValueError}: {nameof(openApiService)}");
         }
 
         public static IOpenApiService GetOpenApiService(string configFilePath)
@@ -41,17 +35,6 @@ namespace OpenAPIService.Test
                                                     .Build();
 
             return new OpenApiService(configuration);
-        }
-
-        private static OpenApiDocument CloneOpenApiDocument(OpenApiDocument openApiDocument)
-        {
-            using var stream = new MemoryStream();
-            var writer = new OpenApiYamlWriter(new StreamWriter(stream));
-            openApiDocument.SerializeAsV3(writer);
-            writer.Flush();
-            stream.Position = 0;
-            var reader = new OpenApiStreamReader();
-            return reader.Read(stream, out _); ;
         }
 
         /// <summary>
@@ -1008,7 +991,7 @@ namespace OpenAPIService.Test
                                                     Id = "StringCollectionResponse"
                                                 }
                                             }
-                                        } 
+                                        }
                                     }
                                 }
                             }
@@ -1056,7 +1039,7 @@ namespace OpenAPIService.Test
                                             Name = "identityGovernance.Actions"
                                         }
                                     },
-                                    OperationId = "identityGovernance.lifecycleWorkflows.workflows.workflow.activate"                                    
+                                    OperationId = "identityGovernance.lifecycleWorkflows.workflows.workflow.activate"
                                 }
                             }
                         }
@@ -1251,7 +1234,7 @@ namespace OpenAPIService.Test
                 }
             };
 
-            return CloneOpenApiDocument(document);
+            return _openApiService.CloneOpenApiDocument(document);
         }
     }
 }

--- a/OpenAPIService/Interfaces/IOpenApiService.cs
+++ b/OpenAPIService/Interfaces/IOpenApiService.cs
@@ -28,5 +28,7 @@ namespace OpenAPIService.Interfaces
         void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode rootNode, Stream stream);
 
         OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument, bool includeRequestBody = false, bool singularizeOperationIds = false);
+
+        OpenApiDocument CloneOpenApiDocument(OpenApiDocument document);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1458

This PR:

- Replaces use of copy constructors with cloning of an OpenAPI document. Copy constructors has a missing capability that will be addressed in this https://github.com/microsoft/OpenAPI.NET/issues/1193.
- Adds missing parameter fileName to the html output of /openapi/operations.

**NB:** This PR is making a commit into `master` because `dev` has some permissions work that is not yet ready to ship.