### PR TITLE
Remap known trimmed paths in snippet generation

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -326,7 +326,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                             var functionName = x.Segment.Split('(').First();
                                             var parameters = x.Segment.Split('(').Last().TrimEnd(')').Split(',')
                                                 .Select(static s => $"With{s.Split('=').First().ToFirstCharacterUpperCase()}")
-                                                .Aggregate(static (a, b) => $"{a}{b}");;
+                                                .Aggregate(static (a, b) => $"{a}{b}");
                                             var parametersValues = x.Segment.Split('(').Last().TrimEnd(')').Split(',')
                                                 .Select(static s => $"\"{s.Split('=').Last().Trim('\'')}\"")
                                                 .Aggregate(static (a, b) => $"{a},{b}");

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -362,11 +362,12 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             if ((propSchema?.Enum.Count ?? 0) == 0 && enumSchema == null)
                 return new CodeProperty { Name = propertyName, Value = escapeSpecialCharacters(value.GetString()), PropertyType = PropertyType.String, Children = new List<CodeProperty>() };
             enumSchema ??= propSchema;
-            var propValue = String.IsNullOrWhiteSpace(value.GetString()) ? null : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.GetString().ToFirstCharacterUpperCase()}";
             // Pass the list of options in the enum as children so that the language generators may use them for validation if need be, 
             var enumValueOptions = enumSchema?.Enum.Where(option => option is OpenApiString)
                                                                 .Select(option => new CodeProperty{Name = ((OpenApiString)option).Value,Value = ((OpenApiString)option).Value,PropertyType = PropertyType.String})
                                                                 .ToList() ?? new List<CodeProperty>();
+            var propValue = String.IsNullOrWhiteSpace(value.GetString()) ? $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{enumValueOptions.FirstOrDefault().Value.ToFirstCharacterUpperCase()}" : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.GetString().ToFirstCharacterUpperCase()}";
+
             return new CodeProperty { Name = propertyName, Value = propValue, PropertyType = PropertyType.Enum, Children = enumValueOptions ,NamespaceName = GetNamespaceFromSchema(enumSchema)};
         }
 

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -36,7 +36,8 @@ namespace CodeSnippetsReflection.OpenAPI
         {
             if (treeNode == null) throw new ArgumentNullException(nameof(treeNode));
 
-            var splatPath = ReplaceIndexParametersByPathSegment(requestPayload.RequestUri
+            var remappedPayload = RemapKnownPathsIfNeeded(requestPayload);
+            var splatPath = ReplaceIndexParametersByPathSegment(remappedPayload.RequestUri
                                         .AbsolutePath
                                         .TrimStart(pathSeparator))
                                         .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries)
@@ -44,6 +45,35 @@ namespace CodeSnippetsReflection.OpenAPI
             LoadPathNodes(treeNode, splatPath);
             InitializeModel(requestPayload);
         }
+
+        private static readonly Dictionary<Regex, string> KnownReMappings = new()
+        {
+            { new Regex(@"/me/drive/root/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
+            { new Regex(@"/me/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/groups/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
+            { new Regex(@"/groups/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/sites/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
+            { new Regex(@"/sites/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/users/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
+            { new Regex(@"/users/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/drive/bundles",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/bundles" },
+            { new Regex(@"/drive/items",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items" },
+        };
+        
+        private static HttpRequestMessage RemapKnownPathsIfNeeded(HttpRequestMessage originalRequest)
+        {
+            var originalUri = originalRequest.RequestUri.OriginalString;
+            var regexMatch = KnownReMappings.Keys.FirstOrDefault(regex => regex.Match(originalUri).Success);
+            if (regexMatch == null)
+            {
+                return originalRequest;
+            }
+
+            originalUri = regexMatch.Replace(originalUri, KnownReMappings[regexMatch]);
+            originalRequest.RequestUri = new Uri(originalUri);
+            return originalRequest;
+        }
+
         private static Regex oDataIndexReplacementRegex = new(@"\('([\w=]+)'\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         /// <summary>
         /// Replaces OData style ids to path segments
@@ -167,6 +197,17 @@ namespace CodeSnippetsReflection.OpenAPI
                     return;
                 }
             }
+
+            if (node.Children.Keys.Any(static x => x.IsFunctionWithParameters()) && pathSegment.IsFunctionWithParameters())
+            {
+                var functionWithParametersNode = node.Children.FirstOrDefault(function => function.Key.IsFunctionWithParametersMatch(pathSegment));
+                if (functionWithParametersNode.Value != null)
+                {
+                    LoadNextNode(functionWithParametersNode.Value, pathSegments);
+                    return;
+                }
+            }
+
             throw new EntryPointNotFoundException($"Path segment '{pathSegment}' not found in path");
         }
         private void LoadNextNode(OpenApiUrlTreeNode node, IEnumerable<string> pathSegments)

--- a/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
@@ -10,6 +10,26 @@ internal static class StringExtensions
     internal static bool IsCollectionIndex(this string pathSegment) =>
         !string.IsNullOrEmpty(pathSegment) && pathSegment.StartsWith('{') && pathSegment.EndsWith('}');
     internal static bool IsFunction(this string pathSegment) => !string.IsNullOrEmpty(pathSegment) && pathSegment.Contains('.');
+
+    private static readonly Regex FunctionWithParameterRegex = new(@"\([\w=':${}<>|\-,]+\)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
+    internal static bool IsFunctionWithParameters(this string pathSegment) => !string.IsNullOrEmpty(pathSegment) 
+                                                                              && FunctionWithParameterRegex.Match(pathSegment).Success;
+
+    internal static bool IsFunctionWithParametersMatch(this string pathSegment, string segment)
+    {
+        // verify both have parameters
+        if (!pathSegment.IsFunctionWithParameters() || !segment.IsFunctionWithParameters())
+            return false;
+        
+        // verify both have same prefix/name
+        if (!pathSegment.Split('(').First().Equals(segment.Split('(').First(), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var originalParameters = pathSegment.Split('(').Last().TrimEnd(')').Split(',').Select(static s => s.Split('=').First());
+        var compareParameters = segment.Split('(').Last().TrimEnd(')').Split(',').Select(static s => s.Split('=').First());
+
+        return compareParameters.All(parameter => originalParameters.Contains(parameter.Split('=').First(), StringComparer.OrdinalIgnoreCase));
+    }
     internal static string RemoveFunctionBraces(this string pathSegment) => pathSegment.TrimEnd('(',')');
     internal static string ReplaceValueIdentifier(this string original) =>
         original?.Replace("$value", "Content");


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1453

It introduces a KnownReMappings collection that remaps paths trimmed from the original openApi description to alternate paths so that inputs to the snippet generation result in outputs and not failures and should result in increase numbers for snippet generation across all openAPI based languages.

e.g. a snippet with the path `/me/drive/root/` will be remapped to the path `/drives/driveId/items/root/` path to ensure doc examples and sample responses on GE.

Tests have been added to validate this

Other changes include 
- Fixes path matching for functions with parameters `/range(address='A1:B2')` for excel functions
- Fixes a bug in dotnet generation where empty collections in the payload would result in failed type lookup. 

Sample update generation can viewed at 
https://github.com/microsoftgraph/microsoft-graph-docs/compare/main...preview-snippet-generation/111959 

and run at https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=111959&view=ms.vss-test-web.build-test-results-tab

Missing snippets/failed generation should reduce by up to 50% in V1 353 -> 171 while 515 ->308 in beta in comparison with the latest run. 