### PR TITLE
Remove hash suffix from all operationIds

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -456,6 +456,27 @@ namespace OpenAPIService.Test
                             }
                         }
                     },
+                    ["/users/$count"] = new OpenApiPathItem() // root path
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    OperationId = "users.GetCount-ee47",
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200",new OpenApiResponse()
+                                            {
+                                                Description = "OK"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     ["/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore"] = new OpenApiPathItem()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -358,7 +358,7 @@ namespace OpenAPIService.Test
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.Plain, subsetOpenApiDocument);
 
             // Assert
-            Assert.Equal(17, subsetOpenApiDocument.Paths.Count);
+            Assert.Equal(18, subsetOpenApiDocument.Paths.Count);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Schemas);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Parameters);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Responses);
@@ -647,6 +647,30 @@ namespace OpenAPIService.Test
             Assert.Null(defaultPriceProperty.OneOf);
             Assert.Equal("number", defaultPriceProperty.Type);
             Assert.Equal("double", defaultPriceProperty.Format);
+        }
+
+
+        [Theory]
+        [InlineData("/users/$count", OperationType.Get, "users_GetCount")]
+        [InlineData("/reports/microsoft.graph.getSharePointSiteUsageDetail(period={period})", OperationType.Get, "reports_getSharePointSiteUsageDetail")]
+        public void RemoveHashSuffixFromOperationIdsForPowerShellStyle(string url, OperationType operationType, string expectedOperationId)
+        {
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: null,
+                                                           tags: null,
+                                                           url: url,
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var operationId = subsetOpenApiDocument.Paths
+                              .FirstOrDefault().Value
+                              .Operations[operationType]
+                              .OperationId;
+
+            // Assert
+            Assert.Equal(expectedOperationId, operationId);
         }
 
         private void ConvertOpenApiUrlTreeNodeToJson(OpenApiUrlTreeNode node, Stream stream)

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -24,6 +24,8 @@ namespace OpenAPIService
         private const string NewPutPrefix = "_Set";
         private readonly Stack<OpenApiSchema> _schemaLoop = new();
         private readonly bool _singularizeOperationIds;
+        private static readonly Regex s_hashSuffixRegex = new(@"^[^-]+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex s_oDataRefRegex = new("(?<=[a-z])Ref(?=[A-Z])", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
         public PowershellFormatter(bool singularizeOperationIds)
         {
@@ -68,7 +70,6 @@ namespace OpenAPIService
         public override void Visit(OpenApiOperation operation)
         {
             var operationId = operation.OperationId;
-
             if (operation.Extensions.TryGetValue("x-ms-docs-operation-type",
                                                   out var value) && value != null)
             {
@@ -90,11 +91,13 @@ namespace OpenAPIService
                     ResolveFunctionParameters(operation);
                 }
             }
+            // Remove hash suffix values from OperationIds.
+            operationId = s_hashSuffixRegex.Match(operationId).Value;
 
             if (_singularizeOperationIds)
             {
                 operationId = SingularizeAndDeduplicateOperationId(operationId);
-            }            
+            }
 
             var charPos = operationId.LastIndexOf('.', operationId.Length - 1);
 
@@ -110,10 +113,9 @@ namespace OpenAPIService
             // Update $ref path operationId name
             // Ref key word is enclosed between lower-cased and upper-cased letters
             // Ex.: applications_GetRefCreatedOnBehalfOf to applications_GetCreatedOnBehalfOfByRef
-            var regex = new Regex("(?<=[a-z])Ref(?=[A-Z])", RegexOptions.None, TimeSpan.FromSeconds(5));
-            if (regex.Match(operationId).Success)
+            if (s_oDataRefRegex.Match(operationId).Success)
             {
-                operationId = $"{regex.Replace(operationId, string.Empty)}ByRef";
+                operationId = $"{s_oDataRefRegex.Replace(operationId, string.Empty)}ByRef";
             }
 
             operation.OperationId = operationId;
@@ -145,7 +147,7 @@ namespace OpenAPIService
         private static string ResolveActionFunctionOperationId(OpenApiOperation operation)
         {
             var operationId = operation.OperationId;
-            var segments = operationId.Split(new char[] {'.'}, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var segments = operationId.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).ToList();
 
             // Remove ODataKeySegment values from OperationIds of actions and functions paths.
             // This is to prevent breaking changes of OperationId values already
@@ -170,16 +172,7 @@ namespace OpenAPIService
                 }
             }
 
-            var updatedOperationId = string.Join(".", segments);
-
-            // Remove hash suffix values from OperationIds of function paths.
-            // For example,
-            // Default OperationId --> reports_getEmailActivityUserDetail-fe32
-            // Resolved OperationId --> reports_getEmailActivityUserDetail
-            var regex = new Regex(@"^[^-]+", RegexOptions.None, TimeSpan.FromSeconds(5));
-            updatedOperationId = regex.Match(updatedOperationId).Value;
-
-            return updatedOperationId;
+            return string.Join(".", segments);
         }
 
         /// <summary>
@@ -219,7 +212,7 @@ namespace OpenAPIService
 
             // drives does not properly singularize to drive.
             Vocabularies.Default.AddSingular("(drive)s$", "$1");
-            
+
             var segments = operationId.Split('.').ToList();
 
             // The last segment is ignored as a rule.


### PR DESCRIPTION
This PR fixes #1478 by proposing the following changes:
- Ensures removal of hash suffix from all operationIds for PowerShell style.
- Optimizes regular expressions by making static compiled.