### PR TITLE
Update code snippets tab ordering for docs

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -28,7 +28,7 @@ pool:
 parameters:
   - name: snippetLanguages
     type: object
-    default: ['C#', 'JavaScript', 'Java', 'Go', 'PowerShell', 'PHP']
+    default: ['C#', 'Go', 'Java', 'JavaScript', 'PHP', 'PowerShell']
     displayName: 'Languages to generate snippets for'
 
 variables:


### PR DESCRIPTION
## Overview
Fixes #1470

Update ordering of code snippets tabs in docs to:
- C#
- Go
- Java
- JavaScript
- PHP
- PowerShell