### PR TITLE
Format OData cast operationIds

### DIFF
--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,9 +2,6 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
@@ -31,7 +28,7 @@ namespace OpenAPIService.Test
         public OpenApiDocumentCreatorMock(IOpenApiService openApiService)
         {
             _openApiService = openApiService
-                ?? throw new ArgumentNullException(nameof(openApiService), $"{ NullValueError }: { nameof(openApiService) }");
+                ?? throw new ArgumentNullException(nameof(openApiService), $"{NullValueError}: {nameof(openApiService)}");
         }
 
         public static IOpenApiService GetOpenApiService(string configFilePath)
@@ -1008,7 +1005,7 @@ namespace OpenAPIService.Test
                                                     Id = "StringCollectionResponse"
                                                 }
                                             }
-                                        } 
+                                        }
                                     }
                                 }
                             }
@@ -1056,7 +1053,49 @@ namespace OpenAPIService.Test
                                             Name = "identityGovernance.Actions"
                                         }
                                     },
-                                    OperationId = "identityGovernance.lifecycleWorkflows.workflows.workflow.activate"                                    
+                                    OperationId = "identityGovernance.lifecycleWorkflows.workflows.workflow.activate"
+                                }
+                            }
+                        }
+                    },
+                    ["/directory/deletedItems/{directoryObject-id}/microsoft.graph.application"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Get, new OpenApiOperation
+                                {
+                                    OperationId = "directory.GetDeletedItems.AsApplication",
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200",new OpenApiResponse()
+                                            {
+                                                Description = "OK"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ["/drives/{drive-id}/items/{driveItem-id}/assignSensitivityLabel"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            {
+                                OperationType.Post, new OpenApiOperation
+                                {
+                                    OperationId = "drives.drive.items.driveItem.assignSensitivityLabel",
+                                    Responses = new OpenApiResponses()
+                                    {
+                                        {
+                                            "200",new OpenApiResponse()
+                                            {
+                                                Description = "OK"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -358,7 +358,7 @@ namespace OpenAPIService.Test
             subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.Plain, subsetOpenApiDocument);
 
             // Assert
-            Assert.Equal(16, subsetOpenApiDocument.Paths.Count);
+            Assert.Equal(18, subsetOpenApiDocument.Paths.Count);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Schemas);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Parameters);
             Assert.NotEmpty(subsetOpenApiDocument.Components.Responses);
@@ -410,6 +410,29 @@ namespace OpenAPIService.Test
 
             // Assert
             Assert.Equal(expectedOperationId, operationId);
+        }
+
+        [Theory]
+        [InlineData("directory.GetDeletedItems.AsApplication", "directory_GetDeletedItemsAsApplication", OperationType.Get)]
+        [InlineData("drives.drive.items.driveItem.assignSensitivityLabel", "drives.drive.items.driveItem_assignSensitivityLabel", OperationType.Post)]
+        public void ResolveODataCastOperationIdsForPowerShellStyle(string operationId, string expectedOperationId, OperationType operationType)
+        {
+            // Act
+            var predicate = _openApiService.CreatePredicate(operationIds: operationId,
+                                                           tags: null,
+                                                           url: null,
+                                                           source: _graphMockSource,
+                                                           graphVersion: GraphVersion);
+
+            var subsetOpenApiDocument = _openApiService.CreateFilteredDocument(_graphMockSource, Title, GraphVersion, predicate);
+            subsetOpenApiDocument = _openApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+            var singularizedOpId = subsetOpenApiDocument.Paths
+                                  .FirstOrDefault().Value
+                                  .Operations[operationType]
+                                  .OperationId;
+
+            // Assert
+            Assert.Equal(expectedOperationId, singularizedOpId);
         }
 
         [Fact]

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -184,7 +184,7 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// Resolves operationIds of OData cast paths by merging the [ACTION] and [AS_CAST_TYPE] segmenets on an operationId.
+        /// Resolves operationIds of OData cast paths by merging the [ACTION] and [AS_CAST_TYPE] segments on an operationId.
         /// </summary>
         /// <param name="operationId">The target OpenAPI operation.</param>
         /// <returns>The resolved OperationId.</returns>


### PR DESCRIPTION
## Overview

This PR fixes #1228 by ensuring OData cast operationIds are resolved to format that can be interpreted by AutoREST. This is done by merging `[ACTION]` and `[AS_CAST_TYPE]` segments on an OData cast operationId. For example:
- `directory.ListDeletedItems.AsApplication` -> `directory_ListDeletedItemsAsApplication` -> `Get-MgDirectoryDeletedItemAsApplication`.

This PR is a continuation of https://github.com/microsoftgraph/msgraph-metadata/pull/317.

## Testing Instructions

* See unit tests.