### PR TITLE
Fixes snippets cleanup pipeline

### DIFF
--- a/scripts/cleanupUnusedSnippets.ps1
+++ b/scripts/cleanupUnusedSnippets.ps1
@@ -7,7 +7,7 @@ foreach ($docFile in $docsFiles) {
 		$pathMatches = [regex]::Matches($content, "\(([^\)]+)\)"); # gets the path portion of a MD link
 		foreach($pathMatch in $pathMatches) {
 			$snippetPath = $pathMatch.Groups[1].Value;
-			if($snippetPath -match ".*snippets.*" -and $snippetPath -cnotmatch ".*:\/\/.*") { # checks that the snippet is in a "snippets" folder and that it's not a link "://"
+			if($snippetPath -match ".*snippets.*" -and $snippetPath -cnotmatch ".*:\/\/.*" -and $snippetPath.EndsWith('.md')) { # checks that the snippet is in a "snippets" folder and that it's not a link "://"
 				$snippetFullPath = (Resolve-Path -LiteralPath (Join-Path $docFile.DirectoryName $snippetPath)).Path
 				$resolvedSnippetsFiles.add($snippetFullPath) | Out-Null
 			}

--- a/scripts/cleanupUnusedSnippets.ps1
+++ b/scripts/cleanupUnusedSnippets.ps1
@@ -7,7 +7,7 @@ foreach ($docFile in $docsFiles) {
 		$pathMatches = [regex]::Matches($content, "\(([^\)]+)\)"); # gets the path portion of a MD link
 		foreach($pathMatch in $pathMatches) {
 			$snippetPath = $pathMatch.Groups[1].Value;
-			if($snippetPath -match ".*snippets.*" -and $snippetPath -cnotmatch ".*:\/\/.*" -and $snippetPath.EndsWith('.md')) { # checks that the snippet is in a "snippets" folder and that it's not a link "://"
+			if($snippetPath -match ".*snippets.*" -and $snippetPath -cnotmatch ".*:\/\/.*" -and $snippetPath.EndsWith('.md', 'OrdinalIgnoreCase')) { # checks that the snippet is in a "snippets" folder and that it's not a link "://"
 				$snippetFullPath = (Resolve-Path -LiteralPath (Join-Path $docFile.DirectoryName $snippetPath)).Path
 				$resolvedSnippetsFiles.add($snippetFullPath) | Out-Null
 			}


### PR DESCRIPTION
Fixes the snippet cleanup pipeline that fails due to the cleanup script following links that are not markdown files causing parsing failures. 

This should clean up unused snippets left when parent files are deleted.

Related run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=112548&view=results