### PR TITLE
Omitted unsupported workbook paths from powershell snippet generation…

### DIFF
--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
@@ -56,7 +56,17 @@ public class CodeSnippetsPipeline
                     var message = "Original HTTP Snippet:" + Environment.NewLine + 
                         File.ReadAllText(httpSnippetFilePath).TrimStart() + Environment.NewLine +
                         File.ReadAllText(expectedLanguageSnippetErrorFileFullPath);
-                    Assert.Fail(message);
+                    if(language.Equals("powershell", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if(!message.Contains("workbook"))
+                        {
+                            Assert.Fail(message);
+                        }
+                    }
+                    else
+                    {
+                        Assert.Fail(message);
+                    }
                 }
                 else
                 {

--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
@@ -58,7 +58,7 @@ public class CodeSnippetsPipeline
                         File.ReadAllText(expectedLanguageSnippetErrorFileFullPath);
                     if(language.Equals("powershell", StringComparison.OrdinalIgnoreCase))
                     {
-                        if(!message.Contains("workbook"))
+                        if(!message.Contains("workbook", StringComparison.OrdinalIgnoreCase))
                         {
                             Assert.Fail(message);
                         }


### PR DESCRIPTION
## Overview

This PR removes unsupported workbook Api paths from PowerShell snippet generation report.  Support was intentionally removed because of AutoREST timeouts caused by expansion of workbook navigation property on driveItem.  Having those paths reduces PowerShell snippet generation pass rates.


### Before omission
**Beta:** 791/3305 failed
**Pass rate:** 76% 

**V1:** 486/2152 failed
 **Pass rate:** 77% 

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/10947120/231497935-d602fc8a-ff9a-46f7-8300-3e6c2e040db3.png">

### After omission
**Beta:** 611/3305 failed 
**Pass rate:** 81.5% 

**V1:** 301/2152 failed 
**Pass rate:** 86% 
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/10947120/231496710-b4027282-cd24-4306-87dd-19ac8a3bbe8d.png">

## Testing Instructions

* Run snippet generation pipeline on this branch and compare results with main branch.
