### PR TITLE
Update go snippet execution path

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains(".Me().MessagesById(\"message-id\")", result);
+            Assert.Contains(".Me().Messages().WithMessageId(\"message-id\")", result);
         }
         [Fact]
         public async Task GeneratesTheCorrectFluentAPIPathForIndexedCollectionsWithMultipleParams() {
@@ -64,7 +64,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains(".DrivesById(\"drive-id\").ItemsById(\"driveItem-id\").Checkin().", result);
+            Assert.Contains("Drives().WithDriveId(\"drive-id\").Items().WithItemId(\"driveItem-id\").Checkin().", result);
         }
         [Fact]
         public async Task IgnoreOdataTypeWhenGenerating() {
@@ -122,7 +122,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Patch", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
-            Assert.Contains("graphClient.Me().MessagesById(\"message-id\").Patch(context.Background(), requestBody, nil)", result);
+            Assert.Contains("graphClient.Me().Messages().WithMessageId(\"message-id\").Patch(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task GeneratesThePutMethodCall() {
@@ -137,7 +137,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Put", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
-            Assert.Contains("graphClient.ApplicationsById(\"application-id\").Logo().Put(context.Background(), requestBody, nil)", result);
+            Assert.Contains("graphClient.Applications().WithApplicationId(\"application-id\").Logo().Put(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task GeneratesTheDeleteMethodCall() {
@@ -147,7 +147,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("Delete", result);
             Assert.DoesNotContain("result, err :=", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
-            Assert.Contains("graphClient.Me().MessagesById(\"message-id\").Delete(context.Background(), nil)", result);
+            Assert.Contains("graphClient.Me().Messages().WithMessageId(\"message-id\").Delete(context.Background(), nil)", result);
         }
         [Fact]
         public async Task WritesTheRequestPayload() {
@@ -263,7 +263,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("&graphconfig.UserItemRequestBuilderGetRequestConfiguration", result);
             Assert.Contains("configuration :=", result);
             Assert.Contains("requestParameters :=", result);
-            Assert.Contains("result, err := graphClient.UsersById(\"user-id\").Get(context.Background(), configuration)", result);
+            Assert.Contains("result, err := graphClient.Users().WithUserId(\"user-id\").Get(context.Background(), configuration)", result);
         }
         [Fact]
         public async Task GeneratesODataTypesAreEscaped()
@@ -282,7 +282,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("requestBody := graphmodels.NewReferenceCreate()", result);
             Assert.Contains("requestBody.SetOdataId(&odataId)", result);
             Assert.Contains("odataId := \"https://graph.microsoft.com/v1.0/directoryObjects/{id}\"", result);
-            Assert.Contains("graphClient.GroupsById(\"group-id\").Members().Ref().Post(context.Background(), requestBody, nil)", result);
+            Assert.Contains("graphClient.Groups().WithGroupId(\"group-id\").Members().Ref().Post(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task GeneratesCountBooleanQueryParameters() {
@@ -339,7 +339,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.Me().EventsById(\"event-id\").Attachments().Post(context.Background(), requestBody, nil)", result);
+            Assert.Contains("graphClient.Me().Events().WithEventId(\"event-id\").Attachments().Post(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task ParsesThePayloadEvenIfContentTypeIsMissing() {
@@ -349,7 +349,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.TeamsById(\"team-id\").ChannelsById(\"channel-id\").Messages().Post(context.Background(), requestBody, nil)", result);
+            Assert.Contains("graphClient.Teams().WithTeamId(\"team-id\").Channels().WithChannelId(\"channel-id\").Messages().Post(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task WritesEmptyPrimitiveArrays() {
@@ -397,7 +397,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/me/messages/AAMkADYAAAImV_jAAA=/?$expand=microsoft.graph.eventMessage/event");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient.Me().MessagesById(\"message-id\").Get(context.Background(), configuration)", result);
+            Assert.Contains("graphClient.Me().Messages().WithMessageId(\"message-id\").Get(context.Background(), configuration)", result);
         }
         [Fact]
         public async Task IncludesRequestBodyClassName() {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -482,22 +482,27 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static string GetFluentApiPath(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
             if (!(nodes?.Any() ?? false)) return string.Empty;
-            return nodes.Select(static x =>
+            var elements = nodes.Select(static (x, i) =>
             {
                 if (x.Segment.IsCollectionIndex())
-                    return $"ById{x.Segment.Replace("{", "(\"").Replace("}", "\")")}.";
+                    return $"WithTypeId{x.Segment.Replace("{", "(\"").Replace("}", "\")")}.";
                 else if (x.Segment.IsFunction())
                     return x.Segment.Split('.')
                                     .Select(static s => s.ToFirstCharacterUpperCase())
                                     .Aggregate(static (a, b) => $"{a}{b}") + "().";
                 return x.Segment.ToFirstCharacterUpperCase() + "().";
             })
-                        .Aggregate(static (x, y) =>
+                        .Aggregate(new List<String>(), (current, next) =>
                         {
-                            return $"{x}{y.Replace("$", string.Empty, StringComparison.OrdinalIgnoreCase).ToFirstCharacterUpperCase()}";
-                        })
-                        .Replace("().ById(", "ById(")
-                        .Replace("()()", "()");
+                            var element = next.Contains("WithTypeId",StringComparison.OrdinalIgnoreCase) ? 
+                            next.Replace("WithTypeId", $"With{current.Last().Replace("s().", string.Empty, StringComparison.OrdinalIgnoreCase)}Id") :
+                            $"{next.Replace("$", string.Empty, StringComparison.OrdinalIgnoreCase).ToFirstCharacterUpperCase()}";
+
+                            current.Add(element);
+                            return current;
+                        });
+
+            return string.Join("", elements).Replace("()()", "()");
         }
     }
 }


### PR DESCRIPTION
## Overview
Closes https://github.com/microsoftgraph/msgraph-sdk-go/issues/458

Update go snippets indexer to use latest kiota changes https://github.com/microsoft/kiota/issues/2528

Previous statement 

```go
result, err := graphClient.TeamsById("team-id").ChannelsById("channel-id").Messages().Post(context.Background(), requestBody, nil)

```

Current statement 

```go

result, err := graphClient.Teams().WithTeamId("team-id").Channels().WithChannelId("channel-id").Messages().Post(context.Background(), requestBody, nil)

```

Tested by unit tests