### PR TITLE
Fix date time offset in URL path segments

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -613,6 +613,35 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
         
         [Fact]
+        public async Task CorrectlyHandlesDateTimeOffsetInUrl()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/reports/getUserArchivedPrintJobs(userId='{{id}}',startDateTime=<timestamp>,endDateTime=<timestamp>)");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.Reports.GetUserArchivedPrintJobsWithUserIdWithStartDateTimeWithEndDateTime(DateTimeOffset.Parse(\"{endDateTime}\"),DateTimeOffset.Parse(\"{startDateTime}\"),\"{userId}\").GetAsync()", result);
+        }
+
+        [Fact]
+        public async Task CorrectlyHandlesNumberInUrl()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/drive/items/{{id}}/workbook/worksheets/{{id|name}}/cell(row=<row>,column=<column>)");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"].CellWithRowWithColumn(1,1).GetAsync();",result);
+        }
+        [Fact]
+        public async Task CorrectlyHandlesDateInUrl()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/reports/getYammerGroupsActivityDetail(date='2018-03-05')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.Reports.GetYammerGroupsActivityDetailWithDate(new Date(DateTime.Parse(\"{date}\"))).GetAsync();", result);
+        }
+
+        [Fact]
         public async Task MatchesPathWithPathParameter()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/drive/items/{{id}}/workbook/worksheets/{{id|name}}/range(address='A1:B2')");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -331,7 +331,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
                                             // use the existing WriteObjectFromCodeProperty functionality to write the parameters as if they were a comma seperated array so as to automatically infer type handling from the codeDom :)
                                             var parametersBuilder = new StringBuilder();
-                                            foreach (var codeProperty in snippetCodeGraph.PathParameters.OrderBy(static parameter => parameter.Name))
+                                            foreach (var codeProperty in snippetCodeGraph.PathParameters.OrderBy(static parameter => parameter.Name, StringComparer.OrdinalIgnoreCase))
                                             {
                                                 var parameter = new StringBuilder();
                                                 WriteObjectFromCodeProperty(new CodeProperty{PropertyType = PropertyType.Array}, codeProperty, parameter, new IndentManager(), snippetCodeGraph.ApiVersion);

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -189,7 +189,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
             var pathParameters = snippetModel.EndPathNode.PathItems.FirstOrDefault()
                 .Value?.Operations.FirstOrDefault()
-                .Value?.Parameters.Where(param => param.In == ParameterLocation.Path) ?? new List<OpenApiParameter>();
+                .Value?.Parameters.Where(static param => param.In == ParameterLocation.Path) ?? new List<OpenApiParameter>();
 
             var parameters = new List<CodeProperty>();
             foreach (var parameter in pathParameters)

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -194,7 +194,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             var parameters = new List<CodeProperty>();
             foreach (var parameter in pathParameters)
             {
-                switch (parameter.Schema.Type)
+                switch (parameter.Schema.Type.ToLowerCaseInvariant())
                 {
                     case "string":
                         parameters.Add(evaluateStringProperty(parameter.Name, $"{{{parameter.Name}}}", parameter.Schema));

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
@@ -10,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Web;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 
@@ -55,6 +53,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             Headers = parseHeaders(snippetModel);
             Options = Enumerable.Empty<CodeProperty>();
             Parameters = parseParameters(snippetModel);
+            PathParameters = parsePathParameters(snippetModel);
             Body = parseBody(snippetModel);
             ApiVersion = snippetModel.ApiVersion;
         }
@@ -89,6 +88,11 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         }
 
         public IEnumerable<CodeProperty> Parameters
+        {
+            get; set;
+        }
+        
+        public IEnumerable<CodeProperty> PathParameters
         {
             get; set;
         }
@@ -175,6 +179,32 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                     }else{
                         parameters.Add(new() { Name = name, Value = value, PropertyType = PropertyType.String });
                     }
+                }
+            }
+            return parameters;
+        }
+        
+        private static List<CodeProperty> parsePathParameters(SnippetModel snippetModel)
+        {
+
+            var pathParameters = snippetModel.EndPathNode.PathItems.FirstOrDefault()
+                .Value?.Operations.FirstOrDefault()
+                .Value?.Parameters.Where(param => param.In == ParameterLocation.Path) ?? new List<OpenApiParameter>();
+
+            var parameters = new List<CodeProperty>();
+            foreach (var parameter in pathParameters)
+            {
+                switch (parameter.Schema.Type)
+                {
+                    case "string":
+                        parameters.Add(evaluateStringProperty(parameter.Name, $"{{{parameter.Name}}}", parameter.Schema));
+                        break;
+                    case "integer":
+                        parameters.Add(new CodeProperty { Name = parameter.Name, Value = int.TryParse(parameter.Name, out _) ? parameter.Name : "1", PropertyType = PropertyType.Int32, Children = new List<CodeProperty>() });
+                        break;
+                    case "double":
+                        parameters.Add(new CodeProperty { Name = parameter.Name, Value = double.TryParse(parameter.Name, out _) ? parameter.Name : "1.0d", PropertyType = PropertyType.Double, Children = new List<CodeProperty>() });
+                        break;
                 }
             }
             return parameters;
@@ -351,22 +381,22 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             return $"models{namespaceSuffix}";
         }
         
-        private static CodeProperty evaluateStringProperty(string propertyName, JsonElement value, OpenApiSchema propSchema)
+        private static CodeProperty evaluateStringProperty(string propertyName, string value, OpenApiSchema propSchema)
         {
             if ((propSchema?.Type?.Equals("boolean", StringComparison.OrdinalIgnoreCase) ?? false))
-                return new CodeProperty { Name = propertyName, Value = value.GetString(), PropertyType = PropertyType.Boolean, Children = new List<CodeProperty>() };
+                return new CodeProperty { Name = propertyName, Value = value, PropertyType = PropertyType.Boolean, Children = new List<CodeProperty>() };
             var formatString = propSchema?.Format;
             if (!string.IsNullOrEmpty(formatString) && _formatPropertyTypes.TryGetValue(formatString, out var type))
-                return new CodeProperty { Name = propertyName, Value = value.GetString(), PropertyType = type, Children = new List<CodeProperty>() };
+                return new CodeProperty { Name = propertyName, Value = value, PropertyType = type, Children = new List<CodeProperty>() };
             var enumSchema = propSchema?.AnyOf.FirstOrDefault(x => x.Enum.Count > 0);
             if ((propSchema?.Enum.Count ?? 0) == 0 && enumSchema == null)
-                return new CodeProperty { Name = propertyName, Value = escapeSpecialCharacters(value.GetString()), PropertyType = PropertyType.String, Children = new List<CodeProperty>() };
+                return new CodeProperty { Name = propertyName, Value = escapeSpecialCharacters(value), PropertyType = PropertyType.String, Children = new List<CodeProperty>() };
             enumSchema ??= propSchema;
             // Pass the list of options in the enum as children so that the language generators may use them for validation if need be, 
             var enumValueOptions = enumSchema?.Enum.Where(option => option is OpenApiString)
                                                                 .Select(option => new CodeProperty{Name = ((OpenApiString)option).Value,Value = ((OpenApiString)option).Value,PropertyType = PropertyType.String})
                                                                 .ToList() ?? new List<CodeProperty>();
-            var propValue = String.IsNullOrWhiteSpace(value.GetString()) ? $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{enumValueOptions.FirstOrDefault().Value.ToFirstCharacterUpperCase()}" : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.GetString().ToFirstCharacterUpperCase()}";
+            var propValue = String.IsNullOrWhiteSpace(value) ? $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{enumValueOptions.FirstOrDefault().Value.ToFirstCharacterUpperCase()}" : $"{enumSchema?.Title.ToFirstCharacterUpperCase()}.{value.ToFirstCharacterUpperCase()}";
 
             return new CodeProperty { Name = propertyName, Value = propValue, PropertyType = PropertyType.Enum, Children = enumValueOptions ,NamespaceName = GetNamespaceFromSchema(enumSchema)};
         }
@@ -404,7 +434,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             switch (value.ValueKind)
             {
                 case JsonValueKind.String:
-                    return evaluateStringProperty(propertyName, value, propSchema);
+                    return evaluateStringProperty(propertyName, value.GetString(), propSchema);
                 case JsonValueKind.Number:
                     return evaluateNumericProperty(propertyName, value, propSchema);
                 case JsonValueKind.False:


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/612

Type information is needed to correctly infer types used in URL path parameters for functions. This PR therefore adds a collection of CodeProperty instances to the snippetCode graph with the type information so that this may be taken advantage of during snippet generation.

Tests have been added to validate this. 