### PR TITLE
Fetch least privilege permissions for set of request URLs and not individual request URLs

### DIFF
--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -55,12 +55,14 @@ namespace GraphWebApi.Controllers
 
             string localeCode = GetPreferredLocaleLanguage(Request);
 
-            var requestUrls = requestUrl != null ? new List<string> { requestUrl } : null;
+            var requests = requestUrl != null
+                ? new List<RequestInfo> { new RequestInfo { RequestUrl = requestUrl, HttpMethod = method } }
+                : null;
+
             PermissionResult result = await _permissionsStore.GetScopesAsync(
-                                                                requestUrls: requestUrls,
+                                                                requests: requests,
                                                                 locale: localeCode,
                                                                 scopeType: scopeType,
-                                                                method: method,
                                                                 includeHidden: includeHidden,
                                                                 leastPrivilegeOnly: leastPrivilegeOnly,
                                                                 org: org,
@@ -76,24 +78,22 @@ namespace GraphWebApi.Controllers
 
         [HttpPost]
         [Produces("application/json")]
-        public async Task<IActionResult> GetPermissionScopes([FromBody] List<string> requestUrls,
+        public async Task<IActionResult> GetPermissionScopes([FromBody] List<RequestInfo> requests,
                                                              [FromQuery] ScopeType? scopeType = null,
-                                                             [FromQuery] string method = null,
                                                              [FromQuery] string org = null,
                                                              [FromQuery] string branchName = null,
                                                              [FromQuery] bool leastPrivilegeOnly = true,
                                                              [FromQuery] bool includeHidden = false)
         {
-            if (requestUrls == null || !requestUrls.Any())
+            if (requests == null || !requests.Any())
                 return BadRequest("Request URLs cannot be null or empty");
 
             string localeCode = GetPreferredLocaleLanguage(Request);
 
             PermissionResult result = await _permissionsStore.GetScopesAsync(
-                                                                requestUrls: requestUrls,
+                                                                requests: requests,
                                                                 locale: localeCode,
                                                                 scopeType: scopeType,
-                                                                method: method,
                                                                 includeHidden: includeHidden,
                                                                 leastPrivilegeOnly: leastPrivilegeOnly,
                                                                 org: org,

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -257,20 +257,24 @@ paths:
       description: Get list of permissions that enable access to a specified set of resources
       operationId: permissions.ListPermissionsSet
       parameters:
-        - $ref: "#/components/parameters/method"
         - $ref: "#/components/parameters/scopeType"
         - $ref: "#/components/parameters/org"
         - $ref: "#/components/parameters/branchName"
         - $ref: "#/components/parameters/includeHidden"
         - $ref: "#/components/parameters/leastPrivilegeOnly"
       requestBody:
-        description: An array of URLs
+        description: An array of URLs and corresponding HTTP methods
         content:
           application/json:
             schema:
               type: array
               items:
-                type: string
+                type: object
+                properties:
+                  requestUrl:
+                    type: string
+                  method:
+                    type: string
       responses:
         "200":
           description: Ordered array of permissions that enable access to a specified resource (or all the Microsoft Graph API endpoints), from least to most privileged along with detailed information about the permissions.
@@ -446,17 +450,17 @@ paths:
       description: Get the Microsoft Graph API metadata CSDL document as an OpenAPI document.
       operationId: openapi.GetDocument
       parameters:
-        - $ref: '#/components/parameters/url'
-        - $ref: '#/components/parameters/tags'
-        - $ref: '#/components/parameters/operationIds'
-        - $ref: '#/components/parameters/openApiVersion'
-        - $ref: '#/components/parameters/graphVersion'
-        - $ref: '#/components/parameters/style'
-        - $ref: '#/components/parameters/title'
-        - $ref: '#/components/parameters/format'
-        - $ref: '#/components/parameters/forceRefresh'
-        - $ref: '#/components/parameters/singularizeOperationIds'
-        - $ref: '#/components/parameters/fileName'
+        - $ref: "#/components/parameters/url"
+        - $ref: "#/components/parameters/tags"
+        - $ref: "#/components/parameters/operationIds"
+        - $ref: "#/components/parameters/openApiVersion"
+        - $ref: "#/components/parameters/graphVersion"
+        - $ref: "#/components/parameters/style"
+        - $ref: "#/components/parameters/title"
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/forceRefresh"
+        - $ref: "#/components/parameters/singularizeOperationIds"
+        - $ref: "#/components/parameters/fileName"
       responses:
         "200":
           description: List of operations associated to a tag/operationIds/url
@@ -471,14 +475,14 @@ paths:
       description: Get all the operations from the Microsoft Graph API metadata CSDL document.
       operationId: openapi.operations.ListOperations
       parameters:
-        - $ref: '#/components/parameters/openApiVersion'
-        - $ref: '#/components/parameters/graphVersion'
-        - $ref: '#/components/parameters/style'
-        - $ref: '#/components/parameters/title'
-        - $ref: '#/components/parameters/format'
-        - $ref: '#/components/parameters/forceRefresh'
-        - $ref: '#/components/parameters/singularizeOperationIds'
-        - $ref: '#/components/parameters/fileName'
+        - $ref: "#/components/parameters/openApiVersion"
+        - $ref: "#/components/parameters/graphVersion"
+        - $ref: "#/components/parameters/style"
+        - $ref: "#/components/parameters/title"
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/forceRefresh"
+        - $ref: "#/components/parameters/singularizeOperationIds"
+        - $ref: "#/components/parameters/fileName"
       responses:
         "200":
           description: OK
@@ -492,8 +496,8 @@ paths:
       description: Get the Microsoft Graph API metadata CSDL document as an OpenAPIUrlTreeNode document.
       operationId: openapi.tree.GetUrlTreeNode
       parameters:
-        - $ref: '#/components/parameters/graphVersions'
-        - $ref: '#/components/parameters/forceRefresh'
+        - $ref: "#/components/parameters/graphVersions"
+        - $ref: "#/components/parameters/forceRefresh"
       responses:
         "200":
           description: Simplified OpenAPI document(s) rendered as an OpenApiUrlTreeNode document.
@@ -869,7 +873,7 @@ components:
           - yaml
         default: json
       description: The OpenAPI document output format.
-    forceRefresh: 
+    forceRefresh:
       name: forceRefresh
       in: query
       schema:

--- a/PermissionsService/Interfaces/IPermissionStore.cs
+++ b/PermissionsService/Interfaces/IPermissionStore.cs
@@ -17,19 +17,17 @@ namespace PermissionsService.Interfaces
         /// <summary>
         /// Retrieves permissions scopes information for a set of URLs.
         /// </summary>
-        /// <param name="requestUrls">The list of request URLs to fetch permissions for.</param>
-        /// <param name="locale">Optional: The language code for the preferred localized file.</param>
+        /// <param name="requests">The list of request URLs to fetch permissions for.</param>
+        /// <param name="locale">Optional: The language code for the preferred localized file.<</param>
         /// <param name="scopeType">Optional: The type of scope to be retrieved for the target request url.</param>
-        /// <param name="method">Optional: The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="includeHidden">Optional: Whether to include hidden permissions or not: Defaults to false.</param>
-        /// <param name="isLeastPrivilege">Optional: Whether to only return least privilege permissions on not. Defaults to false.</param>
+        /// <param name="leastPrivilegeOnly">Optional: Whether to only return least privilege permissions on not. Defaults to false.</param>
         /// <param name="org">Optional: The name of the org/owner of the repo.</param>
-        /// <param name="branchName">Optional: The name of the branch containing the files</param>
+        /// <param name="branchName">Optional: The name of the branch containing the files.</param>
         /// <returns></returns>
-        Task<PermissionResult> GetScopesAsync(List<string> requestUrls = null,
+        Task<PermissionResult> GetScopesAsync(List<RequestInfo> requests = null,
                                                    string locale = null,
                                                    ScopeType? scopeType = null,
-                                                   string method = null,
                                                    bool includeHidden = false,
                                                    bool leastPrivilegeOnly = false,
                                                    string org = null,

--- a/PermissionsService/Models/RequestInfo.cs
+++ b/PermissionsService/Models/RequestInfo.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace PermissionsService.Models
+{
+    public class RequestInfo
+    {
+        [JsonProperty(PropertyName = "requestUrl")]
+        public string RequestUrl
+        {
+            get; set;
+        }
+
+        [JsonProperty(PropertyName = "method")]
+        public string HttpMethod
+        {
+            get; set;
+        }
+    }
+}

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -350,16 +350,18 @@ namespace PermissionsService
                     }
                 }
 
-                var allLeastPrivilegeScopes = scopesByRequestUrl.Values.SelectMany(x => x).Where(x => x.IsLeastPrivilege == true).ToList();
+                var allLeastPrivilegeScopes = scopesByRequestUrl.Values
+                    .SelectMany(static x => x).Where(static x => x.IsLeastPrivilege == true).ToList();
                 foreach (var scopeSet in scopesByRequestUrl.Values)
                 {
                     bool foundInOthers = false;
-                    var higherPrivilegedScopes = scopeSet.Where(scope => scope.IsLeastPrivilege == false);
+                    var higherPrivilegedScopes = scopeSet.Where(static x => x.IsLeastPrivilege == false);
 
                     // If any of the higher privilege permissions is a leastPrivilegePermissions somewhere, ignore
                     if (higherPrivilegedScopes.Any(scope =>
                             allLeastPrivilegeScopes.Any(leastScope =>
-                                leastScope.ScopeName == scope.ScopeName && leastScope.ScopeType == scope.ScopeType)))
+                                leastScope.ScopeName.Equals(scope.ScopeName, StringComparison.OrdinalIgnoreCase) && 
+                                    leastScope.ScopeType == scope.ScopeType)))
                         foundInOthers = true;
 
                     if (!foundInOthers)
@@ -367,7 +369,7 @@ namespace PermissionsService
                 }
 
                 if (leastPrivilegeOnly)
-                    scopes = scopes.Where(x => x.IsLeastPrivilege == true).ToList();
+                    scopes = scopes.Where(static x => x.IsLeastPrivilege == true).ToList();
             }
 
             // Create a dict of scopes information from GitHub files or cached files

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -306,10 +306,9 @@ namespace PermissionsService
         }
 
         ///<inheritdoc/>
-        public async Task<PermissionResult> GetScopesAsync(List<string> requestUrls = null,
+        public async Task<PermissionResult> GetScopesAsync(List<RequestInfo> requests = null,
                                                    string locale = DefaultLocale,
                                                    ScopeType? scopeType = null,
-                                                   string method = null,
                                                    bool includeHidden = false,
                                                    bool leastPrivilegeOnly = false,
                                                    string org = null,
@@ -319,44 +318,58 @@ namespace PermissionsService
             if (permissionsData?.PathPermissions == null)
                 throw new InvalidOperationException("Failed to fetch permissions");
 
-            List<ScopeInformation> scopes = new List<ScopeInformation>();
-            List<PermissionError> errors = new List<PermissionError>();
+            var scopes = new List<ScopeInformation>();
+            var errors = new List<PermissionError>();
 
-            if (requestUrls == null || !requestUrls.Any())
+            if (requests == null || !requests.Any())
             {
-                // Get all scopes
+                // Get all scopes if no request URLs are provided
                 var allScopes = await GetAllScopesAsync(scopeType);
                 scopes.AddRange(allScopes);
             }
             else
             {
-                // Get scopes for multiple request URLs
-                foreach (var url in requestUrls)
+                var scopesByRequestUrl = new Dictionary<string, IEnumerable<ScopeInformation>>();
+                foreach (var request in requests)
                 {
                     try
                     {
-                        if (string.IsNullOrEmpty(url))
-                            throw new InvalidOperationException("The request URL cannot be null or empty.");
-
-                        var scopesForUrl = await GetScopesForRequestUrlAsync(requestUrl: url,
-                                                                scopeType: scopeType,
-                                                                method: method,
-                                                                leastPrivilegeOnly: leastPrivilegeOnly);
-
+                        var scopesForUrl = await GetScopesForRequestUrlAsync(request.RequestUrl, request.HttpMethod, scopeType);
                         if (scopesForUrl == null || !scopesForUrl.Any())
-                            throw new InvalidOperationException($"Permissions information for {url} were not found.");
+                            throw new InvalidOperationException($"Permissions information for '{request.HttpMethod} {request.RequestUrl}' were not found.");
 
-                        scopes.AddRange(scopesForUrl);
+                        scopesByRequestUrl.TryAdd($"{request.HttpMethod} {request.RequestUrl}", scopesForUrl);
                     }
                     catch (Exception exception)
                     {
                         errors.Add(new PermissionError()
                         {
-                            Url = url,
+                            Url = request.RequestUrl,
                             Message = exception.Message
                         });
                     }
                 }
+
+                var allLeastPrivilegeScopes = scopesByRequestUrl.Values.SelectMany(x => x).Where(x => x.IsLeastPrivilege == true).ToList();
+                foreach (var scopeSet in scopesByRequestUrl.Values)
+                {
+                    bool foundInOthers = false;
+                    var higherPriviledgedScopes = scopeSet.Where(x => x.IsLeastPrivilege == false);
+                    foreach (var scope in higherPriviledgedScopes)
+                    {
+                        // if any of the higher privilege permissions is a leastPrivilegePermissions somewhere, ignore
+                        if (allLeastPrivilegeScopes.Exists(x => x.ScopeName == scope.ScopeName && x.ScopeType == scope.ScopeType))
+                        {
+                            foundInOthers = true;
+                            break;
+                        }
+                    }
+                    if (!foundInOthers)
+                        scopes.AddRange(scopeSet);
+                }
+
+                if (leastPrivilegeOnly)
+                    scopes = scopes.Where(x => x.IsLeastPrivilege == true).ToList();
             }
 
             // Create a dict of scopes information from GitHub files or cached files
@@ -372,8 +385,8 @@ namespace PermissionsService
             // exclude hidden permissions unless stated otherwise
             scopesInfo = scopesInfo.Where(x => includeHidden || !x.IsHidden).ToList();
 
-            _telemetryClient?.TrackTrace(requestUrls == null || !requestUrls.Any() ? 
-                "Return all permissions" : $"Return permissions for '{string.Join(",", requestUrls)}'", 
+            _telemetryClient?.TrackTrace(requests == null || !requests.Any() ? 
+                "Return all permissions" : $"Return permissions for '{string.Join(", ", requests.Select(x => x.RequestUrl))}'", 
                 SeverityLevel.Information, 
                 _permissionsTraceProperties);
 
@@ -402,14 +415,16 @@ namespace PermissionsService
         }
 
         private async Task<IEnumerable<ScopeInformation>> GetScopesForRequestUrlAsync(string requestUrl,
-                                                              string method = null,
-                                                              ScopeType? scopeType = null,
-                                                              bool leastPrivilegeOnly = false)
+                                                              string method,
+                                                              ScopeType? scopeType = null)
         {
-            var permissionsData = await PermissionsData;
-
             if (string.IsNullOrEmpty(requestUrl))
-                return Enumerable.Empty<ScopeInformation>();
+                throw new InvalidOperationException("The request URL cannot be null or empty.");
+
+            if (string.IsNullOrEmpty(method))
+                throw new InvalidOperationException("The HTTP method value cannot be null or empty.");
+
+            var permissionsData = await PermissionsData;
 
             requestUrl = CleanRequestUrl(requestUrl);
 
@@ -440,16 +455,15 @@ namespace PermissionsService
             }
 
             var scopes = pathPermissions
-                .Where(x => string.IsNullOrEmpty(method)
-                    || x.Key.Equals(method, StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.Key.Equals(method, StringComparison.OrdinalIgnoreCase))
                 .SelectMany(static x => x.Value)
                 .Where(x => scopeType == null || x.Key == scopeType)
-                .SelectMany(x => leastPrivilegeOnly ? x.Value.LeastPrivilegePermissions : x.Value.AllPermissions,
+                .SelectMany(x => x.Value.AllPermissions,
                     (x, permission) => new ScopeInformation
                     {
                         ScopeType = x.Key,
                         ScopeName = permission,
-                        IsLeastPrivilege = leastPrivilegeOnly || x.Value.LeastPrivilegePermissions.Contains(permission)
+                        IsLeastPrivilege = x.Value.LeastPrivilegePermissions.Contains(permission)
                     })
                 .DistinctBy(static x => $"{x.ScopeName}{x.ScopeType}", StringComparer.OrdinalIgnoreCase);
 

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -354,16 +354,14 @@ namespace PermissionsService
                 foreach (var scopeSet in scopesByRequestUrl.Values)
                 {
                     bool foundInOthers = false;
-                    var higherPriviledgedScopes = scopeSet.Where(x => x.IsLeastPrivilege == false);
-                    foreach (var scope in higherPriviledgedScopes)
-                    {
-                        // if any of the higher privilege permissions is a leastPrivilegePermissions somewhere, ignore
-                        if (allLeastPrivilegeScopes.Exists(x => x.ScopeName == scope.ScopeName && x.ScopeType == scope.ScopeType))
-                        {
-                            foundInOthers = true;
-                            break;
-                        }
-                    }
+                    var higherPrivilegedScopes = scopeSet.Where(scope => scope.IsLeastPrivilege == false);
+
+                    // If any of the higher privilege permissions is a leastPrivilegePermissions somewhere, ignore
+                    if (higherPrivilegedScopes.Any(scope =>
+                            allLeastPrivilegeScopes.Any(leastScope =>
+                                leastScope.ScopeName == scope.ScopeName && leastScope.ScopeType == scope.ScopeType)))
+                        foundInOthers = true;
+
                     if (!foundInOthers)
                         scopes.AddRange(scopeSet);
                 }


### PR DESCRIPTION
## Overview
Fixes #1505

## Example
Sample permissions file
```json
{
  "/users/{id}/chats": {
     "GET": {
         "DelegatedWork": {
	      "leastPrivilegePermissions": [
                  "Chat.ReadBasic"
	      ],
	   "allPermissions": [
	       "Chat.Read",
	       "Chat.ReadBasic",
	       "Chat.ReadWrite"
	   ]
      }
  },
  "/chats/{id}/messages": {
     "GET": {
         "DelegatedWork": {
	      "leastPrivilegePermissions": [
                  "Chat.Read"
	      ],
	   "allPermissions": [
	       "Chat.Read",
	       "Chat.ReadWrite"
	   ]
      }
  }
}
```

### Request
```
POST /permissions?scopeType=DelegatedWork
[ 
    { 
        "requestUrl": "/users/{id}/chats",
        "method": "GET"
    },
    { 
        "requestUrl": "/chats/{id}/messages",
        "method": "POST"
    }
]
```
### Response
```json
[
    {
        "value": "Chat.Read",
        "scopeType": "DelegatedWork",
        "consentDisplayName": "Read your chat messages",
        "consentDescription": "Allows an app to read your 1 on 1 or group chat messages in Microsoft Teams, on your behalf.",
        "isAdmin": false,
        "isLeastPrivilege": true,
        "isHidden": false
    }
]
```

