### PR TITLE
Return Workbook Paths to PowerShell Snippet Generation Test Report

### DIFF
--- a/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
+++ b/CodeSnippetsPipeline.Test/CodeSnippetsPipeline.cs
@@ -56,17 +56,7 @@ public class CodeSnippetsPipeline
                     var message = "Original HTTP Snippet:" + Environment.NewLine + 
                         File.ReadAllText(httpSnippetFilePath).TrimStart() + Environment.NewLine +
                         File.ReadAllText(expectedLanguageSnippetErrorFileFullPath);
-                    if(language.Equals("powershell", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if(!message.Contains("workbook", StringComparison.OrdinalIgnoreCase))
-                        {
-                            Assert.Fail(message);
-                        }
-                    }
-                    else
-                    {
-                        Assert.Fail(message);
-                    }
+                    Assert.Fail(message);     
                 }
                 else
                 {


### PR DESCRIPTION

## Overview

This PR returns the previously omitted workbook paths in the PowerShell snippet generation report. It is an action plan as a result of the discussions on this [PR](https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1496) that omitted the workbook paths.

