### PR TITLE
Default scope type to 'DelegatedWork' when fetching permissions for backward compatibility

### DIFF
--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -42,7 +42,7 @@ namespace GraphWebApi.Controllers
         // Gets the permissions scopes
         [HttpGet]
         [Produces("application/json")]
-        public async Task<IActionResult> GetPermissionScopes([FromQuery]ScopeType? scopeType = null,
+        public async Task<IActionResult> GetPermissionScopes([FromQuery]ScopeType scopeType = ScopeType.DelegatedWork,
                                                              [FromQuery]string requestUrl = null,
                                                              [FromQuery]string method = null,
                                                              [FromQuery]string org = null,


### PR DESCRIPTION
## Overview
This is for backward compatibility for GE and Raptor tests. 