### PR TITLE
Modified powershell generator to handle encoded strings

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -77,6 +77,16 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
 
         [Fact]
+        public async Task GeneratesNoneEncodedSnippetForRequestWithFilterQueryOptionAndEncodedPayloads()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$filter=displayName+eq+'Megan+Bowen'");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("-Filter \"displayName eq 'Megan Bowen'\"", result);
+        }
+
+        
+        [Fact]
         public async Task GeneratesSnippetForRequestWithFilterQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$filter=displayName eq 'Megan Bowen'");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -31,6 +31,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             LazyThreadSafetyMode.PublicationOnly
         );
         private static readonly Regex meSegmentRegex = new("^/me($|(?=/))", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex encodedQueryParamsPayLoad = new(@"\w*\+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
             var indentManager = new IndentManager();
@@ -94,7 +95,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
             var queryParamsPayload = GetRequestQueryParameters(snippetModel);
             if (!string.IsNullOrEmpty(queryParamsPayload))
-                payloadSB.Append($" {queryParamsPayload}");
+                payloadSB.Append($" {ReturnCleanParamsPayload(queryParamsPayload)}");
 
             var parameterList = GetActionParametersList(payloadVarName);
             if (!string.IsNullOrEmpty(parameterList))
@@ -104,6 +105,12 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (!string.IsNullOrEmpty(requestHeadersPayload))
                 payloadSB.Append(requestHeadersPayload);
             return payloadSB.ToString();
+        }
+        public static string ReturnCleanParamsPayload(string queryParamsPayload)
+        {
+            if(encodedQueryParamsPayLoad.IsMatch(queryParamsPayload))
+                return queryParamsPayload.Replace("+", " ");
+            return queryParamsPayload;
         }
 
         private static (string, string) SubstituteMeSegment(bool isMeSegment, string path)


### PR DESCRIPTION
## Overview

This PR fixes #1520 
It ensures that the snippet returned does not have encoded payload for $filter option.
### Generated snippet before fix
<img width="701" alt="image" src="https://user-images.githubusercontent.com/10947120/236170847-a86d437b-3f86-4063-a74e-f638d6f43cc6.png">

<img width="574" alt="image" src="https://user-images.githubusercontent.com/10947120/236170976-6eb3df35-d1d5-46c1-90fc-446fdf07ebc2.png">



### Generated snippet after fix
<img width="638" alt="image" src="https://user-images.githubusercontent.com/10947120/236171051-45158a6e-5116-4695-b20d-acdbc8bda368.png">

<img width="638" alt="image" src="https://user-images.githubusercontent.com/10947120/236171861-f520c32d-1f71-472d-95bd-bdf9eca6fde8.png">


## Testing Instructions

* Checkout this branch , run it locally and use Postman to test using the examples on the postman screenshots