### PR TITLE
Fixes missing paths being generated

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -659,6 +659,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [InlineData("/users/{user-id}/drive/items/{item-id}/children","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Children.GetAsync()")]
         [InlineData("/me/drive/items/{item-id}/children","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Children.GetAsync()")]
         [InlineData("/drive/bundles","graphClient.Drives[\"{drive-id}\"].Bundles.GetAsync()")]
+        [InlineData("/me/drive/special/documents","graphClient.Drives[\"{drive-id}\"].Special[\"{driveItem-id}\"].GetAsync()")]
+        [InlineData("/me/drive/root/search(q='Contoso%20Project')","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].SearchWithQ(\"{q}\").GetAsync()")]
         [InlineData("/me/drive/items/{id}/workbook/application/calculate","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Workbook.Application.Calculate", "POST")]
         public async Task GeneratesSnippetWithRemappedDriveCall(string inputPath, string expected, string method = "") 
         {

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -49,15 +49,14 @@ namespace CodeSnippetsReflection.OpenAPI
         private static readonly Dictionary<Regex, string> KnownReMappings = new()
         {
             { new Regex(@"/me/drive/root/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
-            { new Regex(@"/me/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/me/drive/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/" },
             { new Regex(@"/groups/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
-            { new Regex(@"/groups/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/groups/[A-z0-9{}\-]+/drive/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/" },
             { new Regex(@"/sites/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
-            { new Regex(@"/sites/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
+            { new Regex(@"/sites/[A-z0-9{}\-]+/drive/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/" },
             { new Regex(@"/users/[A-z0-9{}\-]+/drive/root",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/root/" },
-            { new Regex(@"/users/[A-z0-9{}\-]+/drive/items/[A-z0-9{}\-]+/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items/itemId/" },
-            { new Regex(@"/drive/bundles",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/bundles" },
-            { new Regex(@"/drive/items",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/items" },
+            { new Regex(@"/users/[A-z0-9{}\-]+/drive/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/" },
+            { new Regex(@"/drive/",RegexOptions.Compiled, TimeSpan.FromMilliseconds(200)), "/drives/driveId/" },
         };
         
         private static HttpRequestMessage RemapKnownPathsIfNeeded(HttpRequestMessage originalRequest)

--- a/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
@@ -11,7 +11,7 @@ internal static class StringExtensions
         !string.IsNullOrEmpty(pathSegment) && pathSegment.StartsWith('{') && pathSegment.EndsWith('}');
     internal static bool IsFunction(this string pathSegment) => !string.IsNullOrEmpty(pathSegment) && pathSegment.Contains('.');
 
-    private static readonly Regex FunctionWithParameterRegex = new(@"\([\w=':${}<>|\-,]+\)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
+    private static readonly Regex FunctionWithParameterRegex = new(@"\([\w\s\d=':${}<>|\-,]+\)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
     internal static bool IsFunctionWithParameters(this string pathSegment) => !string.IsNullOrEmpty(pathSegment) 
                                                                               && FunctionWithParameterRegex.Match(pathSegment).Success;
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1468 and related to https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1453

It fixes missing openAPI based snippets at 

- https://learn.microsoft.com/en-us/graph/api/driveitem-get?view=graph-rest-1.0&tabs=javascript#request
- https://learn.microsoft.com/en-us/graph/api/drive-get-specialfolder?view=graph-rest-1.0&tabs=http#example-1-get-special-folder-by-name
- https://learn.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=http

Closes https://github.com/microsoftgraph/microsoft-graph-docs/issues/20943

Sample generation at https://github.com/microsoftgraph/microsoft-graph-docs/compare/preview-snippet-generation/114050?expand=1

Generation failure should reduce by about ~30(C#/Go V1) and ~40(C#/Go beta)  between [This PR ](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=114050&view=ms.vss-test-web.build-test-results-tab) and [Latest weekly generation PR](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=113719&view=ms.vss-test-web.build-test-results-tab)