### PR TITLE
Update response for endpoint used to fetch permissions for a set of request URLs

### DIFF
--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -69,11 +69,11 @@ namespace GraphWebApi.Controllers
                                                                 branchName: branchName);
 
             _permissionsTraceProperties.Add(UtilityConstants.TelemetryPropertyKey_SanitizeIgnore, nameof(PermissionsController));
-            _telemetryClient?.TrackTrace($"Fetched {result?.Results.Count ?? 0} permissions",
+            _telemetryClient?.TrackTrace($"Fetched {result?.Results?.Count ?? 0} permissions",
                                             SeverityLevel.Information,
                                             _permissionsTraceProperties);
 
-            return result == null || !result.Results.Any() ? NotFound() : Ok(result.Results);
+            return result == null || result.Results == null ? NotFound() : Ok(result.Results);
         }
 
         [HttpPost]

--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -98,10 +98,10 @@ namespace GraphWebApi.Controllers
                                                                 leastPrivilegeOnly: leastPrivilegeOnly,
                                                                 org: org,
                                                                 branchName: branchName);
-            if (result == null || !result.Results.Any())
+            if (result == null)
                 return NotFound();
 
-            return result.Errors.Any() ? BadRequest(result) : Ok(result.Results);
+            return Ok(result);
         }
 
         private string GetPreferredLocaleLanguage(HttpRequest request)

--- a/GraphWebApi/wwwroot/OpenApi.yaml
+++ b/GraphWebApi/wwwroot/OpenApi.yaml
@@ -278,52 +278,27 @@ paths:
                     type: string
       responses:
         "200":
-          description: Ordered array of permissions that enable access to a specified resource (or all the Microsoft Graph API endpoints), from least to most privileged along with detailed information about the permissions.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/permission"
-              example:
-                - value: Mail.ReadBasic
-                  scopeType: Application
-                  consentDisplayName: Read user basic mail
-                  consentDescription: "Allows the app to read email in the signed-in user's mailbox except body, previewBody, attachments and any extended properties."
-                  isAdmin: false,
-                  leastPrivilegeOnly: true
-                - value: Mail.Read
-                  scopeType: Application
-                  consentDisplayName: "Read your mail "
-                  consentDescription: "Allows the app to read email in your mailbox. "
-                  isAdmin: false
-                  leastPrivilegeOnly: false
-                - value: Mail.ReadWrite
-                  scopeType: Application
-                  consentDisplayName: "Read and write access to your mail "
-                  consentDescription: "Allows the app to read, update, create and delete email in your mailbox. Does not include permission to send mail. "
-                  isAdmin: false
-                  leastPrivilegeOnly: false
-        "400":
-          description: Returns results with description of errors encountered
+          description: An array of least privileged permissions that enable access to a set of resources, along with detailed information about the permissions and any errors encountered.
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  Results:
+                  results:
                     type: array
                     items:
                       $ref: "#/components/schemas/permission"
-                  Errors:
+                  errors:
                     type: array
                     items:
                       type: object
                       properties:
-                        Url:
+                        requestUrl:
                           type: string
-                        Message:
+                        message:
                           type: string
-
-                  type: object
+        "404":
+          description: Not found
         "500":
           description: Internal server error
   /changes:

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -8,6 +8,7 @@ using PermissionsService.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -240,6 +241,22 @@ namespace PermissionsService.Test
             Assert.Equal(expectedCount, result.Results.Count);
         }
 
+        [Fact]
+        public async Task ReturnErrorWhenLeastPrivilegePermissionsForSetOfResourcesIsNotAvailable()
+        {
+            // Act
+            var result = await _permissionsStore.GetScopesAsync(
+                new List<RequestInfo> { new RequestInfo { RequestUrl = "/no/least/privileged/permissions", HttpMethod = "DELETE" } },
+                scopeType: ScopeType.DelegatedWork,
+                leastPrivilegeOnly: true);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Null(result.Results);
+            Assert.NotNull(result.Errors);
+            Assert.Single(result.Errors);
+            Assert.Equal("No permissions found.", result.Errors.First().Message);
+        }
 
         [Theory]
         [InlineData("/users/{id}/drive/items/{id}/workbook/worksheets/{id}/range")]

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -138,7 +138,7 @@ namespace PermissionsService.Test
             }
             else
             {
-                Assert.Empty(result.Results);
+                Assert.Null(result.Results);
             }
         }
 
@@ -199,7 +199,7 @@ namespace PermissionsService.Test
                 new List<RequestInfo> { new RequestInfo { RequestUrl = "/foo/bar/{id}", HttpMethod = "GET" } }); // non-existent request url
 
             // Assert
-            Assert.Empty(result.Results);
+            Assert.Null(result.Results);
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace PermissionsService.Test
                         HttpMethod = "Foobar" } }); // non-existent http verb
 
             // Assert
-            Assert.Empty(result.Results);
+            Assert.Null(result.Results);
         }
 
         [Theory]
@@ -332,18 +332,18 @@ namespace PermissionsService.Test
                         new RequestInfo { RequestUrl = null, HttpMethod = "GET" } }
                     );
             // Assert
-            Assert.Empty(result.Results);
+            Assert.Null(result.Results);
             Assert.NotEmpty(result.Errors);
             Assert.Equal(2, result.Errors.Count);
             Assert.Collection(result.Errors,
                 item =>
                 {
-                    Assert.Equal("", item.Url);
+                    Assert.Equal("", item.RequestUrl);
                     Assert.Equal("The request URL cannot be null or empty.", item.Message);
                 },
                 item =>
                 {
-                    Assert.Null(item.Url);
+                    Assert.Null(item.RequestUrl);
                     Assert.Equal("The request URL cannot be null or empty.", item.Message);
                 });
         }
@@ -357,14 +357,14 @@ namespace PermissionsService.Test
                     requests: new List<RequestInfo>() {
                         new RequestInfo { RequestUrl = "/foo/bar", HttpMethod = "GET" } });
             // Assert
-            Assert.Empty(result.Results);
+            Assert.Null(result.Results);
             Assert.NotEmpty(result.Errors);
             Assert.Single(result.Errors);
             Assert.Collection(result.Errors,
                 item =>
                 {
-                    Assert.Equal("/foo/bar", item.Url);
-                    Assert.Equal("Permissions information for 'GET /foo/bar' were not found.", item.Message);
+                    Assert.Equal("/foo/bar", item.RequestUrl);
+                    Assert.Equal("Permissions information for 'GET /foo/bar' was not found.", item.Message);
                 });
         }
 

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -219,7 +219,7 @@ namespace PermissionsService.Test
 
         [Theory]
         [InlineData(true, 6)]
-        [InlineData(false, 10)]
+        [InlineData(false, 12)]
         public async Task ReturnLeastPrivilegePermissionsForSetOfResources(bool leastPrivilegeOnly, int expectedCount)
         {
             // Arrange
@@ -239,6 +239,30 @@ namespace PermissionsService.Test
             Assert.NotNull(result.Results);
             Assert.NotEmpty(result.Results);
             Assert.Equal(expectedCount, result.Results.Count);
+        }
+
+        [Fact]
+        public async Task ReturnCorrectLeastPrivilegePermissionsForResourcesThatHaveMatchMoreThanOneTemplate()
+        {
+            // Arrange
+            var request1 = new List<RequestInfo>()
+            {
+                new RequestInfo { RequestUrl = "/me/tasks/lists/delta", HttpMethod = "GET" }
+            };
+
+            var request2 = new List<RequestInfo>()
+            {
+                new RequestInfo { RequestUrl = "/me/tasks/lists/{lists_id}", HttpMethod = "GET" }
+            };
+
+            // Act
+            var result1 = await _permissionsStore.GetScopesAsync(requests: request1);
+            var result2 = await _permissionsStore.GetScopesAsync(requests: request2);
+
+            // Assert
+            Assert.NotNull(result1?.Results);
+            Assert.NotNull(result2?.Results);
+            Assert.NotEqual(result1.Results.Count, result2.Results.Count);
         }
 
         [Fact]

--- a/PermissionsService.Test/TestFiles/permissions-test-file.json
+++ b/PermissionsService.Test/TestFiles/permissions-test-file.json
@@ -157424,5 +157424,15 @@
         ]
       }
     }
+  },
+  "/no/least/privileged/permissions": {
+    "DELETE": {
+      "DelegatedWork": {
+        "leastPrivilegePermissions": [],
+        "allPermissions": [
+          "PrinterShare.ReadWrite.All"
+        ]
+      }
+    }
   }
 }

--- a/PermissionsService/Models/PermissionResult.cs
+++ b/PermissionsService/Models/PermissionResult.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// -------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// -------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace PermissionsService.Models

--- a/PermissionsService/Models/PermissionResult.cs
+++ b/PermissionsService/Models/PermissionResult.cs
@@ -1,27 +1,30 @@
 ﻿using System.Collections.Generic;
-using System.Net;
+using Newtonsoft.Json;
 
 namespace PermissionsService.Models
 {
     public class PermissionResult
     {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<ScopeInformation> Results
         {
             get; set;
-        } = new();
+        }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<PermissionError> Errors
         {
             get; set;
-        } = new();
+        }
     }
 
     public class PermissionError
     {
-        public string Url
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string RequestUrl
         {
             get; set;
-        } = string.Empty;
+        }
 
         public string Message
         {

--- a/PermissionsService/Models/RequestInfo.cs
+++ b/PermissionsService/Models/RequestInfo.cs
@@ -1,4 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿// -------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// -------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
 
 namespace PermissionsService.Models
 {

--- a/PermissionsService/Models/SchemePermissions.cs
+++ b/PermissionsService/Models/SchemePermissions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// -------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// -------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/PermissionsService/Models/ScopeType.cs
+++ b/PermissionsService/Models/ScopeType.cs
@@ -1,4 +1,8 @@
-﻿namespace PermissionsService.Models
+﻿// -------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// -------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace PermissionsService.Models
 {
     /// <summary>
     /// Defines permission schemes

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -89,8 +89,9 @@ namespace PermissionsService
         private Task<PermissionsDataInfo> PermissionsData =>
             _cache.GetOrCreateAsync("PermissionsData", async entry =>
             {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_defaultRefreshTimeInHours);
-                return await LoadPermissionsDataAsync();
+                var permissionsData = await LoadPermissionsDataAsync();
+                entry.AbsoluteExpirationRelativeToNow = permissionsData is not null ? TimeSpan.FromHours(_defaultRefreshTimeInHours) : TimeSpan.FromSeconds(1);
+                return permissionsData;
             });
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace PermissionsService
                 foreach (var key in fetchedPermissions.Keys)
                 {
                     // Remove any '(...)' from the request url and set to lowercase for uniformity
-                    string requestUrl = key.RemoveParentheses().RenameDuplicatePlaceholders().ToLower();
+                    string requestUrl = key.RemoveParentheses().ToLower();
 
                     count++;
 

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -127,7 +127,7 @@ namespace PermissionsService
                 foreach (var key in fetchedPermissions.Keys)
                 {
                     // Remove any '(...)' from the request url and set to lowercase for uniformity
-                    string requestUrl = key.RemoveParentheses().ToLower();
+                    string requestUrl = key.RemoveParentheses().RenameDuplicatePlaceholders().ToLower();
 
                     count++;
 

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -338,7 +338,7 @@ namespace PermissionsService
                     {
                         var scopesForUrl = await GetScopesForRequestUrlAsync(request.RequestUrl, request.HttpMethod, scopeType);
                         if (scopesForUrl == null || !scopesForUrl.Any())
-                            throw new InvalidOperationException($"Permissions information for '{request.HttpMethod} {request.RequestUrl}' were not found.");
+                            throw new InvalidOperationException($"Permissions information for '{request.HttpMethod} {request.RequestUrl}' was not found.");
 
                         scopesByRequestUrl.TryAdd($"{request.HttpMethod} {request.RequestUrl}", scopesForUrl);
                     }
@@ -346,7 +346,7 @@ namespace PermissionsService
                     {
                         errors.Add(new PermissionError()
                         {
-                            Url = request.RequestUrl,
+                            RequestUrl = request.RequestUrl,
                             Message = exception.Message
                         });
                     }
@@ -389,6 +389,14 @@ namespace PermissionsService
             // exclude hidden permissions unless stated otherwise
             scopesInfo = scopesInfo.Where(x => includeHidden || !x.IsHidden).ToList();
 
+            if (!scopesInfo.Any() && !errors.Any())
+            {
+                errors.Add(new PermissionError()
+                {
+                    Message = "No permissions found."
+                });
+            }
+
             _telemetryClient?.TrackTrace(requests == null || !requests.Any() ? 
                 "Return all permissions" : $"Return permissions for '{string.Join(", ", requests.Select(x => x.RequestUrl))}'", 
                 SeverityLevel.Information, 
@@ -396,8 +404,8 @@ namespace PermissionsService
 
             return new PermissionResult()
             {
-                Results = scopesInfo,
-                Errors = errors
+                Results = scopesInfo.Any() ? scopesInfo : null,
+                Errors = errors.Any() ? errors : null
             };
         }
 

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -90,7 +90,7 @@ namespace PermissionsService
             _cache.GetOrCreateAsync("PermissionsData", async entry =>
             {
                 var permissionsData = await LoadPermissionsDataAsync();
-                entry.AbsoluteExpirationRelativeToNow = permissionsData is not null ? TimeSpan.FromHours(_defaultRefreshTimeInHours) : TimeSpan.FromSeconds(1);
+                entry.AbsoluteExpirationRelativeToNow = permissionsData is not null ? TimeSpan.FromHours(_defaultRefreshTimeInHours) : TimeSpan.FromMilliseconds(1);
                 return permissionsData;
             });
 

--- a/UriMatchService/UriTemplateMatcher.cs
+++ b/UriMatchService/UriTemplateMatcher.cs
@@ -17,7 +17,6 @@
 using System;
 #pragma warning restore S125 // Sections of code should not be commented out
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/UtilityService/UtilityExtensions.cs
+++ b/UtilityService/UtilityExtensions.cs
@@ -3,8 +3,6 @@
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace UtilityService

--- a/UtilityService/UtilityExtensions.cs
+++ b/UtilityService/UtilityExtensions.cs
@@ -3,6 +3,8 @@
 // -------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace UtilityService


### PR DESCRIPTION
## Overview
The update is to ensure consistent behaviour regardless of the content of the response.

```
{
  "results": [
    {
      "value": "string",
      "scopeType": "ScopeType",
      "consentDisplayName": "string",
      "consentDescription": "string",
      "isAdmin": "string",
      "leastPrivilegeOnly": "bool"
    }
  ],
  "errors": [
    {
      "requestUrl": "string",
      "message": "string"
    }
  ]
}
```