### PR TITLE
Run tests in linux runner

### DIFF
--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -11,58 +11,73 @@ pr:
     - dev
     - master
 
-pool: 1es-windows-latest
-
 variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-steps:
-- checkout: self
-  clean: true
-  fetchDepth: 1
-  submodules: recursive
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: sdk
-    version: 7.0.x
-    performMultiLevelLookup: true
-    includePreviewVersions: true
-    installationPath: $(Agent.ToolsDirectory)/dotnet
-
-- task: DotNetCoreCLI@2
-  displayName: "Restore Nuget Packages"
-  inputs:
-    command: 'restore'
-    feedsToUse: 'select'
-
-- task: DotNetCoreCLI@2
-  displayName: "Build"
-  inputs:
-    command: 'build'
-
-- task: DotNetCoreCLI@2
-  displayName: "Run Tests"
-  inputs:
-    command: test
-    projects: '**/*Test/*.csproj'
-    arguments: '--configuration $(buildConfiguration) --collect "Code Coverage" --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --filter "TestCategory!=CodeSnippetsPipeline"'
-
-# CredScan
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-  displayName: 'Run CredScan'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)'
-    debugMode: false
-
-- task: PublishTestResults@2
-  displayName: "Publish Test Results"
-  inputs:
-    testResultsFormat: xUnit
-    testResultsFiles: '**/*.trx'
-    codeCoverageTool: 'cobertura'
-    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
+stages:
+  - stage: build
+    jobs:
+      - job: build
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 1
+          submodules: recursive
+        
+        - task: UseDotNet@2
+          displayName: 'Use .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: 7.0.x
+            performMultiLevelLookup: true
+            includePreviewVersions: true
+            installationPath: $(Agent.ToolsDirectory)/dotnet
+        
+        - task: DotNetCoreCLI@2
+          displayName: "Restore Nuget Packages"
+          inputs:
+            command: 'restore'
+            feedsToUse: 'select'
+        
+        - task: DotNetCoreCLI@2
+          displayName: "Build"
+          inputs:
+            command: 'build'
+        
+        - task: DotNetCoreCLI@2
+          displayName: "Run Tests"
+          inputs:
+            command: test
+            projects: '**/*Test/*.csproj'
+            arguments: '--configuration $(buildConfiguration) --collect "Code Coverage" --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --filter "TestCategory!=CodeSnippetsPipeline"'
+        
+        - task: PublishTestResults@2
+          displayName: "Publish Test Results"
+          inputs:
+            testResultsFormat: xUnit
+            testResultsFiles: '**/*.trx'
+            codeCoverageTool: 'cobertura'
+            summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
+  
+      - job: scan
+        pool:
+          vmImage: windows-latest
+        steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 1
+            submodules: recursive
+          
+          # CredScan
+          - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
+            displayName: 'Run CredScan'
+            inputs:
+              toolMajorVersion: 'V2'
+              scanFolder: '$(Build.SourcesDirectory)'
+              debugMode: false
+      


### PR DESCRIPTION
This PR unblocks https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1549, https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1552 ,https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1553, https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1554,https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1560 and https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1548

It runs the devxApi tests in a linux runners to resolve SSL exceptions observed in windows runners when trying to fetch for external metadata in tests. 