### PR TITLE
Chore/update cli code snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
@@ -75,14 +75,17 @@ public class GraphCliGeneratorTests
     [Theory]
     [InlineData("/users/100/directReports/graph.orgContact", "mgc users direct-reports graph-org-contact get --user-id {user-id}")]
     [InlineData("/users/100/directReports/123/graph.orgContact", "mgc users direct-reports graph-org-contact-by-id get --user-id {user-id} --directory-object-id {directoryObject-id}")]
-    public async Task GeneratesSnippetsForConflictingIndexerNavSubCommand(string url, string expectedCommand)
+    public void GeneratesSnippetsForConflictingIndexerNavSubCommand(string url, string expectedCommand)
     {
         // Tests:
         // GET /users/{user-id}/directReports/graph.orgContact
         // GET /users/{user-id}/directReports/{directoryObject-id}/graph.orgContact
         // Given
+        string schema = """{"openapi":"3.0.0","info":{"title":"Tests API","version":"1.0.11"},"servers":[{"url":"https://example.com/api/v1.0"}],"paths":{"/users/{user-id}/directReports/graph.orgContact":{"get":{"responses":{"200":{"description":"Successful operation"}}}},"/users/{user-id}/directReports/{directoryObject-id}/graph.orgContact":{"get":{"responses":{"200":{"description":"Successful operation"}}}}}}""";
+        var doc = new OpenApiStringReader().Read(schema, out _);
+        var rootNode = OpenApiUrlTreeNode.Create(doc, "default");
         using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{url}");
-        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, rootNode);
 
         // When
         var result = _generator.GenerateCodeSnippet(snippetModel);

--- a/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
@@ -32,12 +32,12 @@ public class GraphCliGeneratorTests
     public static IEnumerable<object[]> GetSnippetData()
     {
         return new[] {
-            new object[] {HttpMethod.Delete, $"{ServiceRootUrl}/users/100/settings", "mgc users item settings delete --user-id {user-id}"},
+            new object[] {HttpMethod.Delete, $"{ServiceRootUrl}/users/100/settings", "mgc users settings delete --user-id {user-id}"},
             new object[] {HttpMethod.Get, $"{ServiceRootUrl}/users", "mgc users list"},
-            new object[] {HttpMethod.Get, $"{ServiceRootUrl}/users/100", "mgc users item get --user-id {user-id}"},
-            new object[] {HttpMethod.Patch, $"{ServiceRootUrl}/users/100/licenseDetails/123", "mgc users item license-details item patch --user-id {user-id} --license-details-id {licenseDetails-id}"},
-            new object[] {HttpMethod.Post, $"{ServiceRootUrl}/users/100/extensions", "mgc users item extensions create --user-id {user-id}"},
-            new object[] {HttpMethod.Put, $"{ServiceRootUrl}/users/100/manager/$ref", "mgc users item manager ref put --user-id {user-id}"},
+            new object[] {HttpMethod.Get, $"{ServiceRootUrl}/users/100", "mgc users get --user-id {user-id}"},
+            new object[] {HttpMethod.Patch, $"{ServiceRootUrl}/users/100/licenseDetails/123", "mgc users license-details patch --user-id {user-id} --license-details-id {licenseDetails-id}"},
+            new object[] {HttpMethod.Post, $"{ServiceRootUrl}/users/100/extensions", "mgc users extensions create --user-id {user-id}"},
+            new object[] {HttpMethod.Put, $"{ServiceRootUrl}/users/100/manager/$ref", "mgc users manager ref put --user-id {user-id}"},
         };
     }
 
@@ -69,7 +69,26 @@ public class GraphCliGeneratorTests
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
         // Then
-        Assert.Equal("mgc users item todo lists item tasks item attachments item get --user-id {user-id} --todo-task-list-id {todoTaskList-id} --todo-task-id {todoTask-id} --attachment-base-id {attachmentBase-id}", result);
+        Assert.Equal("mgc users todo lists tasks attachments get --user-id {user-id} --todo-task-list-id {todoTaskList-id} --todo-task-id {todoTask-id} --attachment-base-id {attachmentBase-id}", result);
+    }
+
+    [Theory]
+    [InlineData("/users/100/directReports/graph.orgContact", "mgc users direct-reports graph-org-contact get --user-id {user-id}")]
+    [InlineData("/users/100/directReports/123/graph.orgContact", "mgc users direct-reports graph-org-contact-by-id get --user-id {user-id} --directory-object-id {directoryObject-id}")]
+    public async Task GeneratesSnippetsForConflictingIndexerNavSubCommand(string url, string expectedCommand)
+    {
+        // Tests:
+        // GET /users/{user-id}/directReports/graph.orgContact
+        // GET /users/{user-id}/directReports/{directoryObject-id}/graph.orgContact
+        // Given
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{url}");
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+
+        // When
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+
+        // Then
+        Assert.Equal(expectedCommand, result);
     }
 
     // Powershell metadata doesn't have /$count endpoints
@@ -121,7 +140,7 @@ public class GraphCliGeneratorTests
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
         // Then
-        Assert.Equal("mgc users item manager ref get --user-id {user-id}", result);
+        Assert.Equal("mgc users manager ref get --user-id {user-id}", result);
     }
 
     [Fact]
@@ -137,7 +156,7 @@ public class GraphCliGeneratorTests
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
         // Then
-        Assert.Equal("mgc users item photo content get --user-id {user-id}", result);
+        Assert.Equal("mgc users photo content get --user-id {user-id}", result);
     }
 
     [Fact]
@@ -156,9 +175,9 @@ public class GraphCliGeneratorTests
     }
 
     [Theory]
-    [InlineData("?id=10", "--id {id} --id-query {id-query}")]
-    [InlineData("?id=", "--id {id} --id-query {id-query}")]
-    [InlineData("?id", "--id {id} --id-query {id-query}")]
+    [InlineData("?id=10", "--id {id} --id-query 10")]
+    [InlineData("?id=", "--id {id}")] // When the query parameter value is an empty string, the snippet generator ignores it
+    [InlineData("?id", "--id {id}")] // When the query parameter value is not provided, the snippet generator ignores it
     [InlineData(null, "--id {id}")]
     [InlineData("? ", "--id {id}")]
     public void GeneratesSnippetsForCommandWithConflictingParameterName(string queryString, string commandSuffix)
@@ -176,7 +195,7 @@ public class GraphCliGeneratorTests
 
         // Then
         // TODO: What should happen to the query parameter?
-        Assert.Equal($"mgc tests item results get {commandSuffix}", result);
+        Assert.Equal($"mgc tests results get {commandSuffix}", result);
     }
 
     [Fact]
@@ -197,7 +216,7 @@ public class GraphCliGeneratorTests
 
         // Then
         // TODO: What should happen to the query parameter?
-        Assert.Equal("mgc tests item results get --id {id}", result);
+        Assert.Equal("mgc tests results get --id {id}", result);
     }
 
     [Fact]
@@ -216,13 +235,32 @@ public class GraphCliGeneratorTests
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
         // Then
-        // TODO: What should happen to the query parameter?
-        Assert.Equal("mgc tests item results get --id {id}", result);
+        Assert.Equal("mgc tests results get --id {id}", result);
+    }
+
+    [Fact]
+    public void GeneratesSnippetsForCommandWithConflictingPathAndHeaderParameterName()
+    {
+        // Given
+        // The cookie parameter will be skipped. not supported in the CLI
+        string schema = """{"openapi":"3.0.0","info":{"title":"Tests API","version":"1.0.11"},"servers":[{"url":"https://example.com/api/v1.0"}],"paths":{"/tests/{id}/results":{"get":{"operationId":"getTestResults","parameters":[{"name":"id","in":"path","required":true,"schema":{"type":"integer"}},{"name":"id","in":"header","schema":{"type":"integer"}}],"responses":{"200":{"description":"Successful operation"}}}}}}""";
+        var doc = new OpenApiStringReader().Read(schema, out _);
+        var rootNode = OpenApiUrlTreeNode.Create(doc, "default");
+        string url = $"{ServiceRootUrl}/tests/1/results";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
+        requestPayload.Headers.Add("id", "test-header");
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, rootNode);
+
+        // When
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+
+        // Then
+        Assert.Equal("mgc tests results get --id {id} --id-header test-header", result);
     }
 
     [Theory]
-    [InlineData("?$select=name", " --select {$select}")]
-    [InlineData("?$filter=test&$select=name", " --filter {$filter} --select {$select}")]
+    [InlineData("?$select=name", " --select name")]
+    [InlineData("?$filter=test&$select=name", " --filter test --select name")]
     public async Task GeneratesSnippetsForCommandWithODataParameters(string queryString, string commandOptions)
     {
         // Given
@@ -272,7 +310,7 @@ public class GraphCliGeneratorTests
 
         // Then
         // TODO: What should happen to the query parameter?
-        Assert.Equal("mgc tests get --id {id}", result);
+        Assert.Equal("mgc tests get --id 10", result);
     }
 
     [Theory]
@@ -364,7 +402,7 @@ public class GraphCliGeneratorTests
     public async Task ThrowsExceptionOnUnsupportedApiVersion()
     {
         // Given
-        string rootUrl = "https://example.com/v2";
+        string rootUrl = "https://example.com/v303";
         string url = $"{rootUrl}/users";
         using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
         var snippetModel = new SnippetModel(requestPayload, rootUrl, await GetV1TreeNode());
@@ -372,5 +410,21 @@ public class GraphCliGeneratorTests
         // When
         // Then
         Assert.Throws<ArgumentException>(() => _generator.GenerateCodeSnippet(snippetModel));
+    }
+    
+    [Fact]
+    public async Task GeneratesEscapedSnippetsForMultilineCommand()
+    {
+        // Given
+        string url = $"{ServiceRootUrl}/users";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Post, url);
+        requestPayload.Content = new StringContent("{\n  \"name\": \"test\"\n}");
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+
+        // When
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+
+        // Then
+        Assert.Equal("mgc users create --body '{\\\n  \"name\": \"test\"\\\n}'", result);
     }
 }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
@@ -82,12 +82,6 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
         {
             var segment = node.Segment.Replace("$value", "content", StringComparison.Ordinal).TrimStart('$');
 
-            // Kiota removes redundant microsoft. prefix from actions
-            if (segment.StartsWith("microsoft.graph", StringComparison.Ordinal))
-            {
-                segment = segment.Replace("microsoft.", string.Empty, StringComparison.Ordinal);
-            }
-
             // Handle path operation conflicts
             // GET /users/{user-id}/directReports/graph.orgContact
             // GET /users/{user-id}/directReports/{directoryObject-id}/graph.orgContact

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
@@ -80,7 +80,7 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
         OpenApiUrlTreeNode prevNode = null;
         foreach (var node in snippetModel.PathNodes)
         {
-            var segment = node.Segment.Replace("$value", "content", StringComparison.Ordinal).TrimStart('$');
+            var segment = node.Segment.ReplaceValueIdentifier().TrimStart('$');
 
             // Handle path operation conflicts
             // GET /users/{user-id}/directReports/graph.orgContact

--- a/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
+++ b/CodeSnippetsReflection.OpenAPI/StringExtensions.cs
@@ -32,7 +32,7 @@ internal static class StringExtensions
     }
     internal static string RemoveFunctionBraces(this string pathSegment) => pathSegment.TrimEnd('(',')');
     internal static string ReplaceValueIdentifier(this string original) =>
-        original?.Replace("$value", "Content");
+        original?.Replace("$value", "Content", StringComparison.Ordinal);
    
     internal static string Append(this string original, string suffix) =>
         string.IsNullOrEmpty(original) ? original : original + suffix;


### PR DESCRIPTION
Renames indexer nav commands that have executors which conflict with non-indexer nav commands. (https://github.com/microsoftgraph/msgraph-cli/issues/285, https://github.com/microsoft/kiota/pull/2634)

Fixes redundant microsoft. prefix in generated commands.