### PR TITLE
Match path nodes with method on snippet generation

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
@@ -345,22 +345,6 @@ public class GraphCliGeneratorTests
     }
 
     [Fact]
-    public async Task ReturnsEmptyStringForUnsupportedHttpOperation()
-    {
-        // DELETE /users/{user-id}/createdObjects
-        // Given
-        string url = $"{ServiceRootUrl}/users/100/createdObjects";
-        using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, url);
-        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
-
-        // When
-        var result = _generator.GenerateCodeSnippet(snippetModel);
-
-        // Then
-        Assert.Equal(string.Empty, result);
-    }
-
-    [Fact]
     public async Task ThrowsExceptionOnUnsupportedApiVersion()
     {
         // Given

--- a/CodeSnippetsReflection.OpenAPI.Test/SnippetModelTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/SnippetModelTests.cs
@@ -108,5 +108,33 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 snippetModel.ResponseSchema.AllOf.Any() ||
                 snippetModel.ResponseSchema.OneOf.Any());
         }
+        
+        [Fact]
+        public async Task ThrowsExceptionForUnsupportedHttpOperation()
+        {
+            // DELETE /users/{user-id}/delta
+            // Given
+            string url = $"{ServiceRootUrl}/users/delta";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, url);//delta exists but has not DELETE
+
+            // When
+            // Then
+            var entryPointNotFoundException = await Assert.ThrowsAsync<EntryPointNotFoundException>(async () => new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode()));
+            Assert.Equal("HTTP Method 'DELETE' not found for path.",entryPointNotFoundException.Message);
+        }
+        
+        [Fact]
+        public async Task ThrowsExceptionForUnsupportedPathOperation()
+        {
+            // GET /users/{user-id}/deltaTest
+            // Given
+            string url = $"{ServiceRootUrl}/users/100/deltaTest";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, url);//path does not exists
+
+            // When
+            // Then
+            var entryPointNotFoundException = await Assert.ThrowsAsync<EntryPointNotFoundException>(async () => new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode()));
+            Assert.Equal("Path segment 'deltaTest' not found in path",entryPointNotFoundException.Message);
+        }
     }
 }


### PR DESCRIPTION
This PR updates the snippet generation logic to fail in the event at a path is found but the requested http method does not exist in the metadata to prevent the generation of methods that do not exist in snippets.

Changes have been benchmarked with the dev branch in the pipeline runs at the links below.
Dev - https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=115361&view=ms.vss-test-web.build-test-results-tab&runId=1135195&resultId=100674&paneView=debug
This PR - https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=115362&view=ms.vss-test-web.build-test-results-tab&runId=1135211&resultId=100115&paneView=debug

In summary, snippets generated will reduce by about 1% as summarized in the table below from the above runs,

| Title | Current rate| New rate | Change |
|--------|--------|--------|--------|
| V1 Go/C#| 92.59%| 91.63%| 0.91%(23 snippets)|
| Beta Go/C#| 91.15% | 89.43 | 1.71% (63 snippets)| 

**Note**
Pass rates in compilation stages will therefore go up due to the failed compilation snippets now not being generated. 