### PR TITLE
Lookup QueryParameters from schema

### DIFF
--- a/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.OData.Test/CSharpGeneratorShould.cs
@@ -225,7 +225,7 @@ namespace CodeSnippetsReflection.Test
             // Act by generating the code snippet
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
-            Assert.Contains(".Expand(\"singleValueExtendedProperties($filter=id%20eq%20'%7Bid_value%7D')\")", result);
+            Assert.Contains(".Expand(\"singleValueExtendedProperties($filter=id eq '{id_value}')\")", result);
             Assert.DoesNotContain(".Filter(", result);
         }
 
@@ -242,7 +242,7 @@ namespace CodeSnippetsReflection.Test
             // Act by generating the code snippet
             var result = new CSharpGenerator(_edmModel.Value).GenerateCodeSnippet(snippetModel, expressions);
 
-            Assert.Contains(".Expand(\"singleValueExtendedProperties($filter=id%20eq%20'%7Bid_value1%7D')\")", result);
+            Assert.Contains(".Expand(\"singleValueExtendedProperties($filter=id eq '{id_value1}')\")", result);
             Assert.Contains(".Filter(\"id eq '{id_value2}'\")", result);
         }
 

--- a/CodeSnippetsReflection.OpenAPI.Test/SnippetCodeGraphTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/SnippetCodeGraphTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -218,7 +218,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.True(result.HasParameters());
             var param = result.Parameters.First();
             Assert.Equal("filter",param.Name);
-            Assert.Equal("groupTypes/any",param.Value); // TODO check if result should be `groupTypes/any(c:c+eq+'Unified')`
+            Assert.Equal("groupTypes/any(c:c+eq+'Unified')",param.Value);
         }
 
         [Fact]
@@ -273,12 +273,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.True(result.HasParameters());
             Assert.Equal(2, result.Parameters.Count());
 
-            var expectedProperty1 = new CodeProperty { Name = "filter" , Value = "roleDefinitionId eq '62e90394-69f5-4237-9190-012177145e10'", PropertyType = PropertyType.String };
+            var expectedProperty1 = new CodeProperty { Name = "filter" , Value = "roleDefinitionId eq '62e90394-69f5-4237-9190-012177145e10'", PropertyType = PropertyType.String, Children = new List<CodeProperty>()};
             var actualParam1 = result.Parameters.First();
 
-            Assert.Equal(expectedProperty1, actualParam1);
+            Assert.Equal(expectedProperty1.Name, actualParam1.Name);
+            Assert.Equal(expectedProperty1.Value, actualParam1.Value);
+            Assert.Equal(expectedProperty1.PropertyType, actualParam1.PropertyType);
+            Assert.Equal(expectedProperty1.Children.Count, actualParam1.Children.Count);
 
-            var expectedProperty2 = new CodeProperty { Value = "principal", PropertyType = PropertyType.String };
+            var expectedProperty2 = new CodeProperty { Value = "principal", PropertyType = PropertyType.String};
             var actualParam2 = result.Parameters.Skip(1).First();
 
             Assert.Equal("expand", actualParam2.Name);

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
@@ -17,7 +17,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
     public record SnippetCodeGraph
     {
 
-        private static readonly Regex nestedStatementRegex = new(@"(\w+)(\([^)]+\))", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+        private static readonly Regex nestedStatementRegex = new(@"([/\w]+)(\([^)]+\))", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
         private static readonly Regex splitCommasExcludingBracketsRegex = new(@"([^,\(\)]+(\(.*?\))*)+", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
@@ -153,6 +153,13 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         private static List<CodeProperty> parseParameters(SnippetModel snippetModel)
         {
 
+            var queryParameters = snippetModel.EndPathNode
+                .PathItems
+                .SelectMany(static pathItem => pathItem.Value.Operations)
+                .Where(operation => operation.Key.ToString().Equals(snippetModel.Method.ToString(), StringComparison.OrdinalIgnoreCase)) // get the operations that match the method
+                .SelectMany(static operation => operation.Value.Parameters)
+                .Where(static parameter => parameter.In == ParameterLocation.Query); // find the parameters in the path
+            
             var ArrayParameters = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,"select", "expand", "orderby");
             var NumberParameters = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,"skip", "top");
 
@@ -164,20 +171,47 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 foreach (String key in queryCollection.AllKeys)
                 {
+                    //try to lookup the parameter from the schema
+                    var queryParam = queryParameters.FirstOrDefault(param =>
+                        NormalizeQueryParameterName(param.Name).Equals(NormalizeQueryParameterName(key),
+                            StringComparison.OrdinalIgnoreCase));
+
+                    //setup defaults
                     var name = NormalizeQueryParameterName(key).Trim();
                     var value = GetQueryParameterValue(queryCollection[key], replacements);
-                    if(ArrayParameters.Contains(name)){
-                        var children = splitCommasExcludingBracketsRegex.Split(value)
-                            .Where(x => !String.IsNullOrEmpty(x) && !x.StartsWith("(") && !x.Equals(","))
-                            .Select(x => new CodeProperty() { Name = null, Value = x, PropertyType = PropertyType.String }).ToList();
-
-                        parameters.Add(new() { Name = name.ToLower(), Value = null, PropertyType = PropertyType.Array , Children = children});
-                    }else if (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value.Equals("false", StringComparison.OrdinalIgnoreCase)){
-                        parameters.Add(new() { Name = name.ToLower(), Value = value, PropertyType = PropertyType.Boolean });
-                    }else if (NumberParameters.Contains(name)){
-                        parameters.Add(new() { Name = name.ToLower(), Value = value, PropertyType = PropertyType.Int32 });
-                    }else{
-                        parameters.Add(new() { Name = name, Value = value, PropertyType = PropertyType.String });
+                    var schema = "string";
+                    if (NumberParameters.Contains(name))
+                        schema = "integer";
+                    else if(ArrayParameters.Contains(name))
+                        schema = "array";
+                    
+                    // use values from the schema if match is found
+                    if (queryParam != null)
+                    {
+                        schema = queryParam.Schema.Type.ToLowerInvariant();
+                        name = NormalizeQueryParameterName(queryParam.Name).Trim();
+                    }
+                    
+                    switch (schema)
+                    {
+                        case "string":
+                            parameters.Add(evaluateStringProperty(name, value, queryParam?.Schema));
+                            break;
+                        case "integer":
+                            parameters.Add(new CodeProperty { Name = name, Value = int.TryParse(value, out _) ? value : "1", PropertyType = PropertyType.Int32, Children = new List<CodeProperty>() });
+                            break;
+                        case "double":
+                            parameters.Add(new CodeProperty { Name = name, Value = double.TryParse(value, out _) ? value : "1.0d", PropertyType = PropertyType.Double, Children = new List<CodeProperty>() });
+                            break;
+                        case "boolean":
+                            parameters.Add(new CodeProperty { Name = name, Value = bool.TryParse(value, out _) ? value : "false", PropertyType = PropertyType.Boolean, Children = new List<CodeProperty>() });
+                            break;
+                        case "array":
+                            var children = splitCommasExcludingBracketsRegex.Split(GetQueryParameterValue(queryCollection[key], replacements))
+                                .Where(x => !String.IsNullOrEmpty(x) && !x.StartsWith("(") && !x.Equals(","))
+                                .Select(x => new CodeProperty() { Name = null, Value = x, PropertyType = PropertyType.String }).ToList();
+                            parameters.Add(new CodeProperty { Name = name, Value = null, PropertyType = PropertyType.Array, Children = children });
+                            break;
                     }
                 }
             }

--- a/CodeSnippetsReflection/SnippetBaseModel.cs
+++ b/CodeSnippetsReflection/SnippetBaseModel.cs
@@ -33,7 +33,7 @@ namespace CodeSnippetsReflection
 
             this.Method = requestPayload.Method;
             this.Path = Uri.UnescapeDataString(requestPayload.RequestUri.AbsolutePath.Substring(5));
-            this.QueryString = requestPayload.RequestUri.Query;
+            this.QueryString = Uri.UnescapeDataString(requestPayload.RequestUri.Query);
             this.ApiVersion = serviceRootUrl.Substring(serviceRootUrl.Length - 4);
             this.SelectFieldList = new List<string>();
             this.FilterFieldList = new List<string>();

--- a/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
+++ b/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
@@ -76,7 +76,8 @@ namespace CodeSnippetsReflection.StringExtensions
        
         public static string EscapeQuotes(this string stringValue)
         {
-            return stringValue.Replace("\"", "\\\"");
+            return stringValue.Replace("\\\"", "\"")//try to unescape quotes in case the input string is already escaped to avoid double escaping.
+                              .Replace("\"", "\\\"");
         }
 
         public static string AddQuotes(this string stringValue)


### PR DESCRIPTION
This PR updates the `snippetCodeGraph` to lookup `queryParameters` from the reference schema/openapi file as opposed to using the naming from the input http request. 

This is will reduce errors in generation due to different casing and types as the generated builders will use the casing and types from the reference document. 

https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0&tabs=csharp

Also closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1567 where filter clauses would have the filter statement in the event the filter statement involved a referencing nested property using the `/` character

https://github.com/microsoftgraph/microsoft-graph-docs/issues/21388

Generation diff viewable at https://github.com/microsoftgraph/microsoft-graph-docs/compare/preview-snippet-generation/115791..preview-snippet-generation/115848?expand=1