### PR TITLE
Fixes GO inline array generation for uuid

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -85,6 +85,28 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.DoesNotContain("@odata.type", result);
         }
         [Fact]
+        public async Task GeneratesObjectsInArray() {
+            var sampleJson = @"
+            {
+            ""addLicenses"": [
+                {
+                ""disabledPlans"": [ ""11b0131d-43c8-4bbb-b2c8-e80f9a50834a"" ],
+                ""skuId"": ""45715bb8-13f9-4bf6-927f-ef96c102d394""
+                }
+            ],
+            ""removeLicenses"": [ ""bea13e0c-3828-4daa-a392-28af7ff61a0f"" ]
+            }
+            ";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/assignLicense"){
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("requestBody := graphusers.NewItemAssignLicensePostRequestBody()", result);
+            Assert.Contains("disabledPlans := []uuid.UUID {", result);
+            Assert.Contains("removeLicenses := []uuid.UUID {\r\n\tuuid.MustParse(\"bea13e0c-3828-4daa-a392-28af7ff61a0f\"),\r\n}", result);
+        }
+        [Fact]
         public async Task GeneratesTheSnippetHeader() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -104,7 +104,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestBody := graphusers.NewItemAssignLicensePostRequestBody()", result);
             Assert.Contains("disabledPlans := []uuid.UUID {", result);
-            Assert.Contains("removeLicenses := []uuid.UUID {\r\n\tuuid.MustParse(\"bea13e0c-3828-4daa-a392-28af7ff61a0f\"),\r\n}", result);
+            Assert.Contains("removeLicenses := []uuid.UUID {", result);
+            Assert.Contains("uuid.MustParse(\"bea13e0c-3828-4daa-a392-28af7ff61a0f\"),", result);
         }
         [Fact]
         public async Task GeneratesTheSnippetHeader() {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -7,7 +7,6 @@ using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Services;
 using System.Text.RegularExpressions;
-using System.Xml;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -356,7 +355,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             else
             {
                 // objects in namespace user have a prefix of item
-                string bodyName = codeGraph.Body.NamespaceName.StartsWith("Me") ? $"Item{codeGraph.Body.Name}" : codeGraph.Body.Name;
+                string bodyName = codeGraph.Body.NamespaceName.StartsWith("Me", StringComparison.OrdinalIgnoreCase) ? $"Item{codeGraph.Body.Name}" : codeGraph.Body.Name;
                 builder.AppendLine($"{indentManager.GetIndent()}{requestBodyVarName} := graph{ProcessFinalNameSpaceName(codeGraph.Body.NamespaceName).Replace(".","").ToLowerInvariant()}.New{bodyName.ToFirstCharacterUpperCase()}()");
                 WriteCodePropertyObject(requestBodyVarName, builder, codeGraph.Body, indentManager);
             }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -7,6 +7,7 @@ using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Services;
 using System.Text.RegularExpressions;
+using System.Xml;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -32,6 +33,16 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         {
             return ImmutableHashSet.Create("string", "int", "float");
         }
+
+
+        public static Dictionary<string, string> formatPropertyName = new(StringComparer.OrdinalIgnoreCase)
+        {
+            {"guid", "uuid.UUID"},
+            {"uuid", "uuid.UUID"},
+            {"date-time", "time.Time"},
+            {"date", "serialization.DateOnly"},
+            {"duration", "serialization.ISODuration"}
+        };
 
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
@@ -345,7 +356,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             }
             else
             {
-                builder.AppendLine($"{indentManager.GetIndent()}{requestBodyVarName} := graph{ProcessFinalNameSpaceName(codeGraph.Body.NamespaceName).Replace(".","").ToLowerInvariant()}.New{codeGraph.Body.Name.ToFirstCharacterUpperCase()}()");
+                // objects in namespace user have a prefix of item
+                string bodyName = codeGraph.Body.NamespaceName.StartsWith("Me") ? $"Item{codeGraph.Body.Name}" : codeGraph.Body.Name;
+                builder.AppendLine($"{indentManager.GetIndent()}{requestBodyVarName} := graph{ProcessFinalNameSpaceName(codeGraph.Body.NamespaceName).Replace(".","").ToLowerInvariant()}.New{bodyName.ToFirstCharacterUpperCase()}()");
                 WriteCodePropertyObject(requestBodyVarName, builder, codeGraph.Body, indentManager);
             }
         }
@@ -388,9 +401,21 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 builder.AppendLine(objectBuilder.ToString());
             }
 
-            var typeName = NativeTypes.Contains(codeProperty.TypeDefinition?.ToLowerInvariant()?.Trim()) ? codeProperty.TypeDefinition?.ToLowerInvariant() : $"graph{ProcessFinalNameSpaceName(parentProperty.NamespaceName).Replace(".","").ToLowerInvariant()}.{codeProperty.TypeDefinition}able";
+            var typeDefinition = codeProperty.TypeDefinition?.ToLowerInvariant()?.Trim();
+
+            String typeName;
+            if (NativeTypes.Contains(typeDefinition)) {
+                typeName = typeDefinition;
+            } else if (formatPropertyName.TryGetValue(typeDefinition, out var type))
+            {
+                typeName = type;
+            } else
+            {
+                typeName = $"graph{ProcessFinalNameSpaceName(codeProperty.NamespaceName).Replace(".", "").ToLowerInvariant()}.{codeProperty.TypeDefinition}able";
+            }
+
             builder.AppendLine($"{indentManager.GetIndent()}{propertyName} := []{typeName} {{");
-            builder.AppendLine(contentBuilder.ToString());
+            builder.AppendLine(contentBuilder.ToString().TrimEnd());
             builder.AppendLine($"{indentManager.GetIndent()}}}");
             if (parentProperty.PropertyType == PropertyType.Object)
                 builder.AppendLine($"{indentManager.GetIndent()}{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}({objectName})");
@@ -433,8 +458,16 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     WriteArrayProperty(propertyAssignment, objectName, builder, codeProperty, child, indentManager);
                     break;
                 case PropertyType.Guid:
-                    builder.AppendLine($"{propertyName} := uuid.MustParse(\"{child.Value}\")");
-                    builder.AppendLine($"{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}(&{propertyName}) ");
+
+                    if (!isArray)
+                    {
+                        builder.AppendLine($"{propertyName} := uuid.MustParse(\"{child.Value}\")");
+                        builder.AppendLine($"{propertyAssignment}.Set{propertyName.ToFirstCharacterUpperCase()}(&{propertyName}) ");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"{indentManager.GetIndent()}uuid.MustParse(\"{child.Value}\"),");
+                    }
                     break;
                 case PropertyType.String:
                     WriteStringProperty(propertyAssignment, codeProperty, builder, indentManager, child);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -34,8 +34,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             return ImmutableHashSet.Create("string", "int", "float");
         }
 
-
-        public static Dictionary<string, string> formatPropertyName = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, string> formatPropertyName = new(StringComparer.OrdinalIgnoreCase)
         {
             {"guid", "uuid.UUID"},
             {"uuid", "uuid.UUID"},

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -460,13 +460,18 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         private static CodeProperty parseJsonArrayValue(string propertyName, JsonElement value, OpenApiSchema schema)
         {
             var alternativeType = schema?.Items?.AnyOf?.FirstOrDefault()?.AllOf?.LastOrDefault()?.Title;
-            var children = value.EnumerateArray().Select(item => parseProperty(schema.GetSchemaTitle() ?? alternativeType?.ToFirstCharacterUpperCase(), item, schema?.Items)).ToList();
-
             // uuid schemas 
             var genericType = schema.GetSchemaTitle().ToFirstCharacterUpperCase() ??
                               (value.EnumerateArray().Any() ?
                                   evaluatePropertyTypeDefinition(value.EnumerateArray().First().ValueKind.ToString(), schema?.Items) :
                                   schema?.Items?.Type);
+            var children = value.EnumerateArray().Select(item =>
+            {
+                var prop = parseProperty(schema.GetSchemaTitle() ?? alternativeType?.ToFirstCharacterUpperCase(), item,
+                    schema?.Items);
+                prop.TypeDefinition = prop.TypeDefinition ?? genericType;
+                return prop;
+            }).ToList();
             return new CodeProperty { Name = propertyName, Value = null, PropertyType = PropertyType.Array, Children = children, TypeDefinition = genericType ?? alternativeType };
         }
 

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -23,7 +23,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 
         private static readonly CodeProperty EMPTY_PROPERTY = new() { Name = null, Value = null, Children = null, PropertyType = PropertyType.Default };
 
-        public static Dictionary<string, PropertyType> _formatPropertyTypes = new (StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, PropertyType> _formatPropertyTypes = new (StringComparer.OrdinalIgnoreCase)
         {
             {"int32", PropertyType.Int32},
             {"int64", PropertyType.Int64},


### PR DESCRIPTION
Resolves https://github.com/microsoftgraph/microsoft-graph-docs/issues/21282
Resolves https://github.com/microsoftgraph/microsoft-graph-docs/issues/21304

Fixes 

- [x] Inline UUID script for arrays
- [x] TypeInformation for slices / arrays when generation SnippetCodeGraph
- [x] Adding the `Item` naming scheme in go Me/Users Package 

Current example https://learn.microsoft.com/en-us/graph/api/user-assignlicense?view=graph-rest-1.0&tabs=go

```go

import (
	  "context"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphmodels "github.com/microsoftgraph/msgraph-sdk-go/Me/AssignLicense"
	  //other-imports
)

graphClient := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)


requestBody := graphmodels.NewAssignLicensePostRequestBody()


assignedLicense := graphmodels.NewAssignedLicense()
disabledPlans := []string {
 := uuid.MustParse("11b0131d-43c8-4bbb-b2c8-e80f9a50834a")
assignedLicense.Set(&) 

}
assignedLicense.SetDisabledPlans(disabledPlans)
skuId := uuid.MustParse("45715bb8-13f9-4bf6-927f-ef96c102d394")
assignedLicense.SetSkuId(&skuId) 

addLicenses := []graphmodels.AssignedLicenseable {
	assignedLicense,

}
requestBody.SetAddLicenses(addLicenses)
removeLicenses := []string {
 := uuid.MustParse("bea13e0c-3828-4daa-a392-28af7ff61a0f")
requestBody.Set(&) 

}
requestBody.SetRemoveLicenses(removeLicenses)

result, err := graphClient.Me().AssignLicense().Post(context.Background(), requestBody, nil)
```

Fixed result


```go
import (
	  "context"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphusers "github.com/microsoftgraph/msgraph-sdk-go/users"
	  graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
	  //other-imports
)

graphClient, err := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)


requestBody := graphusers.NewItemAssignLicensePostRequestBody()


assignedLicense := graphmodels.NewAssignedLicense()
disabledPlans := []uuid.UUID {
	uuid.MustParse("11b0131d-43c8-4bbb-b2c8-e80f9a50834a"),
}
assignedLicense.SetDisabledPlans(disabledPlans)
skuId := uuid.MustParse("45715bb8-13f9-4bf6-927f-ef96c102d394")
assignedLicense.SetSkuId(&skuId) 

addLicenses := []graphmodels.AssignedLicenseable {
	assignedLicense,
}
requestBody.SetAddLicenses(addLicenses)
removeLicenses := []uuid.UUID {
	uuid.MustParse("bea13e0c-3828-4daa-a392-28af7ff61a0f"),
}
requestBody.SetRemoveLicenses(removeLicenses)

result, err := graphClient.Me().AssignLicense().Post(context.Background(), requestBody, nil)

```