### PR TITLE
Return empty results array if no permissions found

### DIFF
--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -73,7 +73,7 @@ namespace GraphWebApi.Controllers
                                             SeverityLevel.Information,
                                             _permissionsTraceProperties);
 
-            return result == null || result.Results == null || !result.Results.Any() ? NotFound() : Ok(result.Results);
+            return result?.Results == null || !result.Results.Any() ? NotFound() : Ok(result.Results);
         }
 
         [HttpPost]

--- a/GraphWebApi/Controllers/PermissionsController.cs
+++ b/GraphWebApi/Controllers/PermissionsController.cs
@@ -73,7 +73,7 @@ namespace GraphWebApi.Controllers
                                             SeverityLevel.Information,
                                             _permissionsTraceProperties);
 
-            return result == null || result.Results == null ? NotFound() : Ok(result.Results);
+            return result == null || result.Results == null || !result.Results.Any() ? NotFound() : Ok(result.Results);
         }
 
         [HttpPost]

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -139,7 +139,7 @@ namespace PermissionsService.Test
             }
             else
             {
-                Assert.Null(result.Results);
+                Assert.Empty(result.Results);
             }
         }
 
@@ -200,7 +200,7 @@ namespace PermissionsService.Test
                 new List<RequestInfo> { new RequestInfo { RequestUrl = "/foo/bar/{id}", HttpMethod = "GET" } }); // non-existent request url
 
             // Assert
-            Assert.Null(result.Results);
+            Assert.Empty(result.Results);
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace PermissionsService.Test
                         HttpMethod = "Foobar" } }); // non-existent http verb
 
             // Assert
-            Assert.Null(result.Results);
+            Assert.Empty(result.Results);
         }
 
         [Theory]
@@ -276,7 +276,7 @@ namespace PermissionsService.Test
 
             // Assert
             Assert.NotNull(result);
-            Assert.Null(result.Results);
+            Assert.Empty(result.Results);
             Assert.NotNull(result.Errors);
             Assert.Single(result.Errors);
             Assert.Equal("No permissions found.", result.Errors.First().Message);
@@ -373,7 +373,7 @@ namespace PermissionsService.Test
                         new RequestInfo { RequestUrl = null, HttpMethod = "GET" } }
                     );
             // Assert
-            Assert.Null(result.Results);
+            Assert.Empty(result.Results);
             Assert.NotEmpty(result.Errors);
             Assert.Equal(2, result.Errors.Count);
             Assert.Collection(result.Errors,
@@ -398,7 +398,7 @@ namespace PermissionsService.Test
                     requests: new List<RequestInfo>() {
                         new RequestInfo { RequestUrl = "/foo/bar", HttpMethod = "GET" } });
             // Assert
-            Assert.Null(result.Results);
+            Assert.Empty(result.Results);
             Assert.NotEmpty(result.Errors);
             Assert.Single(result.Errors);
             Assert.Collection(result.Errors,

--- a/PermissionsService/Models/PermissionResult.cs
+++ b/PermissionsService/Models/PermissionResult.cs
@@ -9,11 +9,10 @@ namespace PermissionsService.Models
 {
     public class PermissionResult
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<ScopeInformation> Results
         {
             get; set;
-        }
+        } = new();
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<PermissionError> Errors

--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -405,7 +405,7 @@ namespace PermissionsService
 
             return new PermissionResult()
             {
-                Results = scopesInfo.Any() ? scopesInfo : null,
+                Results = scopesInfo,
                 Errors = errors.Any() ? errors : null
             };
         }


### PR DESCRIPTION
## Overview
Fixes #1601 
Returns empty results array if no permissions are found
```
{
    "results": [],
    "errors": [
        {
            "requestUrl": "/admin",
            "message": "Permissions information for 'GET /admin' was not found."
        }
     ]
}
```