### PR TITLE
Lookup schema with discriminator in OpenAPI snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -727,8 +727,8 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("var requestBody = new Microsoft.Graph.Me.SendMail.SendMailPostRequestBody", result);
-            Assert.Contains("Attachments = new List<Attachment>", result);
-            Assert.Contains("new FileAttachment", result);
+            Assert.Contains("Attachments = new List<Attachment>", result);// Collection defines Base type
+            Assert.Contains("new FileAttachment", result);// Individual items are derived types
             Assert.Contains("ContentBytes = Convert.FromBase64String(\"SGVsbG8gV29ybGQh\"),", result);
         }
         

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -664,6 +664,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("await graphClient.Communications.CallRecords.MicrosoftGraphCallRecordsGetPstnCallsWithFromDateTimeWithToDateTime(DateTimeOffset.Parse(\"{fromDateTime}\"),DateTimeOffset.Parse(\"{toDateTime}\")).GetAsync();", result);
         }
         [Fact]
+        public async Task CorrectlyHandlesEnumInUrl()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/identityGovernance/appConsent/appConsentRequests/filterByCurrentUser(on='reviewer')?$filter=userConsentRequests/any(u:u/status eq 'InProgress')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.IdentityGovernance.AppConsent.AppConsentRequests.FilterByCurrentUserWithOn(\"reviewer\").GetAsync", result);
+        }
+        [Fact]
         public async Task GeneratesObjectsInArray() {
             var sampleJson = @"
             {

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -654,6 +654,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
 
             Assert.Contains("await graphClient.Reports.GetYammerGroupsActivityDetailWithDate(new Date(DateTime.Parse(\"{date}\"))).GetAsync();", result);
         }
+        [Fact]
+        public async Task CorrectlyHandlesDateInUrl2()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.Communications.CallRecords.MicrosoftGraphCallRecordsGetPstnCallsWithFromDateTimeWithToDateTime(DateTimeOffset.Parse(\"{fromDateTime}\"),DateTimeOffset.Parse(\"{toDateTime}\")).GetAsync();", result);
+        }
         
         [Fact]
         public async Task CorrectlyHandlesTypeFromInUrl()

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -244,6 +244,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("OdataType = \"#microsoft.graph.socialIdentityProvider\",", result);
+            Assert.Contains("new SocialIdentityProvider", result);// ensure the derived type is used
         }
         [Fact]
         public async Task HandlesOdataReferenceSegmentsInUrl() {

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -695,6 +695,42 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("RemoveLicenses = new List<Guid?>", result);
             Assert.Contains("Guid.Parse(\"bea13e0c-3828-4daa-a392-28af7ff61a0f\"),", result);
         }
+        [Fact]
+        public async Task GeneratesCorrectCollectionTypeAndDerivedInstances() {
+            var sampleJson = @"{
+              ""message"": {
+                ""subject"": ""Meet for lunch?"",
+                ""body"": {
+                  ""contentType"": ""Text"",
+                  ""content"": ""The new cafeteria is open.""
+                },
+                ""toRecipients"": [
+                  {
+                    ""emailAddress"": {
+                      ""address"": ""meganb@contoso.onmicrosoft.com""
+                    }
+                  }
+                ],
+                ""attachments"": [
+                  {
+                    ""@odata.type"": ""#microsoft.graph.fileAttachment"",
+                    ""name"": ""attachment.txt"",
+                    ""contentType"": ""text/plain"",
+                    ""contentBytes"": ""SGVsbG8gV29ybGQh""
+                  }
+                ]
+              }
+            }";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/sendMail"){
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Me.SendMail.SendMailPostRequestBody", result);
+            Assert.Contains("Attachments = new List<Attachment>", result);
+            Assert.Contains("new FileAttachment", result);
+            Assert.Contains("ContentBytes = Convert.FromBase64String(\"SGVsbG8gV29ybGQh\"),", result);
+        }
         
         [Fact]
         public async Task CorrectlyHandlesTypeFromInUrl()

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -2,44 +2,39 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
-using Microsoft.OpenApi.Services;
 using Xunit;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {
-    public class CSharpGeneratorTests {
-        private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
-        private static OpenApiUrlTreeNode _v1TreeNode;
-        private static async Task<OpenApiUrlTreeNode> GetV1TreeNode()
-        {
-            return _v1TreeNode ??= await SnippetModelTests.GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml");
-        }
+    public class CSharpGeneratorTests : OpenApiSnippetGeneratorTestBase
+    {
         private readonly CSharpGenerator _generator = new();
+        
         [Fact]
         public async Task GeneratesTheCorrectFluentApiPath() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(".Me.Messages", result);
         }
         [Fact]
         public async Task GeneratesTheCorrectFluentApiPathForIndexedCollections() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(".Me.Messages[\"{message-id}\"]", result);
         }
         [Fact]
         public async Task GeneratesTheSnippetHeader() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("var graphClient = new GraphServiceClient(requestAdapter)", result);
         }
         [Fact]
         public async Task GeneratesTheGetMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("GetAsync", result);
             Assert.Contains("await", result);
@@ -47,28 +42,28 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesThePostMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("PostAsync", result);
         }
         [Fact]
         public async Task GeneratesThePatchMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("PatchAsync", result);
         }
         [Fact]
         public async Task GeneratesThePutMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/applications/{{application-id}}/logo");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("PutAsync", result);
         }
         [Fact]
         public async Task GeneratesTheDeleteMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("DeleteAsync", result);
             Assert.DoesNotContain("var result =", result);
@@ -85,7 +80,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("new User", result);
             Assert.Contains("AccountEnabled = true,", result);
@@ -100,7 +95,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("10L", result);
             Assert.Contains("SendActivityNotificationPostRequestBody", result);
@@ -114,7 +109,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("10d", result);
         }
@@ -124,7 +119,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 Content = new ByteArrayContent(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 })
             };
             requestPayload.Content.Headers.ContentType = new ("application/octet-stream");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("new MemoryStream", result);
         }
@@ -134,7 +129,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/chats/{{chat-id}}/messages/{{chatMessage-id}}/hostedContents") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Convert.FromBase64String", result);
         }
@@ -144,7 +139,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/messages") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("DateTimeOffset.Parse", result);
         }
@@ -154,7 +149,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/groups/{{group-id}}") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("new List", result);
             Assert.Contains("AdditionalData", result);
@@ -163,7 +158,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesSelectQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me?$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("displayName", result);
             Assert.Contains("(requestConfiguration) =>", result);
@@ -172,7 +167,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesCountBooleanQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("displayName", result);
             Assert.DoesNotContain("\"true\"", result);
@@ -181,7 +176,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesSkipQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$skip=10");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.DoesNotContain("\"10\"", result);
             Assert.Contains("10", result);
@@ -189,7 +184,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesSelectExpandQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups?$expand=members($select=id,displayName)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Expand", result);
             Assert.Contains("members($select=id,displayName)", result);
@@ -199,7 +194,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesRequestHeaders() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestConfiguration.Headers.Add(\"ConsistencyLevel\", \"eventual\");", result);
             Assert.Contains("(requestConfiguration) =>", result);
@@ -207,7 +202,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesFilterParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$filter=Department eq 'Finance'&$orderBy=displayName&$select=id,displayName,department");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestConfiguration.QueryParameters.Count", result);
             Assert.Contains("requestConfiguration.QueryParameters.Filter", result);
@@ -217,7 +212,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesFilterParametersWithSpecialCharacters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$filter=imAddresses/any(i:i eq 'admin@contoso.com')");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestConfiguration.QueryParameters.Filter", result);
             Assert.Contains("imAddresses/any(i:i eq 'admin@contoso.com')", result);
@@ -227,7 +222,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" AND \"displayName:al\"");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestConfiguration.QueryParameters.Search", result);
             Assert.Contains("requestConfiguration.QueryParameters.Search = \"\\\"displayName:di\\\" AND \\\"displayName:al\\\"\";", result);
@@ -246,7 +241,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/identity/identityProviders"){
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("OdataType = \"#microsoft.graph.socialIdentityProvider\",", result);
         }
@@ -260,7 +255,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/groups/id/acceptedSenders/$ref"){
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(".AcceptedSenders.Ref.PostAsync(requestBody);", result);
         }
@@ -306,7 +301,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(eventData, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("ContentType = BodyType.Html", result);
@@ -359,7 +354,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("MeetingDuration = TimeSpan.Parse(\"PT1H\")", result);
             Assert.Contains("IsRequired = false,", result);
@@ -400,7 +395,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Users[\"{user-id}\"].SendMail.PostAsync(requestBody);", result);
@@ -422,7 +417,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("new List<string>", result);
@@ -440,7 +435,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("new Microsoft.Graph.Models.ExternalConnectors.Identity", result);
@@ -451,7 +446,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task ReplacesReservedTypeNames()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/directory/administrativeUnits/8a07f5a8-edc9-4847-bbf2-dde106594bf4/scopedRoleMembers");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             // Assert `Directory` is replaced with `DirectoryObject`
@@ -485,7 +480,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("Type = RecurrencePatternType.Weekly,", result);
@@ -504,7 +499,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("Status = RecordingStatus.NotRecording | RecordingStatus.Recording | RecordingStatus.Failed", result);
@@ -514,7 +509,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyOptionalRequestBodyParameter()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/teams/{{id}}/archive");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Teams[\"{team-id}\"].Archive.PostAsync(null);", result);
@@ -537,7 +532,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("StartDate = new Date(DateTime.Parse(\"2017-09-04\")),", result);
@@ -560,7 +555,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("var requestBody = new Microsoft.Graph.Applications.Item.AddKey.AddKeyPostRequestBody", result);
@@ -577,7 +572,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("Guid.Parse(\"cde330e5-2150-4c11-9c5b-14bfdc948c79\")", result);
@@ -599,7 +594,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("ContentType = BodyType.Text,", result);
         }
@@ -615,7 +610,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("PermissionGrantPoliciesAssigned = new List<String>", result);
         }
@@ -623,7 +618,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyHandlesOdataFunction()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/delta?$select=displayName,jobTitle,mobilePhone");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Users.Delta.GetAsync", result);
@@ -634,7 +629,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyHandlesDateTimeOffsetInUrl()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/reports/getUserArchivedPrintJobs(userId='{{id}}',startDateTime=<timestamp>,endDateTime=<timestamp>)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Reports.GetUserArchivedPrintJobsWithUserIdWithStartDateTimeWithEndDateTime(DateTimeOffset.Parse(\"{endDateTime}\"),DateTimeOffset.Parse(\"{startDateTime}\"),\"{userId}\").GetAsync()", result);
@@ -644,7 +639,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyHandlesNumberInUrl()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/drive/items/{{id}}/workbook/worksheets/{{id|name}}/cell(row=<row>,column=<column>)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"].CellWithRowWithColumn(1,1).GetAsync();",result);
@@ -653,7 +648,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyHandlesDateInUrl()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/reports/getYammerGroupsActivityDetail(date='2018-03-05')");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("await graphClient.Reports.GetYammerGroupsActivityDetailWithDate(new Date(DateTime.Parse(\"{date}\"))).GetAsync();", result);
@@ -663,7 +658,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task CorrectlyHandlesTypeFromInUrl()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/mailFolders/?includehiddenfolders=true");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("requestConfiguration.QueryParameters.IncludeHiddenFolders = \"true\";", result);
@@ -673,7 +668,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task MatchesPathWithPathParameter()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/drive/items/{{id}}/workbook/worksheets/{{id|name}}/range(address='A1:B2')");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("var result = await graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"].RangeWithAddress(\"{address}\").GetAsync()", result);
@@ -693,7 +688,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetWithRemappedDriveCall(string inputPath, string expected, string method = "") 
         {
             using var requestPayload = new HttpRequestMessage(string.IsNullOrEmpty(method) ? HttpMethod.Get : new HttpMethod(method), $"{ServiceRootUrl}{inputPath}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(expected, result);
         }

--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -663,6 +663,29 @@ namespace CodeSnippetsReflection.OpenAPI.Test
 
             Assert.Contains("await graphClient.Communications.CallRecords.MicrosoftGraphCallRecordsGetPstnCallsWithFromDateTimeWithToDateTime(DateTimeOffset.Parse(\"{fromDateTime}\"),DateTimeOffset.Parse(\"{toDateTime}\")).GetAsync();", result);
         }
+        [Fact]
+        public async Task GeneratesObjectsInArray() {
+            var sampleJson = @"
+            {
+            ""addLicenses"": [
+                {
+                ""disabledPlans"": [ ""11b0131d-43c8-4bbb-b2c8-e80f9a50834a"" ],
+                ""skuId"": ""45715bb8-13f9-4bf6-927f-ef96c102d394""
+                }
+            ],
+            ""removeLicenses"": [ ""bea13e0c-3828-4daa-a392-28af7ff61a0f"" ]
+            }
+            ";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/assignLicense"){
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("var requestBody = new Microsoft.Graph.Me.AssignLicense.AssignLicensePostRequestBody", result);
+            Assert.Contains("DisabledPlans = new List<Guid?>", result);
+            Assert.Contains("RemoveLicenses = new List<Guid?>", result);
+            Assert.Contains("Guid.Parse(\"bea13e0c-3828-4daa-a392-28af7ff61a0f\"),", result);
+        }
         
         [Fact]
         public async Task CorrectlyHandlesTypeFromInUrl()

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -4,33 +4,18 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
-using Microsoft.OpenApi.Services;
 using Xunit;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {
-    public class GoGeneratorTests {
-        private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
-        private const string ServiceRootBetaUrl = "https://graph.microsoft.com/beta";
-        private static OpenApiUrlTreeNode _v1TreeNode;
-        private static OpenApiUrlTreeNode _betaTreeNode;
-        private static async Task<OpenApiUrlTreeNode> GetV1TreeNode() {
-            if(_v1TreeNode == null) {
-                _v1TreeNode = await SnippetModelTests.GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml");
-            }
-            return _v1TreeNode;
-        }
-        private static async Task<OpenApiUrlTreeNode> GetBetaTreeNode() {
-            if(_betaTreeNode == null) {
-                _betaTreeNode = await SnippetModelTests.GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml");
-            }
-            return _betaTreeNode;
-        }
+    public class GoGeneratorTests : OpenApiSnippetGeneratorTestBase
+    {
         private readonly GoGenerator _generator = new();
+        
         [Fact]
         public async Task GeneratesTheCorrectFluentAPIPath() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(".Me().Messages()", result);
         }
@@ -38,7 +23,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesMeImportFromUserPackage()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages?$select=sender,subject");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("import", result);
             Assert.Contains("graphusers \"github.com/microsoftgraph/msgraph-sdk-go/users\"", result);
@@ -48,7 +33,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesTheCorrectFluentAPIPathForIndexedCollections() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(".Me().Messages().ByMessageId(\"message-id\")", result);
         }
@@ -62,7 +47,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/drives/{{drive-id}}/items/{{item-id}}/checkin"){
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Drives().ByDriveId(\"drive-id\").Items().ByItemId(\"driveItem-id\").Checkin().", result);
         }
@@ -80,7 +65,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/identity/identityProviders"){
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.DoesNotContain("@odata.type", result);
         }
@@ -100,7 +85,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/assignLicense"){
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestBody := graphusers.NewItemAssignLicensePostRequestBody()", result);
             Assert.Contains("disabledPlans := []uuid.UUID {", result);
@@ -110,7 +95,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesTheSnippetHeader() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphClient, err := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)", result);
         }
@@ -134,7 +119,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 {
                     Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
                 };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphapplications \"github.com/microsoftgraph/msgraph-sdk-go/applications\"", result);
         }
@@ -158,7 +143,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 {
                     Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
                 };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphmodelstermstore \"github.com/microsoftgraph/msgraph-sdk-go/models/termstore\"", result);
             Assert.Contains("requestBody := graphmodelstermstore.NewTerm()", result);
@@ -166,7 +151,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesTheGetMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
@@ -178,7 +163,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/messages") {
                 Content = new StringContent(messageObjectJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Post", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
@@ -190,7 +175,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/me/messages/{{message-id}}") {
                 Content = new StringContent(messageObjectJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Patch", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
@@ -205,7 +190,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     }
                 }
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Put", result);
             Assert.DoesNotContain("WithRequestConfigurationAndResponseHandler", result);
@@ -214,7 +199,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesTheDeleteMethodCall() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Delete", result);
             Assert.DoesNotContain("result, err :=", result);
@@ -233,7 +218,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphmodels.NewUser", result);
             Assert.Contains("SetAccountEnabled(&accountEnabled)", result);
@@ -248,7 +233,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("int64(10)", result);
             Assert.DoesNotContain("microsoft.graph", result);
@@ -261,7 +246,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("float64(10)", result);
         }
@@ -271,7 +256,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 Content = new ByteArrayContent(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 })
             };
             requestPayload.Content.Headers.ContentType = new ("application/octet-stream");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("make([]byte, 0)", result);
         }
@@ -281,7 +266,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/chats/{{chat-id}}/messages/{{chatMessage-id}}/hostedContents") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("[]byte(", result);
         }
@@ -291,7 +276,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/messages") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains(", err := time.Parse(time.RFC3339,", result);
         }
@@ -301,7 +286,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/groups/{{group-id}}") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("map[string]interface{}{", result);
             Assert.Contains("[]string {", result);
@@ -312,7 +297,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSelectQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me?$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Select: [] string {\"displayName\"", result);
             Assert.Contains("QueryParameters: ", result);
@@ -327,7 +312,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesNestedParameterNames()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/{{id}}?$select=displayName,givenName,postalCode,identities");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Select: [] string {\"displayName\",\"givenName\",\"postalCode\",\"identities\"}", result);
             Assert.Contains("QueryParameters: ", result);
@@ -349,7 +334,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(jsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestBody := graphmodels.NewReferenceCreate()", result);
             Assert.Contains("requestBody.SetOdataId(&odataId)", result);
@@ -359,7 +344,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesCountBooleanQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("displayName", result);
             Assert.DoesNotContain("\"true\"", result);
@@ -370,7 +355,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesSkipQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$skip=10");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.DoesNotContain("\"10\"", result);
             Assert.Contains("10", result);
@@ -380,7 +365,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task GeneratesSelectExpandQueryParameters() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups?$expand=members($select=id,displayName),teams($select=id,displayName)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Expand", result);
             Assert.Contains("members($select=id,displayName)", result);
@@ -392,7 +377,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesRequestHeaders() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("import", result);
             Assert.Contains("abstractions \"github.com/microsoft/kiota-abstractions-go\"", result);
@@ -409,7 +394,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootBetaUrl}/me/events('AAMkAGI1AAAt9AHjAAA=')/attachments") {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphClient.Me().Events().ByEventId(\"event-id\").Attachments().Post(context.Background(), requestBody, nil)", result);
         }
@@ -419,7 +404,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/teams/57fb72d0-d811-46f4-8947-305e6072eaa5/channels/19:4b6bed8d24574f6a9e436813cb2617d8@thread.tacv2/messages") {
                 Content = new StringContent(messageObject, Encoding.UTF8)
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphClient.Teams().ByTeamId(\"team-id\").Channels().ByChannelId(\"channel-id\").Messages().Post(context.Background(), requestBody, nil)", result);
         }
@@ -429,7 +414,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootBetaUrl}/identity/conditionalAccess/policies") {
                 Content = new StringContent(messageObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("SetIncludeUserActions", result);
         }
@@ -438,7 +423,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get,
                 $"{ServiceRootBetaUrl}/identityGovernance/accessReviews/definitions?$top=100&$skip=0");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestTop := int32(100)", result);
             Assert.Contains("requestSkip := int32(0)", result);
@@ -450,7 +435,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task DoesntReplaceODataFunctionCalls() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/devices/{{objectId}}/usageRights?$filter=state in ('active', 'suspended') and serviceIdentifier in ('ABCD')");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("state%20in%20('active',%20'suspended')%20and%20serviceIdentifier%20in%20('ABCD')", result);
             Assert.Contains("WithRequestConfigurationAndResponseHandler", result);
@@ -460,14 +445,14 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         [Fact]
         public async Task FindsPathItemsWithDifferentCasing() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphClient.Directory().DeletedItems().GraphGroup().Get(context.Background(), nil)", result);
         }
         [Fact]
         public async Task DoesntFailOnTerminalSlash() {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/me/messages/AAMkADYAAAImV_jAAA=/?$expand=microsoft.graph.eventMessage/event");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("graphClient.Me().Messages().ByMessageId(\"message-id\").Get(context.Background(), configuration)", result);
         }
@@ -477,7 +462,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/applications/{{id}}/addPassword") {
                 Content = new StringContent(payloadBody, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaTreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("NewAddPasswordPostRequestBody", result);
         }
@@ -531,7 +516,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 {
                     Content = new StringContent(bodyContent, Encoding.UTF8, "application/json")
                 };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("maxCandidates := int32(100)", result);
             Assert.Contains("minimumAttendeePercentage := float64(200)", result);

--- a/CodeSnippetsReflection.OpenAPI.Test/OpenApiSnippetGeneratorTestBase.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/OpenApiSnippetGeneratorTestBase.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Services;
+
+namespace CodeSnippetsReflection.OpenAPI.Test;
+
+public class OpenApiSnippetGeneratorTestBase
+{
+    private static OpenApiSnippetMetadata _v1SnippetMetadata;
+    private static OpenApiSnippetMetadata _betaSnippetMetadata;
+    
+    protected const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
+    protected const string ServiceRootBetaUrl = "https://graph.microsoft.com/beta";
+    
+    protected async static Task<OpenApiSnippetMetadata> GetV1SnippetMetadata()
+    {
+        return _v1SnippetMetadata ??= await GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml");
+    }
+    
+    protected async static Task<OpenApiSnippetMetadata> GetBetaSnippetMetadata()
+    {
+        return _betaSnippetMetadata ??= await GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml");
+    }
+    
+    private static async Task<OpenApiSnippetMetadata> GetTreeNode(string url)
+    {
+        Stream stream;
+        if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            using var httpClient = new HttpClient();
+            stream = await httpClient.GetStreamAsync(url);
+        }
+        else
+        {
+            stream = File.OpenRead(url);
+        }
+        var reader = new OpenApiStreamReader();
+        var doc = reader.Read(stream, out var diags);
+        await stream.DisposeAsync();
+        return new OpenApiSnippetMetadata(OpenApiUrlTreeNode.Create(doc, "default"), doc.Components.Schemas);
+    }
+}

--- a/CodeSnippetsReflection.OpenAPI.Test/OpenApiSnippetsGeneratortTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/OpenApiSnippetsGeneratortTests.cs
@@ -1,8 +1,6 @@
 using System;
 using Xunit;
-using CodeSnippetsReflection.OpenAPI;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -3,30 +3,19 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
-using Microsoft.OpenApi.Services;
 using Xunit;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {
-    public class PowerShellGeneratorTests
+    public class PowerShellGeneratorTests : OpenApiSnippetGeneratorTestBase
     {
-        private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
-        private static OpenApiUrlTreeNode _v1TreeNode;
         private readonly PowerShellGenerator _generator = new();
-        private static async Task<OpenApiUrlTreeNode> GetV1TreeNode()
-        {
-            if (_v1TreeNode == null)
-            {
-                _v1TreeNode = await SnippetModelTests.GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml");
-            }
-            return _v1TreeNode;
-        }
 
         [Fact]
         public async Task GeneratesSnippetForTheGetMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-", result);
         }
@@ -35,7 +24,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForThePostMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/users");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("New-", result);
         }
@@ -44,7 +33,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForThePatchMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Update-", result);
         }
@@ -53,7 +42,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForThePutMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/applications/{{application-id}}/logo");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Set-", result);
         }
@@ -62,7 +51,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForTheDeleteMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Remove-", result);
         }
@@ -71,7 +60,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithSelectQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Property \"displayName,id\"", result);
         }
@@ -80,7 +69,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesNoneEncodedSnippetForRequestWithFilterQueryOptionAndEncodedPayloads()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$filter=displayName+eq+'Megan+Bowen'");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Filter \"displayName eq 'Megan Bowen'\"", result);
         }
@@ -90,7 +79,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithFilterQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$filter=displayName eq 'Megan Bowen'");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Filter \"displayName eq 'Megan Bowen'\"", result);
         }
@@ -99,7 +88,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithExpandQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups?$expand=members");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-ExpandProperty \"members\"", result);
         }
@@ -108,7 +97,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithExpandQueryOptionWithSelect()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups?$expand=members($select=displayName)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-ExpandProperty \"members(`$select=displayName)\"", result);
         }
@@ -117,7 +106,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithOrderByQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$orderby=displayName");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Sort \"displayName\"", result);
         }
@@ -126,7 +115,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithOrderByQueryOptionWithSortDirection()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$orderby=displayName desc");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Sort \"displayName desc\"", result);
         }
@@ -135,7 +124,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithOrderByQueryOptionWithMultipleSortingFields()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$orderby=displayName,mail");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Sort \"displayName,mail\"", result);
         }
@@ -144,7 +133,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithTopQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$top=3");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Top 3", result);
         }
@@ -153,7 +142,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithSkipQueryOption()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$skip=10");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Skip 10", result);
         }
@@ -163,7 +152,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-CountVariable CountVar", result);
             Assert.Contains("-ConsistencyLevel eventual", result);
@@ -173,7 +162,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithPathParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/48d31887-5fad-4d73-a9f5-3c356e68a038/appRoleAssignments/hxjTSK1fc02p9Tw1bmigOD83KvI8C1hIl2enozuqhEM");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-UserId $userId -AppRoleAssignmentId $appRoleAssignmentId", result);
         }
@@ -182,7 +171,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?customParameter=value");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Customparameter \"value\"", result);
         }
@@ -193,7 +182,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetsForMeSegment(string path)
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{path}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-UserId $userId", result);
             Assert.Contains("# A UPN can also be used as -UserId.", result);
@@ -205,7 +194,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetsForUserSegment(string path)
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{path}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             Assert.Contains("-MgUser", result);
@@ -218,7 +207,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetsForODataAction(string path)
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}{path}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-UserId $userId", result);
             Assert.Contains("Update-MgUserPassword", result);
@@ -230,7 +219,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForImportModule(string path)
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}{path}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var firstLine = result.Substring(0, result.IndexOf(Environment.NewLine));
             Assert.StartsWith("Import-Module Microsoft.Graph.Users", firstLine);
@@ -241,7 +230,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:Megan\"");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Search '\"displayName:Megan\"'", result);
             Assert.Contains("-ConsistencyLevel eventual", result);
@@ -251,7 +240,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" OR \"displayName:al\"");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Search '\"displayName:di\" OR \"displayName:al\"'", result);
             Assert.Contains("-ConsistencyLevel eventual", result);
@@ -261,7 +250,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" AND \"displayName:al\"");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("-Search '\"displayName:di\" AND \"displayName:al\"'", result);
             Assert.Contains("-ConsistencyLevel eventual", result);
@@ -271,7 +260,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSnippetForRequestWithNoBody()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.DoesNotContain("-BodyParameter", result);
         }
@@ -286,7 +275,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
                 $"displayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
@@ -309,7 +298,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
                 $"displayName = \"Melissa Darrow\"{Environment.NewLine}\t" +
@@ -333,7 +322,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
                 $"displayName = \"Library Assist\"{Environment.NewLine}\t" +
@@ -355,7 +344,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expectedParams = $"$params = @{{{Environment.NewLine}\t" +
                 $"definition = @(" +          

--- a/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/TypeScriptGeneratorTest.cs
@@ -1,30 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
-using Microsoft.OpenApi.Services;
 using Xunit;
 
 namespace CodeSnippetsReflection.OpenAPI.Test
 {
-    public class TypeScriptGeneratorTest
+    public class TypeScriptGeneratorTest : OpenApiSnippetGeneratorTestBase
     {
-        private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
-        private static OpenApiUrlTreeNode _v1TreeNode;
-
-        // read the file from disk
-        private static async Task<OpenApiUrlTreeNode> GetV1TreeNode()
-        {
-            if (_v1TreeNode == null)
-            {
-                _v1TreeNode = await SnippetModelTests.GetTreeNode("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml");
-            }
-            return _v1TreeNode;
-        }
-
         private readonly TypeScriptGenerator _generator = new();
 
         // check path correctness
@@ -32,7 +15,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesTheCorrectFluentAPIPath()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -55,7 +38,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -80,7 +63,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesTheCorrectFluentAPIPathForIndexedCollections()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -100,7 +83,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesTheSnippetInitializationStatement()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("const graphServiceClient = GraphServiceClient.init({authProvider});", result);
         }
@@ -109,7 +92,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesTheGetMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expected = @"
             const graphServiceClient = GraphServiceClient.init({authProvider});
@@ -128,7 +111,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesThePostMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/me/messages");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expected = @"
                 const result = async () => {
@@ -144,7 +127,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesThePatchMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expected = @"
                 const result = async () => {
@@ -160,7 +143,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesThePutMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/applications/{{application-id}}/logo");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("put", result);
         }
@@ -169,7 +152,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesTheDeleteMethodCall()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Delete, $"{ServiceRootUrl}/me/messages/{{message-id}}");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             var expected = @"
             const graphServiceClient = GraphServiceClient.init({authProvider});
@@ -204,7 +187,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -241,7 +224,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("10", result);
             Assert.DoesNotContain("microsoft.graph1", result);
@@ -260,7 +243,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -286,7 +269,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                 Content = new ByteArrayContent(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 })
             };
             requestPayload.Content.Headers.ContentType = new("application/octet-stream");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -310,7 +293,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -337,7 +320,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -373,7 +356,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(samplePayload, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -401,7 +384,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(userJsonObject, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -434,7 +417,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSelectQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me?$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -458,7 +441,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesCountBooleanQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$count=true&$select=displayName,id");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -484,7 +467,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSkipQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$skip=10");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -508,7 +491,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesSelectExpandQueryParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups?$expand=members($select=id,displayName)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("expand", result);
             Assert.Contains("members($select=id,displayName)", result);
@@ -520,7 +503,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/groups");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -564,7 +547,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(samplePayload, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"
@@ -617,7 +600,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             {
                 Content = new StringContent(payloadJson, Encoding.UTF8, "application/json")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1TreeNode());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
 
             var expected = @"

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -277,6 +277,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     var collectionTypeString = codeProperty.Children.Any() && codeProperty.Children.First().PropertyType != PropertyType.Object
                         ? GetTypeString(codeProperty.Children.First(), apiVersion)
                         : typeString;
+                    if(string.IsNullOrEmpty(collectionTypeString)) 
+                        collectionTypeString = "object";
                     return $"List<{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{collectionTypeString}>";
                 case PropertyType.Object:
                     return $"{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{ReplaceIfReservedTypeName(typeString)}";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -274,8 +274,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             {
                 case PropertyType.Array:
                     // For objects, rely on the typeDefinition from the array definition otherwise look deeper for primitive collections
-                    var collectionTypeString = codeProperty.Children.Any() && codeProperty.Children.First().PropertyType != PropertyType.Object
-                        ? GetTypeString(codeProperty.Children.First(), apiVersion)
+                    var collectionTypeString = codeProperty.Children.Any() && codeProperty.Children[0].PropertyType != PropertyType.Object
+                        ? GetTypeString(codeProperty.Children[0], apiVersion)
                         : typeString;
                     if(string.IsNullOrEmpty(collectionTypeString)) 
                         collectionTypeString = "object";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -326,6 +326,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                                         if (x.Segment.IsFunctionWithParameters())
                                         {
                                             var functionName = x.Segment.Split('(').First();
+                                            functionName = functionName.Split(".",StringSplitOptions.RemoveEmptyEntries)
+                                                                        .Select(static s => s.ToFirstCharacterUpperCase())
+                                                                        .Aggregate(static (a, b) => $"{a}{b}");
                                             var parameters = snippetCodeGraph.PathParameters
                                                 .Select(static s => $"With{s.Name.ToFirstCharacterUpperCase()}")
                                                 .Aggregate(static (a, b) => $"{a}{b}");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -289,6 +289,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     return "Date";
                 case PropertyType.TimeOnly:
                     return "Time";
+                case PropertyType.Guid:
+                    return "Guid?";
                 default:
                     return ReplaceIfReservedTypeName(typeString);
             }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -273,7 +273,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             switch (codeProperty.PropertyType)
             {
                 case PropertyType.Array:
-                    var collectionTypeString = codeProperty.Children.Any()
+                    // For objects, rely on the typeDefinition from the array definition otherwise look deeper for primitive collections
+                    var collectionTypeString = codeProperty.Children.Any() && codeProperty.Children.First().PropertyType != PropertyType.Object
                         ? GetTypeString(codeProperty.Children.First(), apiVersion)
                         : typeString;
                     return $"List<{GetNamespaceName(codeProperty.NamespaceName,apiVersion)}{collectionTypeString}>";

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -42,7 +42,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         
         private static readonly char NamespaceNameSeparator = '.';
         
-        public SnippetCodeGraph(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiUrlTreeNode treeNode) : this(new SnippetModel(requestPayload, serviceRootUrl, treeNode)) {}
+        public SnippetCodeGraph(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiSnippetMetadata openApiSnippetMetadata) : this(new SnippetModel(requestPayload, serviceRootUrl, openApiSnippetMetadata)) {}
 
         public SnippetCodeGraph(SnippetModel snippetModel)
         {

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -516,13 +516,17 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                               (value.EnumerateArray().Any() ?
                                   evaluatePropertyTypeDefinition(value.EnumerateArray().First().ValueKind.ToString(), schema?.Items) :
                                   schema?.Items?.Type);
+            
+            var typeDefinition = string.IsNullOrEmpty(genericType) || genericType.Equals("Object", StringComparison.OrdinalIgnoreCase) // try to use alternativeType for objects if we couldn't find a useful name.
+                ? alternativeType
+                : genericType;
             var children = value.EnumerateArray().Select(item =>
             {
                 var prop = parseProperty(schema.GetSchemaTitle() ?? alternativeType?.ToFirstCharacterUpperCase(), item, schema?.Items, snippetModelSchemas);
-                prop.TypeDefinition ??= genericType;
+                prop.TypeDefinition ??= typeDefinition;
                 return prop;
             }).ToList();
-            return new CodeProperty { Name = propertyName, Value = null, PropertyType = PropertyType.Array, Children = children, TypeDefinition = genericType ?? alternativeType };
+            return new CodeProperty { Name = propertyName, Value = null, PropertyType = PropertyType.Array, Children = children, TypeDefinition = typeDefinition };
         }
 
         private static string evaluatePropertyTypeDefinition(String typeInfo, OpenApiSchema propSchema)

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -234,7 +234,14 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                 switch (parameter.Schema.Type.ToLowerInvariant())
                 {
                     case "string":
-                        parameters.Add(evaluateStringProperty(parameter.Name, $"{{{parameter.Name}}}", parameter.Schema));
+                        var codeProperty = evaluateStringProperty(parameter.Name, $"{{{parameter.Name}}}", parameter.Schema);
+                        // At the moment, enums in path parameters are passed as strings, so pull a string equivalent of the enum
+                        if (codeProperty.PropertyType == PropertyType.Enum)
+                        {
+                            codeProperty.PropertyType = PropertyType.String;
+                            codeProperty.Value = codeProperty.Children?.FirstOrDefault().Value ?? parameter.Name;
+                        }
+                        parameters.Add(codeProperty);
                         break;
                     case "integer":
                         parameters.Add(new CodeProperty { Name = parameter.Name, Value = int.TryParse(parameter.Name, out _) ? parameter.Name : "1", PropertyType = PropertyType.Int32, Children = new List<CodeProperty>() });

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -526,7 +526,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                 prop.TypeDefinition ??= typeDefinition;
                 return prop;
             }).ToList();
-            return new CodeProperty { Name = propertyName, Value = null, PropertyType = PropertyType.Array, Children = children, TypeDefinition = typeDefinition };
+            return new CodeProperty { Name = propertyName, Value = null, PropertyType = PropertyType.Array, Children = children, TypeDefinition = typeDefinition ,NamespaceName = GetNamespaceFromSchema(schema?.Items) };
         }
 
         private static string evaluatePropertyTypeDefinition(String typeInfo, OpenApiSchema propSchema)

--- a/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenAPISnippetsGenerator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
 using Microsoft.ApplicationInsights;
@@ -20,9 +19,9 @@ namespace CodeSnippetsReflection.OpenAPI
         private readonly TelemetryClient _telemetryClient;
         private readonly Dictionary<string, string> _snippetsTraceProperties =
                     new() { { UtilityConstants.TelemetryPropertyKey_Snippets, nameof(OpenApiSnippetsGenerator) } };
-        private readonly SimpleLazy<OpenApiUrlTreeNode> _v1OpenApiDocument;
-        private readonly SimpleLazy<OpenApiUrlTreeNode> _betaOpenApiDocument;
-        private readonly SimpleLazy<OpenApiUrlTreeNode> _customOpenApiDocument;
+        private readonly SimpleLazy<OpenApiSnippetMetadata> _v1OpenApiSnippetMetadata;
+        private readonly SimpleLazy<OpenApiSnippetMetadata> _betaOpenApiSnippetMetadata;
+        private readonly SimpleLazy<OpenApiSnippetMetadata> _customOpenApiSnippetMetadata;
         public OpenApiSnippetsGenerator(
             string v1OpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml",
             string betaOpenApiDocumentUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/beta/openapi.yaml",
@@ -33,12 +32,12 @@ namespace CodeSnippetsReflection.OpenAPI
             if(string.IsNullOrEmpty(betaOpenApiDocumentUrl)) throw new ArgumentNullException(nameof(betaOpenApiDocumentUrl));
 
             _telemetryClient = telemetryClient;
-            _v1OpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(v1OpenApiDocumentUrl).GetAwaiter().GetResult());
-            _betaOpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(betaOpenApiDocumentUrl).GetAwaiter().GetResult());
+            _v1OpenApiSnippetMetadata = new SimpleLazy<OpenApiSnippetMetadata>(() => GetOpenApiReferences(v1OpenApiDocumentUrl).GetAwaiter().GetResult());
+            _betaOpenApiSnippetMetadata = new SimpleLazy<OpenApiSnippetMetadata>(() => GetOpenApiReferences(betaOpenApiDocumentUrl).GetAwaiter().GetResult());
             if(!string.IsNullOrEmpty(customOpenApiPathOrUrl))
-                _customOpenApiDocument = new SimpleLazy<OpenApiUrlTreeNode>(() => GetOpenApiDocument(customOpenApiPathOrUrl).GetAwaiter().GetResult());
+                _customOpenApiSnippetMetadata = new SimpleLazy<OpenApiSnippetMetadata>(() => GetOpenApiReferences(customOpenApiPathOrUrl).GetAwaiter().GetResult());
         }
-        private static async Task<OpenApiUrlTreeNode> GetOpenApiDocument(string url) {
+        private static async Task<OpenApiSnippetMetadata> GetOpenApiReferences(string url) {
             Stream stream;
             if(url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
                 using var httpClient = new HttpClient();
@@ -51,15 +50,15 @@ namespace CodeSnippetsReflection.OpenAPI
             await stream.DisposeAsync();
             if(diags.Errors.Any())
                 throw new InvalidOperationException($"Failed to load the OpenAPI document:{Environment.NewLine}{diags.Errors.Select(x => x.Message).Aggregate((x, y) => x + Environment.NewLine + y)}");
-            return OpenApiUrlTreeNode.Create(doc, treeNodeLabel);
+            return new OpenApiSnippetMetadata(OpenApiUrlTreeNode.Create(doc, treeNodeLabel), doc.Components.Schemas) ;
         }
         public string ProcessPayloadRequest(HttpRequestMessage requestPayload, string language)
         {
             _telemetryClient?.TrackTrace($"Generating code snippet for '{language}' from the request payload",
                                          SeverityLevel.Information,
                                          _snippetsTraceProperties);
-            var (openApiTreeNode, serviceRootUri) = GetModelAndServiceUriTuple(requestPayload.RequestUri);
-            var snippetModel = new SnippetModel(requestPayload, serviceRootUri.AbsoluteUri, openApiTreeNode);
+            var (openApiSnippetMetadata, serviceRootUri) = GetModelAndServiceUriTuple(requestPayload.RequestUri);
+            var snippetModel = new SnippetModel(requestPayload, serviceRootUri.AbsoluteUri, openApiSnippetMetadata);
 
             var generator = GetLanguageGenerator(language);
             return generator.GenerateCodeSnippet(snippetModel);
@@ -89,15 +88,15 @@ namespace CodeSnippetsReflection.OpenAPI
         /// </summary>
         /// <param name="requestUri">The URI of the service requested</param>
         /// <returns>Tuple of the OpenApiUrlTreeNode and the URI of the service root</returns>
-        private (OpenApiUrlTreeNode, Uri) GetModelAndServiceUriTuple(Uri requestUri)
+        private (OpenApiSnippetMetadata, Uri) GetModelAndServiceUriTuple(Uri requestUri)
         {
             var apiVersion = requestUri.Segments[1].Trim('/');
             var serviceRootUri = new Uri(new Uri(requestUri.GetLeftPart(UriPartial.Authority)), $"/{apiVersion}");
             return apiVersion.ToLowerInvariant() switch
             {
-                "v1.0" => ((_customOpenApiDocument ?? _v1OpenApiDocument).Value, serviceRootUri),
-                "beta" => ((_customOpenApiDocument ?? _betaOpenApiDocument).Value, serviceRootUri),
-                _ when _customOpenApiDocument != null => (_customOpenApiDocument.Value, serviceRootUri),
+                "v1.0" => ((_customOpenApiSnippetMetadata ?? _v1OpenApiSnippetMetadata).Value, serviceRootUri),
+                "beta" => ((_customOpenApiSnippetMetadata ?? _betaOpenApiSnippetMetadata).Value, serviceRootUri),
+                _ when _customOpenApiSnippetMetadata != null => (_customOpenApiSnippetMetadata.Value, serviceRootUri),
                 _ => throw new ArgumentOutOfRangeException(nameof(requestUri), "Unsupported Graph version in url"),
             };
         }

--- a/CodeSnippetsReflection.OpenAPI/OpenApiSnippetMetadata.cs
+++ b/CodeSnippetsReflection.OpenAPI/OpenApiSnippetMetadata.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+namespace CodeSnippetsReflection.OpenAPI;
+
+public record OpenApiSnippetMetadata(OpenApiUrlTreeNode OpenApiUrlTreeNode, IDictionary<string, OpenApiSchema> Schemas);
+

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -208,12 +208,13 @@ namespace CodeSnippetsReflection.OpenAPI
                 }
             }
             // always match indexer last as functions on collections may be interpreted as indexers if processed after.
-            if (node.Children.Any(x => x.Key.IsCollectionIndex()))
+            var collectionIndices = node.Children.Keys.Where(static x => x.IsCollectionIndex()).ToArray();
+            if (collectionIndices.Any())
             {
-                var collectionIndexNode = node.Children.FirstOrDefault(x => x.Key.IsCollectionIndex());
-                if (collectionIndexNode.Value != null)
+                var collectionIndexValue = node.Children[collectionIndices[0]];//lookup the node using the key
+                if (collectionIndexValue != null)
                 {
-                    LoadNextNode(collectionIndexNode.Value, pathSegments, httpMethod);
+                    LoadNextNode(collectionIndexValue, pathSegments, httpMethod);
                     return;
                 }
             }

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -198,6 +198,16 @@ namespace CodeSnippetsReflection.OpenAPI
                     return;
                 }
             }
+            if (node.Children.Keys.Any(static x => x.IsFunctionWithParameters()) && pathSegment.IsFunctionWithParameters())
+            {
+                var functionWithParametersNode = node.Children.FirstOrDefault(function => function.Key.Split('.').Last().IsFunctionWithParametersMatch(pathSegment.Split('.').Last()));
+                if (functionWithParametersNode.Value != null)
+                {
+                    LoadNextNode(functionWithParametersNode.Value, pathSegments, httpMethod);
+                    return;
+                }
+            }
+            // always match indexer last as functions on collections may be interpreted as indexers if processed after.
             if (node.Children.Any(x => x.Key.IsCollectionIndex()))
             {
                 var collectionIndexNode = node.Children.FirstOrDefault(x => x.Key.IsCollectionIndex());
@@ -207,17 +217,7 @@ namespace CodeSnippetsReflection.OpenAPI
                     return;
                 }
             }
-
-            if (node.Children.Keys.Any(static x => x.IsFunctionWithParameters()) && pathSegment.IsFunctionWithParameters())
-            {
-                var functionWithParametersNode = node.Children.FirstOrDefault(function => function.Key.IsFunctionWithParametersMatch(pathSegment));
-                if (functionWithParametersNode.Value != null)
-                {
-                    LoadNextNode(functionWithParametersNode.Value, pathSegments, httpMethod);
-                    return;
-                }
-            }
-
+            
             throw new EntryPointNotFoundException($"Path segment '{pathSegment}' not found in path");
         }
         private void LoadNextNode(OpenApiUrlTreeNode node, IEnumerable<string> pathSegments, HttpMethod httpMethod)

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -200,7 +200,7 @@ namespace CodeSnippetsReflection.OpenAPI
             }
             if (node.Children.Keys.Any(static x => x.IsFunctionWithParameters()) && pathSegment.IsFunctionWithParameters())
             {
-                var functionWithParametersNode = node.Children.FirstOrDefault(function => function.Key.Split('.').Last().IsFunctionWithParametersMatch(pathSegment.Split('.').Last()));
+                var functionWithParametersNode = node.Children.FirstOrDefault(function => function.Key.Split('.')[^1].IsFunctionWithParametersMatch(pathSegment.Split('.')[^1]));
                 if (functionWithParametersNode.Value != null)
                 {
                     LoadNextNode(functionWithParametersNode.Value, pathSegments, httpMethod);

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -32,9 +32,9 @@ namespace CodeSnippetsReflection.OpenAPI
         /// </remarks>
         public OpenApiUrlTreeNode RootPathNode => PathNodes.FirstOrDefault();
         public List<OpenApiUrlTreeNode> PathNodes { get; private set; } = new List<OpenApiUrlTreeNode>();
-        public SnippetModel(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiUrlTreeNode treeNode) : base(requestPayload, serviceRootUrl)
+        public SnippetModel(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiSnippetMetadata openApiSnippetMetadata) : base(requestPayload, serviceRootUrl)
         {
-            if (treeNode == null) throw new ArgumentNullException(nameof(treeNode));
+            if (openApiSnippetMetadata == null) throw new ArgumentNullException(nameof(openApiSnippetMetadata));
 
             var remappedPayload = RemapKnownPathsIfNeeded(requestPayload);
             var splatPath = ReplaceIndexParametersByPathSegment(remappedPayload.RequestUri
@@ -42,7 +42,7 @@ namespace CodeSnippetsReflection.OpenAPI
                                         .TrimStart(pathSeparator))
                                         .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries)
                                         .Skip(1); //skipping the version
-            LoadPathNodes(treeNode, splatPath, requestPayload.Method);
+            LoadPathNodes(openApiSnippetMetadata.OpenApiUrlTreeNode, splatPath, requestPayload.Method);
             InitializeModel(requestPayload);
         }
 

--- a/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
+++ b/CodeSnippetsReflection.OpenAPI/SnippetModel.cs
@@ -32,6 +32,8 @@ namespace CodeSnippetsReflection.OpenAPI
         /// </remarks>
         public OpenApiUrlTreeNode RootPathNode => PathNodes.FirstOrDefault();
         public List<OpenApiUrlTreeNode> PathNodes { get; private set; } = new List<OpenApiUrlTreeNode>();
+        public IDictionary<string, OpenApiSchema> Schemas{ get; private set; }
+        
         public SnippetModel(HttpRequestMessage requestPayload, string serviceRootUrl, OpenApiSnippetMetadata openApiSnippetMetadata) : base(requestPayload, serviceRootUrl)
         {
             if (openApiSnippetMetadata == null) throw new ArgumentNullException(nameof(openApiSnippetMetadata));
@@ -43,6 +45,7 @@ namespace CodeSnippetsReflection.OpenAPI
                                         .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries)
                                         .Skip(1); //skipping the version
             LoadPathNodes(openApiSnippetMetadata.OpenApiUrlTreeNode, splatPath, requestPayload.Method);
+            Schemas = openApiSnippetMetadata.Schemas ?? new Dictionary<string, OpenApiSchema>();
             InitializeModel(requestPayload);
         }
 


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/629

It updates the OpenAPI snippet generator to receive the list of schemas in the reference document so as to allow for the lookup of schemas on snippet generation. This assists in the scenario where the node schema defines the base type (e.g. `Attachment`) but the payload defines a derived type(e.g. `FileAttachement`) with the properties from the derived type. 
As the generator only has the types from the base type, it ends up placing the properties of the derived instance in the additionalDAta rather than initialize the derived type and use its propeties. 

For example 
```cs
var requestBody = new Attachment
{
	OdataType = "#microsoft.graph.fileAttachment",
	Name = "smile",
	AdditionalData = new Dictionary<string, object>
	{
		{
			"contentBytes" , "R0lGODdhEAYEAA7"
		},
	},
};
```

Should be 
```cs
var requestBody = new FileAttachment
{
	OdataType = "#microsoft.graph.fileAttachment",
	Name = "smile",
	ContentBytes = Convert.FromBase64String("R0lGODdhEAYEAA7"),
};
```

As the changes affect the `SnippetCodeGraph`, the fix should apply for all languages using the `SnippetCodeGraph` and type information updated. 

This PR also 
- Refactors the test to use a common initializer to reduce code repetition in the test project.
- Fixes url template matching for paths that contain both indexers and functions and a function would be misinterpreted as an indexer due to order of processing. See docs at https://learn.microsoft.com/en-us/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0&tabs=http

For easier review the PR is composed of 2 updates
- [Update 1(Refactor tests to use common base)](https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1604/commits/1e3fc3cd71849e497e423f4243b8745165f03b53)
- [Update 2(Lookup Schema  and other fixes)](https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1604/files/1e3fc3cd71849e497e423f4243b8745165f03b53..60f64f95b8a962b967bcf565a3f713ee929e6d0d)

Generation Diff
- https://github.com/microsoftgraph/microsoft-graph-docs/compare/preview-snippet-generation/117784...preview-snippet-generation/117818