### PR TITLE
PascalCase for property name generation dotnet

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -731,6 +731,69 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("new FileAttachment", result);// Individual items are derived types
             Assert.Contains("ContentBytes = Convert.FromBase64String(\"SGVsbG8gV29ybGQh\"),", result);
         }
+        [Fact]
+        public async Task GeneratesPropertiesWithSpecialCharacters() {
+            var sampleJson = @"{
+              ""@odata.type"": ""#microsoft.graph.managedIOSLobApp"",
+              ""displayName"": ""Display Name value"",
+              ""description"": ""Description value"",
+              ""publisher"": ""Publisher value"",
+              ""largeIcon"": {
+                ""@odata.type"": ""microsoft.graph.mimeContent"",
+                ""type"": ""Type value"",
+                ""value"": ""dmFsdWU=""
+              },
+              ""isFeatured"": true,
+              ""privacyInformationUrl"": ""https://example.com/privacyInformationUrl/"",
+              ""informationUrl"": ""https://example.com/informationUrl/"",
+              ""owner"": ""Owner value"",
+              ""developer"": ""Developer value"",
+              ""notes"": ""Notes value"",
+              ""uploadState"": 11,
+              ""publishingState"": ""processing"",
+              ""isAssigned"": true,
+              ""roleScopeTagIds"": [
+                ""Role Scope Tag Ids value""
+              ],
+              ""dependentAppCount"": 1,
+              ""supersedingAppCount"": 3,
+              ""supersededAppCount"": 2,
+              ""appAvailability"": ""lineOfBusiness"",
+              ""version"": ""Version value"",
+              ""committedContentVersion"": ""Committed Content Version value"",
+              ""fileName"": ""File Name value"",
+              ""size"": 4,
+              ""bundleId"": ""Bundle Id value"",
+              ""applicableDeviceType"": {
+                ""@odata.type"": ""microsoft.graph.iosDeviceType"",
+                ""iPad"": true,
+                ""iPhoneAndIPod"": true
+              },
+              ""minimumSupportedOperatingSystem"": {
+                ""@odata.type"": ""microsoft.graph.iosMinimumOperatingSystem"",
+                ""v8_0"": true,
+                ""v9_0"": true,
+                ""v10_0"": true,
+                ""v11_0"": true,
+                ""v12_0"": true,
+                ""v13_0"": true,
+                ""v14_0"": true,
+                ""v15_0"": true,
+                ""v16_0"": true
+              },
+              ""expirationDateTime"": ""2016-12-31T23:57:57.2481234-08:00"",
+              ""versionNumber"": ""Version Number value"",
+              ""buildNumber"": ""Build Number value"",
+              ""identityVersion"": ""Identity Version value""
+            }";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootBetaUrl}/deviceAppManagement/mobileApps/{{mobileAppId}}"){
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("MinimumSupportedOperatingSystem = new IosMinimumOperatingSystem", result);
+            Assert.Contains("V80 = true,", result);//Assert that the property was pascal cased
+        }
         
         [Fact]
         public async Task CorrectlyHandlesTypeFromInUrl()

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -167,7 +167,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var isParentArray = parentProperty.PropertyType == PropertyType.Array;
             var isParentMap = parentProperty.PropertyType == PropertyType.Map;
             var assignmentSuffix = isParentMap ? string.Empty : ","; // no comma separator values for additionalData/maps
-            var propertyAssignment = $"{indentManager.GetIndent()}{codeProperty.Name.CleanupSymbolName().ToFirstCharacterUpperCase()} = "; // default assignments to the usual "var x = xyz"
+            var propertyAssignment = $"{indentManager.GetIndent()}{codeProperty.Name.CleanupSymbolName().ToPascalCase()} = "; // default assignments to the usual "var x = xyz"
             if (isParentMap)
             {
                 propertyAssignment = $"{indentManager.GetIndent()}\"{codeProperty.Name}\" , "; // if its in the additionalData assignments happen using string value keys

--- a/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
+++ b/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
@@ -41,13 +41,15 @@ namespace CodeSnippetsReflection.StringExtensions
 
         public static string ToPascalCase(this string str)
         {
+            if (string.IsNullOrEmpty(str)) return str;
             string[] words = str.Split('_');
-            string pascalCaseString = string.Join("", words.Select(w => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(w)));
+            string pascalCaseString = string.Join("", words.Select(ToFirstCharacterUpperCase));
             return pascalCaseString;
         }
 
        public static string ToSnakeCase(this string str)
         {
+            if (string.IsNullOrEmpty(str)) return str;
             StringBuilder snakeCaseBuilder = new StringBuilder();
             for (int i = 0; i < str.Length; i++)
             {


### PR DESCRIPTION
Properties generated by Kiota are pascalCased in the refiner. 
https://github.com/microsoft/kiota/blob/c07239a197d31d0bf40c6140d3afd1577464a8d6/src/Kiota.Builder/Refiners/CSharpRefiner.cs#L81
This PR aligns the behaviour to fix compilation errors due to this.