### PR TITLE
[CLI] Snippet generation fix for overloaded bound functions with parameter values enclosed within single quotes (Non date parameters)

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
@@ -438,4 +438,19 @@ public class GraphCliGeneratorTests : OpenApiSnippetGeneratorTestBase
         // Then
         Assert.Equal("mgc reports get-yammer-device-usage-user-detail-with-date get --date '{date-id}'", result);
     }
+    
+    [Fact]
+    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithNonDateParameter()
+    {
+        // Given
+        string url = $"{ServiceRootUrl}/drives/driveid/items/driveitemid/delta(token='token')";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+
+        // When
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+
+        // Then
+        Assert.Equal("mgc drives items delta-with-token get --token '{token-id}' --drive-id {drive-id} --drive-item-id {driveItem-id}", result);
+    }
 }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
@@ -14,6 +14,7 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
     private static readonly Regex camelCaseRegex = CamelCaseRegex();
     private static readonly Regex delimitedRegex = DelimitedRegex();
     private static readonly Regex overloadedBoundedFunctionWithDateRegex = new(@"\w*\(\w*={\w*\}\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private static readonly Regex overloadedBoundedFunctionWithNoneDateRegex = new(@"\w*\(\w*='{\w*\}'\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
     private static readonly Regex apiPathWithSingleOrDoubleQuotesOnFunctions = new(@"(\/\w+)+\(\w*=(?:'|"").*(?:'|"")\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
     private const string PathItemsKey = "default";
@@ -140,7 +141,8 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
     /// <param name="operationName"></param>
     private static void OverLoadedBoundFunctionsWithDate(List<string> commandSegments, string operationName, SnippetModel snippetModel)
     {
-        int boundedFunctionIndex = commandSegments.FindIndex(static u => overloadedBoundedFunctionWithDateRegex.IsMatch(u));
+        int boundedFunctionIndex = commandSegments.FindIndex(static u => overloadedBoundedFunctionWithDateRegex.IsMatch(u)
+        || overloadedBoundedFunctionWithNoneDateRegex.IsMatch(u));
 
         if (boundedFunctionIndex != -1)
         {


### PR DESCRIPTION
## Overview

Fixes #1622
Fixes #1623 

## Testing Instructions

* Checkout branch associated with this PR
* Run it locally and formulate the request as per the screenshot below showing the request and expected output.
<img width="614" alt="image" src="https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/aefbc766-fc44-4aff-9b5b-57f6d5630616">

<img width="628" alt="image" src="https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/2739bc9a-2e25-4813-ac32-bfef9b734933">
