### PR TITLE
Update code snippets tab ordering for docs

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -28,7 +28,7 @@ pool:
 parameters:
   - name: snippetLanguages
     type: object
-    default: ['C#', 'JavaScript', 'Java', 'Go', 'PowerShell', 'PHP', 'Python', 'Cli']
+    default: ['C#', 'CLI', 'Go', 'Java', 'JavaScript', 'PHP', 'PowerShell', 'Python'] # should be ordered alphabetically
     displayName: 'Languages to generate snippets for'
 
 variables:


### PR DESCRIPTION
## Overview
Closes #1470

Update ordering of code snippets tabs in docs to: 

- C#
- CLI
- Go
- Java
- JavaScript
- PHP
- PowerShell
- Python