### PR TITLE
Bump PowerShell Snippet Generator to V2 GA

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -441,6 +441,89 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("Set-MgUserPhotoContent", result);
             Assert.Contains("-BodyParameter", result);
         }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForDeltaFunctionsWithoutParams()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/contacts/delta()?$select=displayName%2CjobTitle%2Cmail");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgBetaContactDelta", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForDeltaFunctionsWithParams()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/drives/XXXX/items/XXXX/delta(token='token')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgBetaDriveItemDelta", result);
+            Assert.Contains("-Token", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForHttpSnippetsWithGraphPrefixOnLastPathSegment()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/places/graph.room");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgBetaPlaceAsRoom", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForPathsWithIdentityProviderAsRootNode()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/identityProviders");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgBetaIdentityProvider", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForRequestWithTextContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootBetaUrl}/me/drive/items/XXXX/content")
+            {
+                Content = new StringContent(
+                    "Plain text",
+                    Encoding.UTF8,
+                    "text/plain")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgBetaDriveItemContent", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForRequestWithApplicationZipContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootBetaUrl}/me/drive/items/XXXX/content")
+            {
+                Content = new StringContent(
+                    "Zip file content",
+                    Encoding.UTF8,
+                    "application/zip")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgBetaDriveItemContent", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForRequestWithImageContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootBetaUrl}/me/photo/$value")
+            {
+                Content = new StringContent(
+                    "Binary data for the image",
+                    Encoding.UTF8,
+                    "image/jpeg")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgBetaUserPhotoContent", result);
+            Assert.Contains("-BodyParameter", result);
+        }
         
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -455,7 +455,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesBetaSnippetForFunctionsWithoutParams()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/contacts/delta()?$select=displayName%2CjobTitle%2Cmail");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaContactDelta", result);
         }
@@ -464,7 +464,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesBetaSnippetForFunctionsWithSingleParam()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/drives/XXXX/items/XXXX/delta(token='token')");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaDriveItemDelta", result);
             Assert.Contains("-Token", result);
@@ -474,7 +474,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesBetaSnippetForFunctionsWithMultipleParam()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/communications/callRecords/getPstnBlockedUsersLog(fromDateTime=XXXXXX,toDateTime=XXXXX)");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaCommunicationCallRecordPstnBlockedUserLog", result);
             Assert.Contains("-ToDateTime", result);
@@ -484,7 +484,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesBetaSnippetForHttpSnippetsWithGraphPrefixOnLastPathSegment()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/places/graph.room");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaPlaceAsRoom", result);
         }
@@ -493,7 +493,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesBetaSnippetForPathsWithIdentityProviderAsRootNode()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/identityProviders");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaIdentityProvider", result);
         }
@@ -508,7 +508,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "text/plain")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Set-MgBetaDriveItemContent", result);
         }
@@ -523,7 +523,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "application/zip")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Set-MgBetaDriveItemContent", result);
         }
@@ -538,7 +538,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
                     Encoding.UTF8,
                     "image/jpeg")
             };
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Set-MgBetaUserPhotoContent", result);
             Assert.Contains("-BodyParameter", result);

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -374,7 +374,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/drives/XXXX/items/XXXX/delta(token='token')");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("Get-MgContactDelta", result);
+            Assert.Contains("Get-MgDriveItemDelta", result);
             Assert.Contains("-Token", result);
         }
         

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -358,5 +358,25 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains(expectedParams, result);
             Assert.Contains("-BodyParameter $params", result);
         }
+
+        [Fact]
+        public async Task GeneratesSnippetForDeltaFunctionsWithoutParams()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/contacts/delta()?$select=displayName%2CjobTitle%2Cmail");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgContactDelta", result);
+        }
+
+        [Fact]
+        public async Task GeneratesSnippetForDeltaFunctionsWithParams()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/drives/XXXX/items/XXXX/delta(token='token')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgContactDelta", result);
+            Assert.Contains("-Token", result);
+        }
+        
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -386,6 +386,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgPlaceAsRoom", result);
         }
+
+        [Fact]
+        public async Task GeneratesSnippetForPathsWithIdentityProviderAsRootNode()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/identityProviders");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgIdentityProvider", result);
+        }
         
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -377,6 +377,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("Get-MgDriveItemDelta", result);
             Assert.Contains("-Token", result);
         }
+
+        [Fact]
+        public async Task GeneratesSnippetForHttpSnippetsWithGraphPrefixOnLastPathSegment()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/places/graph.room");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgPlaceAsRoom", result);
+        }
         
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -388,6 +388,15 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
 
         [Fact]
+        public async Task GeneratesSnippetForHttpSnippetsWithoutGraphPrefixOnLastPathSegment()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/places/microsoft.graph.room");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgPlaceAsRoom", result);
+        }
+
+        [Fact]
         public async Task GeneratesSnippetForPathsWithIdentityProviderAsRootNode()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/identityProviders");
@@ -443,7 +452,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
 
         [Fact]
-        public async Task GeneratesBetaSnippetForDeltaFunctionsWithoutParams()
+        public async Task GeneratesBetaSnippetForFunctionsWithoutParams()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/contacts/delta()?$select=displayName%2CjobTitle%2Cmail");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
@@ -452,13 +461,23 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         }
 
         [Fact]
-        public async Task GeneratesBetaSnippetForDeltaFunctionsWithParams()
+        public async Task GeneratesBetaSnippetForFunctionsWithSingleParam()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/drives/XXXX/items/XXXX/delta(token='token')");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgBetaDriveItemDelta", result);
             Assert.Contains("-Token", result);
+        }
+
+        [Fact]
+        public async Task GeneratesBetaSnippetForFunctionsWithMultipleParam()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/communications/callRecords/getPstnBlockedUsersLog(fromDateTime=XXXXXX,toDateTime=XXXXX)");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Get-MgCommunicationCallRecord", result);
+            Assert.Contains("-ToDateTime", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -395,6 +395,52 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("Get-MgIdentityProvider", result);
         }
+
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithTextContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/me/drive/items/XXXX/content")
+            {
+                Content = new StringContent(
+                    "Plain text",
+                    Encoding.UTF8,
+                    "text/plain")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgDriveItemContent", result);
+        }
+
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithApplicationZipContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/me/drive/items/XXXX/content")
+            {
+                Content = new StringContent(
+                    "Zip file content",
+                    Encoding.UTF8,
+                    "application/zip")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgDriveItemContent", result);
+        }
+
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithImageContentType()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Put, $"{ServiceRootUrl}/me/photo/$value")
+            {
+                Content = new StringContent(
+                    "Binary data for the image",
+                    Encoding.UTF8,
+                    "image/jpeg")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("Set-MgUserPhotoContent", result);
+            Assert.Contains("-BodyParameter", result);
+        }
         
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PowerShellGeneratorTests.cs
@@ -476,7 +476,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/communications/callRecords/getPstnBlockedUsersLog(fromDateTime=XXXXXX,toDateTime=XXXXX)");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("Get-MgCommunicationCallRecord", result);
+            Assert.Contains("Get-MgBetaCommunicationCallRecordPstnBlockedUserLog", result);
             Assert.Contains("-ToDateTime", result);
         }
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -50,7 +50,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             cleanPath = SubstituteDeltaSegment(lastPathSegment, cleanPath);
             cleanPath = SubstituteGraphSegment(cleanPath, hasGraphPrefix);
             cleanPath = SubstituteMicrosoftSegment(cleanPath, hasMicrosoftPrefix, lastPathSegment);
-            cleanPath = AppendIdentityProtection(cleanPath, rootPathSegment);
             var (path, additionalKeySegmentParmeter) = SubstituteMeSegment(isMeSegment, cleanPath, lastPathSegment);
             IList<PowerShellCommandInfo> matchedCommands = GetCommandForRequest(path, snippetModel.Method.ToString(), snippetModel.ApiVersion);
             var targetCommand = matchedCommands.FirstOrDefault();
@@ -177,15 +176,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
             return path;
         }
-        private static string AppendIdentityProtection(string path, string rootPathSegment)
-        {
-            if (rootPathSegment.StartsWith("riskyUsers") || rootPathSegment.StartsWith("riskDetections"))
-            {
-                path = path.Replace(rootPathSegment, $"identityProtection/{rootPathSegment}");
-            }
-            return path;
-        }
-
         private static string SubstituteIdentityProviderSegment(string path, bool isIdentityProvider)
         {
             if (isIdentityProvider)

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -84,11 +84,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     //Allows genration of an output file for MIME content of the message
                     snippetBuilder.Append(" -OutFile $outFileId");
                 }
-
-                if (deltaWithParams.IsMatch(lastPathSegment))
-                {
-                    snippetBuilder.Append(" -Token $tokenId");
-                }
             }
             else
             {
@@ -126,11 +121,17 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (!string.IsNullOrEmpty(parameterList))
                 payloadSB.Append($" {parameterList}");
 
+            var functionParameterList = GetFunctionParameterList(snippetModel);
+            if (!string.IsNullOrEmpty(functionParameterList))
+                payloadSB.Append($" {functionParameterList}");
+
             var requestHeadersPayload = GetSupportedRequestHeaders(snippetModel);
             if (!string.IsNullOrEmpty(requestHeadersPayload))
                 payloadSB.Append(requestHeadersPayload);
+
             return payloadSB.ToString();
         }
+
         public static string ReturnCleanParamsPayload(string queryParamsPayload)
         {
             if(encodedQueryParamsPayLoad.IsMatch(queryParamsPayload))
@@ -408,5 +409,22 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 return string.Join(" ", nonEmptyParameters.Aggregate((a, b) => $"{a}, {b}"));
             else return string.Empty;
         }
+
+        private static string GetFunctionParameterList(SnippetModel snippetModel)
+        {
+            var lastPathSegment = snippetModel.EndPathNode.Segment;
+            if (deltaWithParams.IsMatch(lastPathSegment))
+            {
+                var segmentItems = lastPathSegment.Split("(");
+                var snippetParameterItems = segmentItems[1].Split("=");
+                var snippetParameter = snippetParameterItems[0];
+                return $"-{snippetParameter.ToFirstCharacterUpperCase()} ${snippetParameter}Id";
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
     }
 }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -44,7 +44,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var hasGraphPrefix = snippetModel.EndPathNode.Path.Contains("graph", StringComparison.OrdinalIgnoreCase);
             var isIdentityProvider = snippetModel.RootPathNode.Path.StartsWith("\\identityProviders", StringComparison.OrdinalIgnoreCase);
             var lastPathSegment = snippetModel.EndPathNode.Segment;
-            var rootPathSegment = snippetModel.RootPathNode.Segment;
             var hasMicrosoftPrefix = lastPathSegment.StartsWith("microsoft", StringComparison.OrdinalIgnoreCase);
             cleanPath = SubstituteIdentityProviderSegment(cleanPath, isIdentityProvider);
             cleanPath = SubstituteDeltaSegment(lastPathSegment, cleanPath);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -41,7 +41,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var snippetBuilder = new StringBuilder();
             var cleanPath = snippetModel.EndPathNode.Path.Replace("\\", "/");
             var isMeSegment = meSegmentRegex.IsMatch(cleanPath);
-            var hasGraphPrefix = snippetModel.EndPathNode.Path.Contains("graph", StringComparison.OrdinalIgnoreCase);
+            var hasGraphPrefix = cleanPath.Contains("graph", StringComparison.OrdinalIgnoreCase);
             var isIdentityProvider = snippetModel.RootPathNode.Path.StartsWith("\\identityProviders", StringComparison.OrdinalIgnoreCase);
             var lastPathSegment = snippetModel.EndPathNode.Segment;
             var hasMicrosoftPrefix = lastPathSegment.StartsWith("microsoft", StringComparison.OrdinalIgnoreCase);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -321,6 +321,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 case "application/zip":
                     payloadSB.AppendLine($"{indentManager.GetIndent()}${requestBodyVarName} = {snippetModel?.RequestBody}");
                     break;
+                case "text/plain":
+                    payloadSB.AppendLine($"{indentManager.GetIndent()}${requestBodyVarName} = {snippetModel?.RequestBody}");
+                    break;
                 default:
                     throw new InvalidOperationException($"Unsupported content type: {snippetModel.ContentType}");
             }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -84,7 +84,12 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 if (RequiresMIMEContentOutPut(snippetModel, path))
                 {
                     //Allows genration of an output file for MIME content of the message
-                    snippetBuilder.Append($" -OutFile $outFileId");
+                    snippetBuilder.Append(" -OutFile $outFileId");
+                }
+
+                if (deltaWithParams.IsMatch(lastPathSegment))
+                {
+                    snippetBuilder.Append(" -Token $tokenId");
                 }
             }
             else

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -35,7 +35,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static readonly Regex wrongQoutesInStringLiterals = new(@"""\{", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static readonly Regex deltaWithParams = new(@"delta\(\w*='{\w*}\'\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static readonly Regex deltaWithoutParams = new(@"delta\(\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-        private static readonly Regex stringLiterals = new(@"""\{", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
             var indentManager = new IndentManager();

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -136,7 +136,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         public static string ReturnCleanParamsPayload(string queryParamsPayload)
         {
             if(encodedQueryParamsPayLoad.IsMatch(queryParamsPayload))
-                return queryParamsPayload.Replace("+", string.Empty);
+                return queryParamsPayload.Replace("+", " ");
             return queryParamsPayload;
         }
         private static (string, string) SubstituteMeSegment(bool isMeSegment, string path, string lastPathSegment)


### PR DESCRIPTION
## Overview
Update the PowerShell snippet generator to V2 GA.
See [release notes](https://github.com/microsoftgraph/msgraph-sdk-powershell/releases) for full v1 to v2 change log and new [changes ](https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/features/2.0/docs/upgrade-to-v2.md) in v2.