### PR TITLE
Prefer msgraph to msgraphm365 for issue area and subarea

### DIFF
--- a/KnownIssuesService/Services/KnownIssuesService.cs
+++ b/KnownIssuesService/Services/KnownIssuesService.cs
@@ -166,13 +166,13 @@ namespace KnownIssuesService.Services
                 Id = x.Id,
                 State = x.Fields.TryGetValue("System.State", out var state) ? state.ToString(): default,
                 Title = x.Fields.TryGetValue("System.Title", out var title) ? title.ToString() : default,
-                WorkLoadArea = x.Fields.TryGetValue("Custom.MSGraphM365Workload", out var workLoadArea) ? workLoadArea.ToString() : (x.Fields.TryGetValue("Custom.MicrosoftGraphArea", out workLoadArea) ? workLoadArea.ToString() : default),
+                WorkLoadArea = x.Fields.TryGetValue("Custom.MicrosoftGraphArea", out var workLoadArea) ? workLoadArea.ToString() : (x.Fields.TryGetValue("Custom.MSGraphM365Workload", out workLoadArea) ? workLoadArea.ToString() : default),
                 Description = x.Fields.TryGetValue("System.Description", out var description) ? description.ToString() : default,
                 WorkAround = x.Fields.TryGetValue("Custom.Workaround", out var workAround) ? workAround.ToString() : "Working on it",
                 Link = x.Fields.TryGetValue("Custom.APIPathLink", out var link) ? link.ToString() : default,
                 CreatedDateTime = x.Fields.TryGetValue("Custom.Dateissuewasraised", out DateTime createdDate) ? createdDate : default,
                 LastUpdatedDateTime = x.Fields.TryGetValue("Custom.Lastupdate", out DateTime changedDate) ? changedDate : default,
-                SubArea = x.Fields.TryGetValue("Custom.MicrosoftGraphSubarea", out var subArea) ? subArea.ToString() : default,
+                SubArea = x.Fields.TryGetValue("Custom.MicrosoftGraphSubarea", out var subArea) ? subArea.ToString() : (x.Fields.TryGetValue("Custom.MSGraphM365SubArea", out workLoadArea) ? workLoadArea.ToString() : default),
                 IsPublicIssue = x.Fields.TryGetValue("Custom.PublicIssue", out bool publicIssue) ? publicIssue : default
             }).ToList();
 


### PR DESCRIPTION
## Overview
Getting area variable from MSGraphM365Workload has intermittent behavior. MicrosoftGraphArea is more consistent

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output