### PR TITLE
Embeds preview notice message to CLI snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
@@ -36,6 +36,7 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
         // List has an initial capacity of 4. Reserve more based on the number of nodes.
         // Reduces reallocations at the expense of more memory used.
         var initialCapacity = Math.Max(snippetModel.PathNodes.Count, 20);
+        var notice = "// THE CLI SDK IS IN PREVIEW. NON-PRODUCTION USE ONLY";
         var commandSegments = new List<string>(initialCapacity)
         {
             GetCommandName(snippetModel)
@@ -47,7 +48,7 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
         // parameters to the parameters dictionary.
         ProcessCommandSegmentsAndParameters(snippetModel, ref commandSegments, ref operation, ref parameters);
 
-        return commandSegments.Aggregate("", (accum, val) => string.IsNullOrWhiteSpace(accum) ? val : $"{accum} {val}")
+        return notice + Environment.NewLine + commandSegments.Aggregate("", (accum, val) => string.IsNullOrWhiteSpace(accum) ? val : $"{accum} {val}")
                     .Replace("\n", "\\\n", StringComparison.Ordinal)
                     .Replace("\r\n", "\\\r\n", StringComparison.Ordinal);
     }


### PR DESCRIPTION
For purposes of uniformity with other languages on preview, this PR embeds a preview notice message. 

**Current**
![Screenshot (169)](https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/be274c71-9fd7-4e85-894b-068e5ce772c1)

**Proposed in this PR**
<img width="584" alt="image" src="https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/80c4417f-9fa5-40fc-ac19-19cf7cb3e495">

