### PR TITLE
Updates go fluent path api

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
 using Xunit;
 
@@ -49,7 +50,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             };
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("Drives().ByDriveId(\"drive-id\").Items().ByItemId(\"driveItem-id\").Checkin().", result);
+            Assert.Contains("Drives().ByDriveId(\"drive-id\").Items().ByDriveItemId(\"driveItem-id\").Checkin().Post(context.Background(), requestBody, nil)", result);
         }
         [Fact]
         public async Task IgnoreOdataTypeWhenGenerating() {
@@ -521,6 +522,14 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("maxCandidates := int32(100)", result);
             Assert.Contains("minimumAttendeePercentage := float64(200)", result);
             Assert.Contains("isOrganizerOptional := false", result);
+        }
+        [Fact]
+        public async Task GeneratesPathSegmentsUsingVariableName()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/drive/items/{{id}}/workbook/worksheets/{{id|name}}/charts");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains(".Drives().ByDriveId(\"drive-id\").Items().ByDriveItemId(\"driveItem-id\").Workbook().Worksheets().ByWorkbookWorksheetId(\"workbookWorksheet-id\").Charts().Get(context.Background(), nil)", result);
         }
         //TODO test for DateTimeOffset
     }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -565,7 +565,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var elements = nodes.Select(static (x, i) =>
             {
                 if (x.Segment.IsCollectionIndex())
-                    return $"ByTypeId{x.Segment.Replace("{", "(\"").Replace("}", "\")")}.";
+                {
+                    var pathName = string.IsNullOrEmpty(x.Segment) ? x.Segment : x.Segment.ReplaceMultiple("", "{", "}").Split('-').Where(static s => !string.IsNullOrEmpty(s)).Select(static s => s.ToFirstCharacterUpperCase()).Aggregate(static (a, b) => $"By{a}{b}");
+                    return $"{pathName ?? "ByTypeId"}{x.Segment.Replace("{", "(\"", StringComparison.OrdinalIgnoreCase).Replace("}", "\")", StringComparison.OrdinalIgnoreCase)}.";
+                }
                 else if (x.Segment.IsFunction())
                     return x.Segment.Split('.')
                                     .Select(static s => s.ToFirstCharacterUpperCase())

--- a/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
+++ b/CodeSnippetsReflection/StringExtensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
-using System.Globalization;
 using System.Linq;
+using System;
 
 namespace CodeSnippetsReflection.StringExtensions
 {
@@ -29,6 +29,18 @@ namespace CodeSnippetsReflection.StringExtensions
         public static string ToFirstCharacterUpperCase(this string stringValue) {
             if(string.IsNullOrEmpty(stringValue)) return stringValue;
             return char.ToUpper(stringValue[0]) + stringValue[1..];
+        }
+
+        public static string ReplaceMultiple(this string stringValue, string haystack, params string []needles)
+        {
+            if (string.IsNullOrEmpty(stringValue)) return stringValue;
+            if (needles == null || needles.Length == 0) return stringValue;
+            foreach (var needle in needles)
+            {
+                if (string.IsNullOrEmpty(needle) || !stringValue.Contains(needle, StringComparison.InvariantCulture)) continue;
+                stringValue = stringValue.Replace(needle, haystack, StringComparison.OrdinalIgnoreCase);
+            }
+            return stringValue;
         }
 
         public static string ToFirstCharacterUpperCaseAfterCharacter(this string stringValue, char character)


### PR DESCRIPTION
## Overview
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/541

Fixes Go samples fluent api.

### Demo

```go
 # https://learn.microsoft.com/en-us/graph/api/worksheet-post-charts?view=graph-rest-1.0&tabs=http
 // current syntax 
result, err := graphClient.Drives().ByDriveId("drive-id").Items().ByItemId("driveItem-id").Workbook().Worksheets().ByWorksheetId("workbookWorksheet-id").Charts().Post(context.Background(), requestBody, nil)


// expected

result, err := graphClient.Drives().ByDriveId("drive-id").Items().ByDriveItemId("driveItem-id").Workbook().Worksheets().ByWorkbookWorksheetId("workbookWorksheet-id").Charts().Post(context.Background(), requestBody, nil)rkbook().Worksheets().ByWorksheetId("workbookWorksheet-id").Charts().Post(context.Background(), requestBody, nil)

```

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Added unit tests 
