### PR TITLE
Fixes functions with parameters in Go

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -467,7 +467,28 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("NewAddPasswordPostRequestBody", result);
         }
-        
+
+        [Fact]
+        public async Task GeneratePathParametersInFluentPath()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/reports/getYammerActivityCounts(period='D7')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("period := \"{period}\"", result);
+            Assert.Contains("graphClient.Reports().GetYammerActivityCountsWithPeriod(&period).Get(context.Background(), nil)", result);
+        }
+
+        [Fact]
+        public async Task GeneratePathParametersInFluentPathWithPeriodsInName()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootBetaUrl}/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("fromDateTime , err := time.Parse(time.RFC3339, \"{fromDateTime}\")", result);
+            Assert.Contains("toDateTime , err := time.Parse(time.RFC3339, \"{toDateTime}\")", result);
+            Assert.Contains("microsoftGraphCallRecordsGetPstnCalls, err := graphClient.Communications().CallRecords().MicrosoftGraphCallRecordsGetPstnCallsWithFromDateTimeWithToDateTime(&fromDateTime, &toDateTime).Get(context.Background(), nil)", result);
+        }
+
         [Fact]
         public async Task GenerateFindMeetingTime()
         {

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
@@ -253,6 +253,9 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                         break;
                     case "double":
                         parameters.Add(new CodeProperty { Name = parameter.Name, Value = double.TryParse(parameter.Name, out _) ? parameter.Name : "1.0d", PropertyType = PropertyType.Double, Children = new List<CodeProperty>() });
+                        break;
+                    case "boolean":
+                        parameters.Add(new CodeProperty { Name = parameter.Name, Value = bool.TryParse(parameter.Name, out _) ? parameter.Name : "false", PropertyType = PropertyType.Boolean, Children = new List<CodeProperty>() });
                         break;
                 }
             }


### PR DESCRIPTION
## Overview

Fixes generation fluent path in go for functions with paramerts e.g https://learn.microsoft.com/en-us/graph/api/reportroot-getyammeractivitycounts?view=graph-rest-1.0&tabs=http


Current behaviour
```go
graphClient.Reports().GetYammerActivityCounts(period='{period}')().Get(context.Background(), nil)
```

expected behaviour

```go
period = '{period}'
graphClient.Reports().GetYammerActivityCountsWithPeriod(&period).Get(context.Background(), nil)
```

## Testing Instructions

* Unit tests 