### PR TITLE
Handle overloaded bound functions with multiple parameters

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GraphCliGeneratorTests.cs
@@ -408,39 +408,9 @@ public class GraphCliGeneratorTests : OpenApiSnippetGeneratorTestBase
         // Then
         Assert.Equal(notice + Environment.NewLine + "mgc users create --body '{\\\n  \"name\": \"test\"\\\n}'", result);
     }
-
-    [Fact]
-    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithDateParameter()
-    {
-        // Given
-        string url = $"{ServiceRootUrl}/reports/getYammerDeviceUsageUserDetail(date=2018-03-05)";
-        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
-        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
-
-        // When
-        var result = _generator.GenerateCodeSnippet(snippetModel);
-
-        // Then
-        Assert.Equal(notice + Environment.NewLine + "mgc reports get-yammer-device-usage-user-detail-with-date get --date {date-id}", result);
-    }
-
-    [Fact]
-    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithDateParameterWithSingleOrDoubleQuotes()
-    {
-        // Given
-        string url = $"{ServiceRootUrl}/reports/getYammerDeviceUsageUserDetail(date='2018-03-05')";
-        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
-        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
-
-        // When
-        var result = _generator.GenerateCodeSnippet(snippetModel);
-
-        // Then
-        Assert.Equal(notice + Environment.NewLine + "mgc reports get-yammer-device-usage-user-detail-with-date get --date '{date-id}'", result);
-    }
     
     [Fact]
-    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithNonDateParameter()
+    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithSingleParameter()
     {
         // Given
         string url = $"{ServiceRootUrl}/drives/driveid/items/driveitemid/delta(token='token')";
@@ -451,7 +421,22 @@ public class GraphCliGeneratorTests : OpenApiSnippetGeneratorTestBase
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
         // Then
-        Assert.Equal(notice + Environment.NewLine + "mgc drives items delta-with-token get --token '{token-id}' --drive-id {drive-id} --drive-item-id {driveItem-id}", result);
+        Assert.Equal(notice + Environment.NewLine + "mgc drives items delta-with-token get --token {token-id} --drive-id {drive-id} --drive-item-id {driveItem-id}", result);
+    }
+
+    [Fact]
+    public async Task GeneratesSnippetsContainingOverLoadedBoundFunctionsWithMultipleParameters()
+    {
+        // Given
+        string url = $"{ServiceRootUrl}/drives/driveid/items/driveitemid/getActivitiesByInterval(startDateTime='startdatetime',endDateTime='enddatetime',interval='interval')";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Get, url);
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+
+        // When
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+
+        // Then
+        Assert.Equal(notice + Environment.NewLine + "mgc drives items get-activities-by-interval-with-start-date-time-with-end-date-time-with-interval get --start-date-time {start-date-time-id} --end-date-time {end-date-time-id} --interval {interval-id}  --drive-id {drive-id} --drive-item-id {driveItem-id}", result);
     }
 
     [Fact]

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GraphCliGenerator.cs
@@ -20,8 +20,9 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
     private static readonly Regex overloadedBoundedFunctionWithSingleOrMultipleParameters = new(@"\w+\([a-zA-Z,={}'-]+\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
     private static readonly Regex overloadedBoundedHyphenatedFunctionWithSingleOrMultipleParameters = new(@"(?:\w+-)+\w+\([a-zA-Z,={}'-]+\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
     private static readonly Regex unBoundFunctionRegex = new(@"^[0-9a-zA-Z\- \/_?:.,\s]+\(\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-    private static readonly Regex systemQueryOptionRegex = new(@"(\w*=\w*\(\D*|\d*\))|(\w*=\w*\D*)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-
+    private static readonly Regex systemQueryOptionRegex = new(@"\w*=\w*\(\D*|\d*\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private static readonly Regex apiPathWithSingleOrDoubleQuotesOnFunctions = new(@"(\/\w+)+\(\w*=(?:'|"").*(?:'|"")\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    
     private const string PathItemsKey = "default";
 
     public string GenerateCodeSnippet(SnippetModel snippetModel)
@@ -239,6 +240,7 @@ public partial class GraphCliGenerator : ILanguageGenerator<SnippetModel, OpenAp
         {
             if (systemQueryOptionRegex.IsMatch(snippetModel.QueryString))
             {
+                Console.WriteLine("Query string ==> "+snippetModel.QueryString);
                 string pattern = "\\?\\$\\w*=";
                 string[] splittedQueryString = Regex.Split(snippetModel.QueryString, pattern, RegexOptions.Compiled, TimeSpan.FromSeconds(5));
                 string queryOptionFunction = HttpUtility.UrlDecode(splittedQueryString[1]);


### PR DESCRIPTION
Fixes #1687 
**Expected executable snippet**
``mgc drives items get-activities-by-interval-with-start-date-time-with-end-date-time-with-interval get --start-date-time {start-date-time-id} --end-date-time {end-date-time-id} --interval {interval-id}  --drive-id {drive-id} --drive-item-id {driveItem-id}``
<img width="1057" alt="image" src="https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/a0a1d84a-a372-4721-a4e7-cdf7a5a3d1e7">
