### PR TITLE
Fixes missing snippets using alternate alternate keys.

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -863,6 +863,16 @@ namespace CodeSnippetsReflection.OpenAPI.Test
 
             Assert.Contains("var result = await graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Workbook.Worksheets[\"{workbookWorksheet-id}\"].RangeWithAddress(\"{address}\").GetAsync()", result);
         }
+        
+        [Fact]
+        public async Task MatchesPathAlternateKeys()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/applications(appId='46e6adf4-a9cf-4b60-9390-0ba6fb00bf6b')?$select=id,appId,displayName,requiredResourceAccess");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+
+            Assert.Contains("await graphClient.ApplicationsWithAppId(\"{appId}\").GetAsync(", result);
+        }
         [Theory]
         [InlineData("/me/drive/root/delta","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Delta.GetAsync()")]
         [InlineData("/groups/{group-id}/drive/items/{item-id}/children","graphClient.Drives[\"{drive-id}\"].Items[\"{driveItem-id}\"].Children.GetAsync()")]

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -226,8 +226,13 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                                              .SelectMany(static pathItem => pathItem.Value.Operations)
                                              .Where(operation => operation.Key.ToString().Equals(snippetModel.Method.ToString(), StringComparison.OrdinalIgnoreCase)) // get the operations that match the method
                                              .SelectMany(static operation => operation.Value.Parameters)
-                                             .Where(static parameter => parameter.In == ParameterLocation.Path); // find the parameters in the path
+                                             .Where(static parameter => parameter.In == ParameterLocation.Path).ToList(); // find the parameters in the path
 
+            pathParameters.AddRange(snippetModel.EndPathNode.PathItems.Values.SelectMany(static pathItem => pathItem.Parameters)
+                                            .Where(parameter => parameter.In == ParameterLocation.Path && 
+                                                                snippetModel.EndPathNode.Segment.IsFunctionWithParameters() && // don't include indexers
+                                                                snippetModel.EndPathNode.Segment.Contains(parameter.Name,StringComparison.OrdinalIgnoreCase)));// alternate keys will show up in the path item and not the operation
+            
             var parameters = new List<CodeProperty>();
             foreach (var parameter in pathParameters)
             {

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -226,12 +226,12 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
                                              .SelectMany(static pathItem => pathItem.Value.Operations)
                                              .Where(operation => operation.Key.ToString().Equals(snippetModel.Method.ToString(), StringComparison.OrdinalIgnoreCase)) // get the operations that match the method
                                              .SelectMany(static operation => operation.Value.Parameters)
-                                             .Where(static parameter => parameter.In == ParameterLocation.Path).ToList(); // find the parameters in the path
-
-            pathParameters.AddRange(snippetModel.EndPathNode.PathItems.Values.SelectMany(static pathItem => pathItem.Parameters)
-                                            .Where(parameter => parameter.In == ParameterLocation.Path && 
-                                                                snippetModel.EndPathNode.Segment.IsFunctionWithParameters() && // don't include indexers
-                                                                snippetModel.EndPathNode.Segment.Contains(parameter.Name,StringComparison.OrdinalIgnoreCase)));// alternate keys will show up in the path item and not the operation
+                                             .Where(static parameter => parameter.In == ParameterLocation.Path)// find the parameters in the path based on operation
+                                             .Union(snippetModel.EndPathNode.PathItems.Values.SelectMany(static pathItem => pathItem.Parameters)
+                                                 .Where(parameter => parameter.In == ParameterLocation.Path && 
+                                                                     snippetModel.EndPathNode.Segment.IsFunctionWithParameters() && // don't include indexers
+                                                                     snippetModel.EndPathNode.Segment.Contains(parameter.Name,StringComparison.OrdinalIgnoreCase))// alternate keys will show up in the path item and not the operation
+                                             );
             
             var parameters = new List<CodeProperty>();
             foreach (var parameter in pathParameters)


### PR DESCRIPTION
Examples with alternate paths fail to get generates or are not correctly generates as the alternate path keys are not added to the `pathParameters` collection in the Snippet code graph. The snippets are therefore generated with incorrect/missing arguments or fail.


This PR unblocks snippet generation in the doc pages such as 
https://learn.microsoft.com/en-us/graph/api/application-get?view=graph-rest-1.0&tabs=csharp#example-2-retrieve-an-application-by-its-appid-and-only-specific-properties
