### PR TITLE
Use deltatoken for delta snippets in dotnet

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/CSharpGeneratorTests.cs
@@ -218,7 +218,17 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("imAddresses/any(i:i eq 'admin@contoso.com')", result);
         }
         [Fact]
-        public async Task GeneratesSnippetForRequestWithSearchQueryOptionWithANDLogicalConjuction()
+        public async Task GeneratesSnippetForRequestWithDeltaAndSkipToken()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/calendarView/delta?$skiptoken=R0usmcCM996atia_s");
+            requestPayload.Headers.Add("Prefer", "odata.maxpagesize=2");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("var result = await deltaRequestBuilder.GetAsync(", result);
+            Assert.Contains("var deltaRequestBuilder = new Microsoft.Graph.Me.CalendarView.Delta.DeltaRequestBuilder(", result);
+        }
+        [Fact]
+        public async Task GeneratesSnippetForRequestWithSearchQueryOptionWithANDLogicalConjunction()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users?$search=\"displayName:di\" AND \"displayName:al\"");
             requestPayload.Headers.Add("ConsistencyLevel", "eventual");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -70,8 +70,9 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
             string pathSegment;
             if(codeGraph.Nodes.Last().Segment.Contains("delta") && 
-               codeGraph.Parameters.Any( property => property.Name.Equals("skiptoken",StringComparison.OrdinalIgnoreCase) || property.Name.Equals("deltatoken",StringComparison.OrdinalIgnoreCase)))
-            {// its a delta query and has an opaque url
+               codeGraph.Parameters.Any( static property => property.Name.Equals("skiptoken",StringComparison.OrdinalIgnoreCase) || 
+                                                            property.Name.Equals("deltatoken",StringComparison.OrdinalIgnoreCase)))
+            {// its a delta query and needs the opaque url passed over.
                 pathSegment = "deltaRequestBuilder";
                 codeGraph.Parameters = new List<CodeProperty>();// clear the query parameters as these will be provided in the url directly.
                 payloadSb.AppendLine($"var deltaRequestBuilder = new {GetDefaultNamespaceName(codeGraph.ApiVersion)}.{GetFluentApiPath(codeGraph.Nodes, codeGraph)}.DeltaRequestBuilder(\"{codeGraph.RequestUrl}\", {ClientVarName}.RequestAdapter);");

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -67,9 +67,23 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var requestPayloadParameterName = codeGraph.HasBody() ? RequestBodyVarName : default;
             if (string.IsNullOrEmpty(requestPayloadParameterName) && ((codeGraph.RequestSchema?.Properties?.Any() ?? false) || (codeGraph.RequestSchema?.AllOf?.Any(schema => schema.Properties.Any()) ?? false)))
                 requestPayloadParameterName = "null";// pass a null parameter if we have a request schema expected but there is not body provided
+
+            string pathSegment;
+            if(codeGraph.Nodes.Last().Segment.Contains("delta") && 
+               codeGraph.Parameters.Any( property => property.Name.Equals("skiptoken",StringComparison.OrdinalIgnoreCase) || property.Name.Equals("deltatoken",StringComparison.OrdinalIgnoreCase)))
+            {// its a delta query and has an opaque url
+                pathSegment = "deltaRequestBuilder";
+                codeGraph.Parameters = new List<CodeProperty>();// clear the query parameters as these will be provided in the url directly.
+                payloadSb.AppendLine($"var deltaRequestBuilder = new {GetDefaultNamespaceName(codeGraph.ApiVersion)}.{GetFluentApiPath(codeGraph.Nodes, codeGraph)}.DeltaRequestBuilder(\"{codeGraph.RequestUrl}\", {ClientVarName}.RequestAdapter);");
+            }
+            else
+            {
+                pathSegment = $"{ClientVarName}.{GetFluentApiPath(codeGraph.Nodes, codeGraph)}";
+            }
+            
             var requestConfigurationPayload = GetRequestConfiguration(codeGraph, indentManager);
             var parametersList = GetActionParametersList(requestPayloadParameterName , requestConfigurationPayload);
-            payloadSb.AppendLine($"{responseAssignment}await {ClientVarName}.{GetFluentApiPath(codeGraph.Nodes,codeGraph)}.{methodName}({parametersList});");
+            payloadSb.AppendLine($"{responseAssignment}await {pathSegment}.{methodName}({parametersList});");
         }
 
         private static string GetRequestConfiguration(SnippetCodeGraph snippetCodeGraph, IndentManager indentManager)

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -56,6 +56,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             PathParameters = parsePathParameters(snippetModel);
             Body = parseBody(snippetModel);
             ApiVersion = snippetModel.ApiVersion;
+            RequestUrl = $"https://graph.microsoft.com/{snippetModel.ApiVersion}{snippetModel.Path}{snippetModel.QueryString}";
         }
 
         public OpenApiSchema ResponseSchema
@@ -67,7 +68,12 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         {
             get; set;
         }
-
+        
+        public string RequestUrl
+        {
+            get; set;
+        }
+        
         public string ApiVersion
         {
             get; set;


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/279
This PR is part of https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1673. 

It updates the snippet generation for C# involving delta queries to use the raw request url in the request builder constructor as the url. 

Therefore an example snippet 
`GET https://graph.microsoft.com/v1.0/users/delta?$deltatoken=oEcOySpF_hWYmTIUZBOIfPzcwisr_rPe8o9M54L45qEXQGmvQC6T2dbL-9O7nSU-njKhFiGlAZqewNAThmCVnNxqPu5gOBegrm1CaVZ-ZtFZ2tPOAO98OD9y0ao460`

will result in the snippet below.

```cs
var graphClient = new GraphServiceClient(requestAdapter);

var deltaRequestBuilder = new Microsoft.Graph.Users.Delta.DeltaRequestBuilder("https://graph.microsoft.com/v1.0/users/delta?$deltatoken=oEcOySpF_hWYmTIUZBOIfPzcwisr_rPe8o9M54L45qEXQGmvQC6T2dbL-9O7nSU-njKhFiGlAZqewNAThmCVnNxqPu5gOBegrm1CaVZ-ZtFZ2tPOAO98OD9y0ao460", graphClient.RequestAdapter);
var result = await deltaRequestBuilder.GetAsync();
```