### PR TITLE
Fix PHP Snippets remove extra spaces and add `wait()` to fluent path

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -875,6 +875,6 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
         Assert.Contains("'owners@odata.bind' => [\n"+
-        "'https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2', 		],", result);
+        "'https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2', ],", result);
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -848,4 +848,35 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         Assert.Contains("->setQualityUpdatesPauseStartDate(new Date('2016-12-31'))", result);
         Assert.Contains("->setScheduledInstallTime(new Time('11:59:31.3170000'))", result);
     }
+
+    [Fact (Skip = "This is a known failure. Working on a fix")]
+    public async Task GenerateWithComplexArray()
+    {
+        const string body = @"
+          {
+          ""description"": ""Group with designated owner and members"",
+                ""displayName"": ""Operations group"",
+                ""groupTypes"": [
+                ],
+                ""mailEnabled"": false,
+                ""mailNickname"": ""operations2019"",
+                ""securityEnabled"": true,
+                ""owners@odata.bind"": [
+                     ""https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2""
+                ],
+                ""members@odata.bind"": [
+                    ""https://graph.microsoft.com/v1.0/users/ff7cb387-6688-423c-8188-3da9532a73cc"",
+                    ""https://graph.microsoft.com/v1.0/users/69456242-0067-49d3-ba96-9de6f2728e14""
+                ]
+            }";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/groups")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+        Assert.Contains("$requestBody = new Group()s;\n" +
+                        "$requestBody->setDescription('Self help community for library');\n" +
+                        "$requestBody->setDisplayName('Library Assist');", result);
+    }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using CodeSnippetsReflection.OpenAPI.LanguageGenerators;
@@ -123,6 +124,31 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         Assert.Contains("'Accept' => 'application/json',", result);
     }
 
+    [Fact]
+    public async Task GenerateForGroupPostTestSpacing()
+    {
+        const string body = @"
+            {
+                ""description"": ""Self help community for library"",
+                ""displayName"": ""Library Assist"",
+                ""groupTypes"": [
+                ""Unified""
+                    ],
+                ""mailEnabled"": true,
+                ""mailNickname"": ""library"",
+                ""securityEnabled"": false
+            }
+        ";
+        using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/groups")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+        var result = _generator.GenerateCodeSnippet(snippetModel);
+        Assert.Contains("$requestBody = new Group();\n" +
+                        "$requestBody->setDescription('Self help community for library');\n" +
+                        "$requestBody->setDisplayName('Library Assist');", result);
+    }
     [Fact]
     public async Task GeneratesComplicatedObjectsWithNesting()
     {
@@ -511,9 +537,9 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
             };
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains(@"'phone' => 		[", result);
+        Assert.Contains(@"'phone' => [", result);
         Assert.Contains("'@odata.type' => '#microsoft.graph.identity',", result);
-        Assert.Contains("'id' => '+12345678901', ", result);
+        Assert.Contains("'id' => '+12345678901',", result);
     }
 
     [Fact]
@@ -557,8 +583,8 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
             };
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("'http%3A//developer%2Emicrosoft%2Ecom' => 		[", result);
-        Assert.Contains("'https%3A//developer%2Emicrosoft%2Ecom/en-us/graph/graph-explorer' => 		[", result);
+        Assert.Contains("'http%3A//developer%2Emicrosoft%2Ecom' => [", result);
+        Assert.Contains("'https%3A//developer%2Emicrosoft%2Ecom/en-us/graph/graph-explorer' => [", result);
     }
 
     [Fact]
@@ -586,7 +612,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
         Assert.Contains("'eventQuery' => [", result);
-        Assert.Contains("'@odata.type' => 'microsoft.graph.security.eventQuery', ", result);
+        Assert.Contains("'@odata.type' => 'microsoft.graph.security.eventQuery',", result);
     }
 
     [Fact]
@@ -656,9 +682,9 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
         Assert.Contains("'value' => 'Welcome to the organization {{userDisplayName}}!',", result);
-        Assert.Contains("'executionConditions' => 		[", result);
-        Assert.Contains("'scope' => 				[", result);
-        Assert.Contains("'trigger' => 				[", result);
+        Assert.Contains("'executionConditions' => [", result);
+        Assert.Contains("'scope' => [", result);
+        Assert.Contains("'trigger' => [", result);
     }
 
     [Fact]

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -849,7 +849,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         Assert.Contains("->setScheduledInstallTime(new Time('11:59:31.3170000'))", result);
     }
 
-    [Fact (Skip = "This is a known failure. Working on a fix")]
+    [Fact]
     public async Task GenerateWithComplexArray()
     {
         const string body = @"
@@ -875,8 +875,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         };
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("$requestBody = new Group()s;\n" +
-                        "$requestBody->setDescription('Self help community for library');\n" +
-                        "$requestBody->setDisplayName('Library Assist');", result);
+        Assert.Contains("'owners@odata.bind' => [\n"+
+        "'https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2', 		],", result);
     }
 }

--- a/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PhpGeneratorTests.cs
@@ -36,7 +36,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
             new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/{{user-id}}/messages");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("->users()->byUserId('user-id')->messages()->get();", result);
+        Assert.Contains("->users()->byUserId('user-id')->messages()->get()->wait();", result);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
             $"{ServiceRootBetaUrl}/directory/deleteditems/microsoft.graph.group");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetBetaSnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("$result = $graphServiceClient->directory()->deletedItems()->graphGroup()->get();", result);
+        Assert.Contains("$result = $graphServiceClient->directory()->deletedItems()->graphGroup()->get()->wait();", result);
     }
 
     [Fact]
@@ -232,7 +232,7 @@ public class PhpGeneratorTests : OpenApiSnippetGeneratorTestBase
         using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/activities/recent");
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
-        Assert.Contains("$result = $graphServiceClient->me()->activities()->recent()->get();", result);
+        Assert.Contains("$result = $graphServiceClient->me()->activities()->recent()->get()->wait();", result);
     }
 
     [Fact /*(Skip = "Should fail by default.")*/]

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -10,7 +10,7 @@ using Microsoft.OpenApi.Services;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators;
 
-public partial class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
+public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
 {
     private const string ClientVarName = "$graphServiceClient";
     private const string ClientVarType = "GraphServiceClient";

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Extensions;

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -98,9 +98,9 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
         var indentManager = new IndentManager();
         var codeGraph = new SnippetCodeGraph(snippetModel);
         var payloadSb = new StringBuilder(
-            "<?php" + Environment.NewLine +
-            "// THIS SNIPPET IS A PREVIEW FOR THE KIOTA BASED SDK. NON-PRODUCTION USE ONLY" + Environment.NewLine +
-            $"{ClientVarName} = new {ClientVarType}({TokenContextVarName}, {ScopesVarName});{Environment.NewLine}");
+            "<?php" + Environment.NewLine + Environment.NewLine +
+            "// THIS SNIPPET IS A PREVIEW. NON-PRODUCTION USE ONLY" + Environment.NewLine +
+            $"{ClientVarName} = new {ClientVarType}({TokenContextVarName}, {ScopesVarName});{Environment.NewLine + Environment.NewLine}");
         if (codeGraph.HasBody())
         {
             WriteObjectProperty(RequestBodyVarName, payloadSb, codeGraph.Body, indentManager);
@@ -201,7 +201,6 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
     {
         var childPosition = 0;
         var objectType = (codeProperty.TypeDefinition ?? codeProperty.Name).ToFirstCharacterUpperCase();
-        payloadSb.AppendLine("");
         payloadSb.AppendLine($"${(childPropertyName ?? propertyAssignment).ToFirstCharacterLowerCase()} = new {ReplaceReservedWord(objectType)}();");
         foreach(CodeProperty child in codeProperty.Children)
         {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -389,7 +389,7 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
         {
             var childPropertyName = $"{EscapePropertyNameForSetterAndGetter(codeProperty.Name)}{EscapePropertyNameForSetterAndGetter(property.Name)}{++childPosition}".ToFirstCharacterLowerCase();
             var propertyCopy = property;
-            if (fromMap) propertyCopy.PropertyType = PropertyType.Map;
+            if (fromMap && property.PropertyType == PropertyType.Object) propertyCopy.PropertyType = PropertyType.Map;
 
             WriteCodeProperty(propertyAssignment, builder, codeProperty, propertyCopy, indentManager, childPosition,
                     childPropertyName, fromMap: fromMap);

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PhpGenerator.cs
@@ -106,7 +106,7 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
             WriteObjectProperty(RequestBodyVarName, payloadSb, codeGraph.Body, indentManager);
         }
         WriteRequestExecutionPath(codeGraph, payloadSb, indentManager);
-        return payloadSb.ToString().Trim('\n');
+        return payloadSb.ToString().Trim();
     }
 
     private static void WriteRequestExecutionPath(SnippetCodeGraph codeGraph, StringBuilder payloadSb, IndentManager indentManager)
@@ -344,7 +344,7 @@ public class PhpGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
             }
             WriteCodeProperty(propertyAssignment, payLoad, currentProperty, p2, indentManager, ++childPosition, default, true);
             payLoad.AppendLine();
-            payloadSb.AppendLine(payLoad.ToString().Trim(' ', '\t', '\n'));
+            payloadSb.AppendLine(payLoad.ToString().Trim());
         }
         indentManager.Unindent();
         payloadSb.AppendLine($"{indentManager.GetIndent()}{(parent.PropertyType == PropertyType.Object ? "];" : "]," )}");


### PR DESCRIPTION
- Remove additional spaces in the snippets.
- Change tests to account for `wait()` in fluent path.


## Overview

Brief description of what this PR does, and why it is needed.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output