### PR TITLE
Fix snippet generation pipeline.

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Threading;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
@@ -21,14 +20,13 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private const string requestBodyVarName = "params";
         private const string modulePrefix = "Microsoft.Graph";
         private const string mgCommandMetadataUrl = "https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/src/Authentication/Authentication/custom/common/MgCommandMetadata.json";
-        private readonly Lazy<IList<PowerShellCommandInfo>> psCommands = new(
+        private static readonly SimpleLazy<IList<PowerShellCommandInfo>> psCommands = new(
             () =>
             {
                 using var httpClient = new HttpClient();
                 using var stream = httpClient.GetStreamAsync(mgCommandMetadataUrl).GetAwaiter().GetResult();
                 return JsonSerializer.Deserialize<IList<PowerShellCommandInfo>>(stream);
-            },
-            LazyThreadSafetyMode.PublicationOnly
+            }
         );
         private static readonly Regex meSegmentRegex = new("^/me($|(?=/))", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static readonly Regex encodedQueryParamsPayLoad = new(@"\w*\+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -279,7 +279,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         }
 
         private static readonly Regex keyIndexRegex = new(@"(?<={)(.*?)(?=})", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-        private IList<PowerShellCommandInfo> GetCommandForRequest(string path, string method, string apiVersion)
+        private static IList<PowerShellCommandInfo> GetCommandForRequest(string path, string method, string apiVersion)
         {
             if (psCommands.Value.Count == 0)
                 return default;

--- a/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
+++ b/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
@@ -21,7 +21,7 @@ namespace CodeSnippetsReflection.OpenAPI
 
         public SimpleLazy(Func<T> valueFactory)
         {
-            this.valueFactory = valueFactory ?? throw new ArgumentNullException("valueFactory");
+            this.valueFactory = valueFactory ?? throw new ArgumentNullException(nameof(valueFactory));
             this.instance = null;
         }
 

--- a/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
+++ b/CodeSnippetsReflection.OpenAPI/SimpleLazy.cs
@@ -21,10 +21,7 @@ namespace CodeSnippetsReflection.OpenAPI
 
         public SimpleLazy(Func<T> valueFactory)
         {
-            if (valueFactory == null)
-                throw new ArgumentNullException("valueFactory");
-
-            this.valueFactory = valueFactory;
+            this.valueFactory = valueFactory ?? throw new ArgumentNullException("valueFactory");
             this.instance = null;
         }
 
@@ -32,8 +29,11 @@ namespace CodeSnippetsReflection.OpenAPI
         {
             get
             {
+                if (instance != null)
+                    return instance;// no need to acquire the lock if the instance is already initialized.
+                
                 lock (locker)
-                    return instance ?? (instance = valueFactory());
+                    return instance ??= valueFactory();
             }
         }
     }


### PR DESCRIPTION
This PR fixes the timing out of the snippet generation pipeline caused by the error in the metadata capture in https://github.com/microsoft/OpenAPI.NET.OData/issues/414

In summary, changes include
- Trace out errors in the openApi metadata([similar to Kiota](https://github.com/microsoft/kiota/blob/b8295058cb28070335d4ee1ef64d89c166a8f22b/src/Kiota.Builder/KiotaBuilder.cs#L440)) rather than throwing an InvalidOperationException to allow for generation where possible.
- Updated `SimpleLazy` to only acquire the lock when uninitialized to prevent unnecessary waits/locks on reads increasing generation time..
- Cache `ISnippetsGenerator` instances in the `CodeSnippetsReflection.App` to avoid multiple loads of the metadata increasing generation time.

Sample run can be found at [here ](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=123173&view=logs&j=3a1ba152-0889-5172-ee77-641fbcfabfa4&t=3a1ba152-0889-5172-ee77-641fbcfabfa4)with generation time cut down to about 15mins from 40+ mins