### PR TITLE
Handle regex creation errors

### DIFF
--- a/PermissionsService/Services/PermissionsStore.cs
+++ b/PermissionsService/Services/PermissionsStore.cs
@@ -353,6 +353,7 @@ namespace PermissionsService
                             RequestUrl = request.RequestUrl,
                             Message = exception.Message
                         });
+                        _telemetryClient?.TrackException(exception);
                     }
                 });
 

--- a/UriMatchService/UriTemplateMatcher.cs
+++ b/UriMatchService/UriTemplateMatcher.cs
@@ -69,13 +69,20 @@ namespace UriMatchingService
             var templateMatches = new Dictionary<KeyValuePair<string, string>, int>(); // {{ templateKey, foundParameterCount }}
             foreach (var template in _templates)
             {
-                var parameters = GetParameters(absolutePath, template.Value);
-                if (parameters != null)
+                try
                 {
-                    if (parameters.Count == 0)
-                        return new TemplateMatch() { Key = template.Key, Template = template.Value }; // exact match, no ids
-                    else 
-                        templateMatches.Add(template, parameters.Count);
+                    var parameters = GetParameters(absolutePath, template.Value);
+                    if (parameters != null)
+                    {
+                        if (parameters.Count == 0)
+                            return new TemplateMatch() { Key = template.Key, Template = template.Value }; // exact match, no ids
+                        else
+                            templateMatches.Add(template, parameters.Count);
+                    }
+                }
+                catch (Exception)
+                {
+                    continue;
                 }
             }
 

--- a/UriMatchService/UriTemplateMatcher.cs
+++ b/UriMatchService/UriTemplateMatcher.cs
@@ -76,7 +76,7 @@ namespace UriMatchingService
                     {
                         if (parameters.Count == 0)
                             return new TemplateMatch() { Key = template.Key, Template = template.Value }; // exact match, no ids
-                        else
+                        else if(!templateMatches.ContainsKey(template))
                             templateMatches.Add(template, parameters.Count);
                     }
                 }


### PR DESCRIPTION
## Overview
Fixes #1633 

If template with no closing bracket is encountered, e.g. in `/employeeexperience/learningproviders/{id}/learningcourseactivities(extern`, an exception is thrown. 

This PR handles the exception.