### PR TITLE
Use correct parameter name for request body in api call

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/PythonGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/PythonGeneratorTests.cs
@@ -295,7 +295,7 @@ public class PythonGeneratorTests : OpenApiSnippetGeneratorTestBase
         var result = _generator.GenerateCodeSnippet(snippetModel);
         Assert.Contains("request_body = ReferenceCreate(", result);
         Assert.Contains("odata_id = \"https://graph.microsoft.com/beta/users/alexd@contoso.com\"", result);
-        Assert.Contains(".accepted_senders.ref.post(request_body = request_body)", result);
+        Assert.Contains(".accepted_senders.ref.post(body = request_body)", result);
     }
     [Fact]
     public async Task GenerateSnippetsWithArrayNesting()
@@ -439,7 +439,7 @@ public class PythonGeneratorTests : OpenApiSnippetGeneratorTestBase
         var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
         var result = _generator.GenerateCodeSnippet(snippetModel);
 
-        Assert.Contains("graph_client.users.by_user_id('user-id').send_mail.post(request_body = request_body)", result);
+        Assert.Contains("graph_client.users.by_user_id('user-id').send_mail.post(body = request_body)", result);
         Assert.Contains("request_body = SendMailPostRequestBody(", result);
         Assert.Contains("to_recipients = [", result);
     }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PythonGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PythonGenerator.cs
@@ -78,7 +78,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 ? $"{RequestConfigurationVarName} = {RequestConfigurationVarName}"
                 : string.Empty;
             var bodyParameter = codeGraph.HasBody()
-                ? $"{RequestBodyVarName} = {RequestBodyVarName}"
+                ? $"body = {RequestBodyVarName}"
                 : string.Empty;
             var optionsParameter = codeGraph.HasOptions() ? "options =" : string.Empty;
             var returnVar = codeGraph.HasReturnedBody() ? "result = " : string.Empty;


### PR DESCRIPTION
## Overview

Renames parameter name for request body in api call from `request_body = request_body` to `body = request_body`.

Fixes https://github.com/microsoftgraph/microsoft-graph-docs-contrib/issues/8427

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output