### PR TITLE
Update permissions file source used to generating permissions tables for docs

### DIFF
--- a/pipelines/docs-permissions.yml
+++ b/pipelines/docs-permissions.yml
@@ -31,7 +31,7 @@ pool:
      
 parameters:
   - name: permissionsSourceFilePath
-    default: 'https://raw.githubusercontent.com/microsoftgraph/microsoft-graph-devx-content/dev/permissions/new/permissions.json'
+    default: 'https://raw.githubusercontent.com/microsoftgraph/microsoft-graph-devx-content/master/permissions/new/permissions.json'
     displayName: 'The file path or URL to permissions in JSON format to be consumed by Kibali'
   - name: bootstrappingOnly
     type: boolean


### PR DESCRIPTION

## Overview

Default permissions file source to `master` branch of DevX content repo.