### PR TITLE
Fixes ``filterByCurrentUser`` snippets that don't match Http Snippet

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -59,10 +59,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                     if (wrongQoutesInStringLiterals.IsMatch(requestPayload))
                     {
                         requestPayload = requestPayload.Replace("\"{", "'{").Replace("}\"", "}'");
-                    }    
+                    }
                     snippetBuilder.Append($"{Environment.NewLine}{requestPayload}");
                 }
-                    
+
 
                 if (isMeSegment)
                     snippetBuilder.Append($"{Environment.NewLine}# A UPN can also be used as -UserId.");
@@ -130,7 +130,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         public static string ReturnCleanParamsPayload(string queryParamsPayload)
         {
-            if(encodedQueryParamsPayLoad.IsMatch(queryParamsPayload))
+            if (encodedQueryParamsPayLoad.IsMatch(queryParamsPayload))
                 return queryParamsPayload.Replace("+", " ");
             return queryParamsPayload;
         }
@@ -408,13 +408,13 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 var function = paths.Last();
                 var functionItems = function.Split("(");
                 var functionParameters = functionItems[1].Split(",");
-                foreach(var param in functionParameters)
+                foreach (var param in functionParameters)
                 {
                     var paramKeys = param.Split("=")[0];
                     var paramKey = $"-{paramKeys.ToFirstCharacterUpperCase()} ${paramKeys}Id ";
                     paramBuilder.Append(paramKey);
                 }
-        
+
             }
             return paramBuilder.ToString();
         }

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/PowerShellGenerator.cs
@@ -32,7 +32,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static readonly Regex encodedQueryParamsPayLoad = new(@"\w*\+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static readonly Regex wrongQoutesInStringLiterals = new(@"""\{", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         private static readonly Regex functionWithParams = new(@"^[0-9a-zA-Z\- \/_?:.,\s]+\([\w*='{\w*}\',]*\)|^[0-9a-zA-Z\- \/_?:.,\s]+\([\w*='\w*\',]*\)|^[0-9a-zA-Z\- \/_?:.,\s]+\([\w*={w*},]*\)|^[0-9a-zA-Z\- \/_?:.,\s]+\([\w*=<w*>,]*\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-        private static readonly Regex functionWithoutParams = new(@"\w*\(\)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
         public string GenerateCodeSnippet(SnippetModel snippetModel)
         {
             var indentManager = new IndentManager();
@@ -44,7 +43,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var lastPathSegment = snippetModel.EndPathNode.Segment;
             var hasMicrosoftPrefix = lastPathSegment.StartsWith("microsoft", StringComparison.OrdinalIgnoreCase);
             cleanPath = SubstituteIdentityProviderSegment(cleanPath, isIdentityProvider);
-            cleanPath = ReplaceFunctionSegments(lastPathSegment, cleanPath);
             cleanPath = SubstituteGraphSegment(cleanPath, hasGraphPrefix);
             cleanPath = SubstituteMicrosoftSegment(cleanPath, hasMicrosoftPrefix, lastPathSegment);
             var (path, additionalKeySegmentParmeter) = SubstituteMeSegment(isMeSegment, cleanPath, lastPathSegment);
@@ -150,15 +148,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             }
             return (path, additionalKeySegmentParmeter);
         }
-
-        private static string ReplaceFunctionSegments(string lastPathSegment, string path)
-        {
-            var segmentItems = lastPathSegment.Split("(");
-            if (functionWithoutParams.IsMatch(lastPathSegment) || functionWithParams.IsMatch(lastPathSegment))
-                path = path.Replace(lastPathSegment, segmentItems[0]);
-            return path;
-        }
-
         private static string SubstituteGraphSegment(string path, bool hasGraphPrefix)
         {
             if (hasGraphPrefix)


### PR DESCRIPTION
Fixes #1023 
**Current snippet**
No PowerShell snippet available for ``/beta/roleManagement/directory/roleEligibilitySchedules/filterByCurrentUser(on='principal')``
See [here](https://learn.microsoft.com/en-us/graph/api/unifiedroleeligibilityschedule-filterbycurrentuser?view=graph-rest-beta&tabs=http#request)

**Expected outcome**
<img width="623" alt="image" src="https://github.com/microsoftgraph/microsoft-graph-devx-api/assets/10947120/6aca4df5-ec00-4078-a783-e7619049d4fa">
