### PR TITLE
Fix left out case on simplifying nested if

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -129,36 +129,36 @@ stages:
         'HTTP v1 Stable':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'v1'
-          SNIPPET_CATEGORY: 'Stable'
+          TEST_CATEGORY: 'Stable'
         'HTTP v1 KnownIssues':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'v1'
-          SNIPPET_CATEGORY: 'KnownIssues'
+          TEST_CATEGORY: 'KnownIssues'
         'HTTP beta Stable':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-          SNIPPET_CATEGORY: 'Stable'
+          TEST_CATEGORY: 'Stable'
         'HTTP beta KnownIssues':
           SNIPPET_LANGUAGE: 'http'
           GRAPH_VERSION: 'beta'
-          SNIPPET_CATEGORY: 'KnownIssues'
+          TEST_CATEGORY: 'KnownIssues'
         ${{ each language in parameters.snippetLanguages }}:
           '${{ language }} v1 Stable':
             SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'v1'
-            SNIPPET_CATEGORY: 'Stable'
+            TEST_CATEGORY: 'Stable'
           '${{ language }} v1 KnownIssues':
             SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'v1'
-            SNIPPET_CATEGORY: 'KnownIssues'
+            TEST_CATEGORY: 'KnownIssues'
           '${{ language }} beta Stable':
             SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'beta'
-            SNIPPET_CATEGORY: 'Stable'
+            TEST_CATEGORY: 'Stable'
           '${{ language }} beta KnownIssues':
             SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'beta'
-            SNIPPET_CATEGORY: 'KnownIssues'
+            TEST_CATEGORY: 'KnownIssues'
 
     steps:
     - template: templates/run-tests.yml

--- a/pipelines/templates/run-tests.yml
+++ b/pipelines/templates/run-tests.yml
@@ -31,8 +31,8 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 - pwsh: |
-    Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION, $env:SNIPPET_CATEGORY "
-    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger "trx;logfilename=$(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(SNIPPET_CATEGORY) TestResults.trx" --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
+    Write-Host "Running tests for language: $env:SNIPPET_LANGUAGE, version: $env:GRAPH_VERSION, $env:TEST_CATEGORY "
+    dotnet test ./CodeSnippetsPipeline.Test/ --configuration $env:BUILD_CONFIGURATION --logger "trx;logfilename=$(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(TEST_CATEGORY) TestResults.trx" --results-directory $env:BUILD_ARTIFACTSTAGINGDIRECTORY/TestResults
   displayName: 'Run CodeSnippetsPipeline.Test'
   env:
     BUILD_CONFIGURATION: '$(buildConfiguration)'
@@ -43,8 +43,8 @@ steps:
   displayName: 'Publish test results'
   inputs:
     testResultsFormat: 'VSTest'
-    testResultsFiles: '**/$(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(SNIPPET_CATEGORY) TestResults.trx'
-    testRunTitle: '$(Build.Reason) Snippet Generation $(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(SNIPPET_CATEGORY)'
+    testResultsFiles: '**/$(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(TEST_CATEGORY) TestResults.trx'
+    testRunTitle: '$(Build.Reason) Snippet Generation $(SNIPPET_LANGUAGE) $(GRAPH_VERSION) $(TEST_CATEGORY)'
     searchFolder: '$(Build.ArtifactStagingDirectory)/TestResults'
     mergeTestResults: false
     failTaskOnFailedTests: false


### PR DESCRIPTION
## Overview

I have realized that all tests run without filters into their correct test categories as should have been the case. This was caused by an error in addressing a PR comment of avoiding nested if.

The following fix should resolve the problem.
Related to #1743

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1792)