### PR TITLE
Fixes generation with complex parameters

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -17,9 +17,6 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
 {
     public record SnippetCodeGraph
     {
-
-        private static readonly Regex nestedStatementRegex = new(@"([/\w]+)(\([^)]+\))", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-
         private static readonly Regex splitCommasExcludingBracketsRegex = new(@"([^,\(\)]+(\(.*?\))*)+", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
         private static readonly CodeProperty EMPTY_PROPERTY = new() { Name = null, Value = null, Children = null, PropertyType = PropertyType.Default };


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-docs-contrib/issues/8735

Nested statements are inadvertently removed during snippet generation by the  SnippetCodegraph.

Sample generation available at https://github.com/microsoftgraph/microsoft-graph-docs/compare/preview-snippet-generation/128645
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1816)