### PR TITLE
Update Go snippet generation to use newer inlineSchema prefixes in me…

### DIFF
--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/CSharpGenerator.cs
@@ -89,7 +89,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 requestPayloadParameterName = "null";// pass a null parameter if we have a request schema expected but there is not body provided
 
             string pathSegment = $"{ClientVarName}.{GetFluentApiPath(codeGraph.Nodes, codeGraph,usedNamespaces)}";
-            var methodName = codeGraph.GetInlinedSchemaFunctionCallPrefix() + "Async";
+            var methodName = codeGraph.GetSchemaFunctionCallPrefix() + "Async";
             if(codeGraph.Parameters.Any( static property => property.Name.Equals("skiptoken",StringComparison.OrdinalIgnoreCase) ||
                                                             property.Name.Equals("deltatoken",StringComparison.OrdinalIgnoreCase)))
             {// its a delta query and needs the opaque url passed over.

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -336,8 +336,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static void WriteExecutionStatement(SnippetCodeGraph codeGraph, StringBuilder builder, params string[] parameters)
         {
-            var methodName = $"{codeGraph.HttpMethod.ToString().ToLowerInvariant().ToFirstCharacterUpperCase()}";
-
+            var methodName = codeGraph.GetSchemaFunctionCallPrefix();
             var parametersList = GetActionParametersList(parameters);
             var resultVarName = GetResultVarName(codeGraph);
             var returnStatement = codeGraph.HasReturnedBody() ? $"{resultVarName}, err := " : "";
@@ -597,7 +596,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 string varNames = String.Join(", ", funcWithParams.Item3.Keys.Select(item => "&" + item));
                 return $"{funcWithParams.Item2.ToFirstCharacterUpperCase()}{withNames}({varNames}).";
 
-                
+
             })
                         .Aggregate(new List<String>(), (current, next) =>
                         {

--- a/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
+++ b/CodeSnippetsReflection.OpenAPI/ModelGraph/SnippetCodeGraph.cs
@@ -111,7 +111,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
         {
             get; set;
         }
-       
+
         public bool HasHeaders()
         {
             return Headers.Any();
@@ -574,7 +574,7 @@ namespace CodeSnippetsReflection.OpenAPI.ModelGraph
             );
             return parameterString;
         }
-        public string GetInlinedSchemaFunctionCallPrefix(){
+        public string GetSchemaFunctionCallPrefix(){
             var methodNameinPascalCase = HttpMethod.Method.ToLowerInvariant().ToFirstCharacterUpperCase();
             var functionNamePrefix = methodNameinPascalCase;
             //if codeGraph.ResponseSchema.Reference is null then recreate functionNamePrefix for inline schema with the following format


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1961
- Only Go has the inline schema changes other than dotnet which was already updated earlier
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1982)