### PR TITLE
Align Go snippet gen spec

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -98,7 +98,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/me/messages");
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
             var result = _generator.GenerateCodeSnippet(snippetModel);
-            Assert.Contains("graphClient := msgraphsdk.NewGraphServiceClientWithCredentials(cred, scopes)", result);
+            Assert.Contains("To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go", result);
         }
         [Fact]
         public async Task GeneratesMultipleImportStatements()

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -190,13 +190,11 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static void writeSnippet(SnippetCodeGraph codeGraph, StringBuilder builder)
         {
-            builder.AppendLine("// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go");
-
-            builder.AppendLine($"{clientVarName} := msgraphsdk.New{clientVarType}({clientFactoryVariables}){Environment.NewLine}{Environment.NewLine}");
             writeHeadersAndOptions(codeGraph, builder);
             WriteBody(codeGraph, builder);
             builder.AppendLine("");
 
+            builder.AppendLine("// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go");
             WriteExecutionStatement(
                 codeGraph,
                 builder,

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -51,6 +51,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var snippetBuilder = new StringBuilder();
             snippetBuilder.AppendLine("");
 
+            var latestMajorVersion = "v1.0".Equals(codeGraph.ApiVersion) ? "v1.*" : "v0.*";
+            snippetBuilder.AppendLine($"// Code snippets are only available for the latest major version. Current major version is ${latestMajorVersion}");
+            snippetBuilder.AppendLine("");
+
             writeImportStatements(codeGraph, snippetBuilder);
             writeSnippet(codeGraph, snippetBuilder);
 
@@ -59,6 +63,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static void writeImportStatements(SnippetCodeGraph codeGraph, StringBuilder builder)
         {
+            builder.AppendLine("// Dependencies");
             var apiVersion = "v1.0".Equals(codeGraph.ApiVersion) ? "msgraph-sdk-go" : "msgraph-beta-sdk-go";
             builder.AppendLine("import (");
             builder.AppendLine("\t  \"context\""); // default
@@ -185,6 +190,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static void writeSnippet(SnippetCodeGraph codeGraph, StringBuilder builder)
         {
+            builder.AppendLine("// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go");
+
             builder.AppendLine($"{clientVarName} := msgraphsdk.New{clientVarType}({clientFactoryVariables}){Environment.NewLine}{Environment.NewLine}");
             writeHeadersAndOptions(codeGraph, builder);
             WriteBody(codeGraph, builder);


### PR DESCRIPTION
## Overview

Update go snippet generation to align with spec
Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1936 

### Demo

```go
// Code snippets are only available for the latest major version. Current major version is v1.*

// Dependencies
import (
	  "context"
	  abstractions "github.com/microsoft/kiota-abstractions-go"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphgroups "github.com/microsoftgraph/msgraph-sdk-go/groups"
	  //other-imports
)

headers := abstractions.NewRequestHeaders()
headers.Add("ConsistencyLevel", "eventual")


requestFilter := "groupTypes/any(c:c eq 'Unified')"

requestParameters := &graphgroups.GroupsRequestBuilderGetQueryParameters{
	Filter: &requestFilter,
}
configuration := &graphgroups.GroupsRequestBuilderGetRequestConfiguration{
	Headers: headers,
	QueryParameters: requestParameters,
}

// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go
groups, err := graphClient.Groups().Get(context.Background(), configuration)

```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2041)