### PR TITLE
Move script to create reports to devxapi (#2025)

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -159,6 +159,53 @@ stages:
             SNIPPET_LANGUAGE: ${{ lower(language) }}
             GRAPH_VERSION: 'beta'
             TEST_CATEGORY: 'KnownIssues'
-
     steps:
     - template: templates/run-tests.yml
+- stage: GenerateRunTestReports
+  dependsOn: RunTests
+  displayName: GenerateRunTestReports
+  jobs:
+  - job: GenerateCategorizationReport
+    steps:
+      - checkout: self
+        displayName: checkout GE api
+        fetchDepth: 1
+        submodules: recursive
+        persistCredentials: true
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download RunTests artifact'
+        inputs:
+          artifact: 'Generation Test Results'
+          path: '$(Build.ArtifactStagingDirectory)/TestResults'
+      - pwsh: |
+          Write-Host "Installing module ImportExcel"
+          Install-Module -Name ImportExcel -Scope CurrentUser -Force -AllowClobber
+          Write-Host "Installing module Microsoft.Graph"
+          Install-Module Microsoft.Graph -Repository PSGallery -Scope CurrentUser -AcceptLicense -Force -AllowClobber
+          Write-Host "Finished installing dependencies"
+        displayName: Install script dependencies
+        workingDirectory: '$(Build.SourcesDirectory)'
+
+      - pwsh: |
+          Write-Host "create file appSettings.json in the workingDirectory"
+          New-Item -Path $(Build.SourcesDirectory) -Name "appSettings.json" -ItemType "file" -Force
+          Write-Host "Creating folder Reports"
+          New-Item -Path $(Build.SourcesDirectory) -Name "Reports" -ItemType "Directory" -Force
+        displayName: Create requisite directory items
+
+      - pwsh: |
+          $ErrorActionPreference="Continue"
+          $(Build.SourcesDirectory)/scripts/categorizeErrors.ps1 -trxFolderPath '$(Build.ArtifactStagingDirectory)/TestResults/' -txtOutputFolderPath '$(Build.ArtifactStagingDirectory)/Reports/'
+        displayName: Generate error category report
+        workingDirectory: '$(Build.SourcesDirectory)'
+        env:
+          RAPTOR_CONFIGCONNECTIONSTRING: $(RAPTOR_CONFIGCONNECTIONSTRING)
+        continueOnError: true
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish categorization report as artifact'
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/Reports/'
+          ArtifactName: 'ErrorCategorizationReport'
+          publishLocation: 'Container'

--- a/scripts/categorizeErrors.ps1
+++ b/scripts/categorizeErrors.ps1
@@ -1,0 +1,118 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$trxFolderPath,
+    [Parameter(Mandatory=$false)]
+    [string]$txtOutputFolderPath
+)
+
+Import-Module ImportExcel
+
+if (!(Test-Path $trxFolderPath))
+{
+    Write-Error "Folder not found at $trxFolderPath";
+    exit
+}
+
+#if $txtOutputFolderPath is not set, use current directory
+if (-not $txtOutputFolderPath)
+{
+    $txtOutputFolderPath = $PSScriptRoot
+}
+
+$outcomeLocal = "Failed"  # Only process failed tests
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+# Get Script getWorkloadOwner.ps1
+$getWorkloadOwnersScript = Join-Path $scriptDir "getWorkloadOwner.ps1"
+. $getWorkloadOwnersScript
+
+# create a dicionary to cache workload owners
+$workloadOwnersCache = @{}
+
+#Create 4 lists each mapping to category "methodNotFound", "pathNotFound","invalidStart", "other"
+$methodNotFound = @()
+$pathNotFound = @()
+$invalidStart = @()
+$other = @()
+
+$files = Get-ChildItem -Path $trxFolderPath -Exclude "http*"
+$SpecificErrorPattern = "/home/vsts/work/1/a/Snippets/"
+foreach ($trxFilePath in $files){
+    Write-Host "Processing file $trxFilePath"
+    [xml]$xmlContent = Get-Content $trxFilePath
+
+    $sourcefile = $trxFilePath.Name.Split("TestResults")[0].Trim()
+
+    $resultsContent = $xmlContent.TestRun.Results.UnitTestResult |
+      Where-Object { $_.outcome -eq $outcomeLocal } |
+      Select-Object -property startTime, testName, @{label="methodAndEndpoint"; Expression={$_.InnerText.Split("Host:")[0].Split("Original HTTP Snippet:")[1].Trim().Split(" ")}}, @{label='specificError'; expression={$_.InnerText.Split($SpecificErrorPattern)[1].Split(" at ")[0].trim()}} |
+      Select-Object -Property startTime, testName, @{label="sourceFile"; Expression={$sourceFile}}, @{label="method"; expression={$_.methodAndEndpoint[0]}}, @{label="endpoint"; Expression={$_.methodAndEndpoint[1]}}, specificError |
+      Sort-Object
+
+    if($resultsContent.Count -eq 0){
+        Write-Host "Specified pattern not found in $trxFilePath"
+        continue
+    }
+    foreach ($result in $resultsContent)
+    {
+        # find endpoint using getWorkloadOwner.ps1
+        $version = $result.endpoint.Contains("v1.0") ? "v1.0" : "beta"
+        $urlSections = $result.endpoint.Split($version+"/")
+        if($urlSections.Count -gt 1){
+            $endpoint =  $urlSections[1]
+        } else{
+            Write-Warning "Endpoint not found in $($result.endpoint)"
+            continue
+        }
+        $endpoint = $endpoint.Trim()
+        Write-Host "Fetching Workload owner for endpoint ${endpoint}"
+        # remove params from endpoint and save as var cacheKey
+        $cacheKey = $endpoint.Split("?")[0].Trim()
+        if ($workloadOwnersCache.ContainsKey($cacheKey))
+        {
+            $owner = $workloadOwnersCache[$cacheKey]
+            write-host "Using cached value $owner for $cacheKey"
+        }
+        else
+        {
+            try {
+                $owner = Get-WorkloadOwner -Endpoint $endpoint -IsFullUri $false -GraphApiVersion $version
+                $workloadOwnersCache[$cacheKey] = $owner
+            }
+            catch {
+                Write-Warning $_
+                $owner = $null
+            }
+        }
+        # add owner to result
+        $result | Add-Member -MemberType NoteProperty -Name "owner" -Value $owner
+
+        # assign result to appropriate category
+        $specificError = $result.specificError
+        if ($specificError -match "HTTP Method .*")
+        {
+            $methodNotFound += $result
+        }
+        elseif ($specificError -match "Path segment .*")
+        {
+            $pathNotFound += $result
+        }
+        elseif ($specificError -match ".* is an invalid start")
+        {
+            $invalidStart += $result
+        }
+        else
+        {
+            $other += $result
+        }
+    }
+
+}
+
+$excelOutputPath = Join-Path $txtOutputFolderPath "report.xlsx"
+$methodNotFound | Export-Excel -Path $excelOutputPath -WorksheetName "MethodNotFound" -AutoSize
+$pathNotFound | Export-Excel -Path $excelOutputPath -WorksheetName "PathNotFound" -AutoSize
+$invalidStart | Export-Excel -Path $excelOutputPath -WorksheetName "InvalidStart" -AutoSize
+$other | Export-Excel -Path $excelOutputPath -WorksheetName "Other" -AutoSize
+
+Write-Host "Categorization complete. Output saved to $excelOutputPath"

--- a/scripts/getWorkloadOwner.ps1
+++ b/scripts/getWorkloadOwner.ps1
@@ -1,0 +1,113 @@
+using namespace System.Diagnostics.CodeAnalysis
+[SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Scope='Function', Target='Get-WorkloadOwner')]
+[SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Scope='Function', Target='Connect-Tenant')]
+[SuppressMessageAttribute('PSUseSingularNouns', '', Scope='Function', Target='Get-AppSettings')]
+param()
+
+$Global:AppSettings = $null
+
+
+<#
+    Connect to the Raptor Tenant
+#>
+Function Connect-Tenant
+{
+    [CmdletBinding()]
+    param(
+        [Bool]$IsEducation = $false
+    )
+    $appToken = Get-DefaultAppApplicationToken -IsEducation $IsEducation
+    $appToken = $appToken | ConvertTo-SecureString -AsPlainText -Force
+    Connect-MgGraph -AccessToken $appToken | Out-Null
+}
+
+function Get-AppSettings ()
+{
+    if($null -ne $Global:AppSettings){
+        return $AppSettings
+    }
+    # read app settings from Azure App Config
+    $appSettingsPath = "./appSettings.json"
+    # Support Reading Settings from a Custom Label, otherwise default to Development
+    $settingsLabel = $env:RAPTOR_CONFIGLABEL
+    if ([string]::IsNullOrWhiteSpace($settingsLabel))
+    {
+        $settingsLabel = "Development"
+    }
+    az appconfig kv export --connection-string $env:RAPTOR_CONFIGCONNECTIONSTRING --label $settingsLabel --destination file --path $appSettingsPath --format json --yes
+    $appSettings = Get-Content $AppSettingsPath -Raw | ConvertFrom-Json
+    Remove-Item $appSettingsPath
+
+    if (    !$appSettings.CertificateThumbprint `
+            -or !$appSettings.ClientID `
+            -or !$appSettings.Username `
+            -or !$appSettings.Password `
+            -or !$appSettings.TenantID)
+    {
+        Write-Error -ErrorAction Stop -Message "please provide CertificateThumbprint, ClientID, Username, Password and TenantID in appsettings.json"
+    }
+    $Global:AppSettings = $appSettings
+    return $appSettings
+}
+
+function Get-CurrentDomain (
+    [Parameter(Mandatory=$true)][String]$DomainUsername
+)
+{
+    $domain = $DomainUsername.Split("@")[1]
+    return $domain
+}
+
+function Get-DefaultAppApplicationToken
+{
+    param(
+        $IsEducation = $false
+    )
+    $AppSettings = Get-AppSettings
+    $grantType = "client_credentials"
+    $tenantUsername = $IsEducation ? $AppSettings.EducationUsername : $AppSettings.Username
+    $domain = Get-CurrentDomain -DomainUsername $tenantUsername
+    $tokenEndpoint = "https://login.microsoftonline.com/$domain/oauth2/v2.0/token"
+    $ScopeString = "https://graph.microsoft.com/.default" # Always use this for app permissions
+    $clientID, $clientSecret = $IsEducation ? ($AppSettings.EducationClientID, $AppSettings.EducationClientSecret) : ($AppSettings.ClientID, $AppSettings.ClientSecret)
+    $body = "grant_type=$grantType&client_id=$clientID&client_secret=$ClientSecret&scope=$($ScopeString)"
+    try
+    {
+        $response = Invoke-RestMethod -Method Post -Uri $tokenEndpoint -Body $body -ContentType 'application/x-www-form-urlencoded'
+
+        Write-Debug "Received Token with .default Scopes"
+        return $response.access_token
+    } catch
+    {
+        Write-Error $_
+        throw
+    }
+}
+
+# A function that takes an endpoint and returns its owner
+function Get-WorkloadOwner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)][string] $Endpoint,
+        [bool] $IsFullUri=$true,
+        [string] $GraphApiVersion="v1.0"
+    )
+    Connect-Tenant
+    #ToDo delegated perms once issue with MFA is resolved
+    # if ($Endpoint -contains "me/")
+    # {
+    #     $userToken = Get-DelegatedAppToken | ConvertTo-SecureString -AsPlainText -Force
+    #     Connect-MgGraph -AccessToken $userToken.access_token | Out-Null
+    # }
+    $ownerEndpoint = $Endpoint.contains("?") ? ($Endpoint + "&`$whatif"):($Endpoint + "?`$whatif")
+    $fullUrl = $IsFullUri ? $Uri : "https://graph.microsoft.com/$($GraphApiVersion)/$ownerEndpoint"
+    try {
+        $responseObject = Invoke-MgGraphRequest -Uri $fullUrl -OutputType PSObject
+        return $responseObject.TargetWorkloadId
+    }
+    catch {
+        <#Do this if a terminating exception happens#>
+        Write-Warning $_
+        return $null
+    }
+}


### PR DESCRIPTION
* use PS baremetal methods

* Move to using PS Graph SDK with some commandlets

* Fix bug on getting script

* Add working directory

* debug script

* add connectionString variable to the yaml file

* Add step to create temp file before calling script

* change location of appSettings file

* convert token to securestring

* specify exact graph sdk version and exclude http files when downloading artifacts

* reinstate conversion to secure string

* Add continue on error

* Change path to publish

* Add try catch block in code to get owner

* Check Continue on host

* add reports folder

* handle exception gracefully

* check for null before accessing it


## Overview

Brief description of what this PR does, and why it is needed.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2044)