### PR TITLE
Fix functions as object names in go snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -433,6 +433,20 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("SetIncludeUserActions", result);
         }
         [Fact]
+        public async Task WriteCorrectFunctionNameWithParametersAsModelName()
+        {
+            const string messageObject = "{\r\n\"displayName\": \"Display name\"\r\n}";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Patch, $"{ServiceRootUrl}/applications(uniqueName='app-65278')")
+            {
+                Content = new StringContent(messageObject, Encoding.UTF8, "application/json")
+            };
+            requestPayload.Headers.Add("Prefer", "create-if-missing");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetBetaSnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("graphapplicationswithuniquename \"github.com/microsoftgraph/msgraph-sdk-go/applicationswithuniquename\"", result);
+            Assert.Contains("graphapplicationswithuniquename.ApplicationsWithUniqueNameRequestBuilderPatchRequestConfiguration", result);
+        }
+        [Fact]
         public async Task WriteCorrectTypesForFilterParameters()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get,

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -1,13 +1,13 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using CodeSnippetsReflection.OpenAPI.ModelGraph;
 using CodeSnippetsReflection.StringExtensions;
 using Microsoft.OpenApi.Services;
-using System.Text.RegularExpressions;
-using System.Collections;
 
 namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 {
@@ -28,6 +28,10 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static IImmutableSet<string> NativeTypes = GetNativeTypes();
 
         private static readonly Regex PropertyNameRegex = new Regex(@"@(.*)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
+
+        private static readonly Regex FunctionRegex = new Regex(@"(\w+)\(([^)]*)\)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
+
+        private static readonly Regex ParamRegex = new Regex(@"(\w+)\s*=\s*'[^']*'", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
 
         static IImmutableSet<string> GetNativeTypes()
         {
@@ -142,9 +146,24 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static String ProcessNameSpaceName(String nameSpace)
         {
-            return (nameSpace != null ? nameSpace.Split(".", StringSplitOptions.RemoveEmptyEntries)
+            if (String.IsNullOrEmpty(nameSpace))
+                return "";
+
+            // process function names and parameters
+            var functionNameMatch = FunctionRegex.Match(nameSpace);
+            if (functionNameMatch.Success)
+            {
+                var paramMatches = ParamRegex.Matches(functionNameMatch.Groups[2].Value);
+                var paramNames = paramMatches.Cast<Match>().Select(m => m.Groups[1].Value).ToList();
+
+                return functionNameMatch.Groups[1].Value + "With" + string.Join("With", paramNames);
+            }
+
+            var processedName = (nameSpace.Split(".", StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Equals("Me", StringComparison.OrdinalIgnoreCase) ? "Users" : x)
-                .Aggregate((current, next) => current + "." + next) : "models").Replace(".microsoft.graph", "");
+                .Aggregate((current, next) => current + "." + next)).Replace(".microsoft.graph", "");
+
+            return processedName;
         }
 
         private static String ProcessFinalNameSpaceName(String nameSpace)
@@ -306,7 +325,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                 if (x.Segment.IsCollectionIndex())
                     return "Item";
                 else
-                    return x.Segment.ToFirstCharacterUpperCase();
+                    return EscapeFunctionNames(x.Segment.ToFirstCharacterUpperCase());
             })
                         .Aggregate(static (x, y) =>
                         {
@@ -314,6 +333,22 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
                             w = "Me".Equals(w, StringComparison.Ordinal) ? "Item" : w;
                             return $"{w}{y}";
                         });
+        }
+
+        private static string EscapeFunctionNames(String objectName)
+        {
+            if (String.IsNullOrEmpty(objectName))
+                return objectName;
+
+            var match = FunctionRegex.Match(objectName);
+            if (match.Success)
+            {
+                var paramMatches = ParamRegex.Matches(match.Groups[2].Value);
+                var paramNames = paramMatches.Cast<Match>().Select(m => m.Groups[1].Value.ToFirstCharacterUpperCase()).ToList();
+
+                return match.Groups[1].Value + "With" + string.Join("With", paramNames);
+            }
+            return objectName;
         }
 
         private static string evaluateParameter(CodeProperty param)

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -14,8 +14,6 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
     public class GoGenerator : ILanguageGenerator<SnippetModel, OpenApiUrlTreeNode>
     {
         private const string clientVarName = "graphClient";
-        private const string clientVarType = "GraphServiceClientWithCredentials";
-        private const string clientFactoryVariables = "cred, scopes";
         private const string requestBodyVarName = "requestBody";
         private const string requestHeadersVarName = "headers";
         private const string optionsParameterVarName = "options";
@@ -154,14 +152,14 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (functionNameMatch.Success)
             {
                 var paramMatches = ParamRegex.Matches(functionNameMatch.Groups[2].Value);
-                var paramNames = paramMatches.Cast<Match>().Select(m => m.Groups[1].Value).ToList();
+                var paramNames = paramMatches.Cast<Match>().Select(static m => m.Groups[1].Value).ToList();
 
                 return functionNameMatch.Groups[1].Value + "With" + string.Join("With", paramNames);
             }
 
             var processedName = (nameSpace.Split(".", StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Equals("Me", StringComparison.OrdinalIgnoreCase) ? "Users" : x)
-                .Aggregate((current, next) => current + "." + next)).Replace(".microsoft.graph", "");
+                .Aggregate(static (current, next) => current + "." + next)).Replace(".microsoft.graph", "");
 
             return processedName;
         }
@@ -344,7 +342,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (match.Success)
             {
                 var paramMatches = ParamRegex.Matches(match.Groups[2].Value);
-                var paramNames = paramMatches.Cast<Match>().Select(m => m.Groups[1].Value.ToFirstCharacterUpperCase()).ToList();
+                var paramNames = paramMatches.Cast<Match>().Select(static m => m.Groups[1].Value.ToFirstCharacterUpperCase()).ToList();
 
                 return match.Groups[1].Value + "With" + string.Join("With", paramNames);
             }


### PR DESCRIPTION
## Overview

Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/698

Fixes generation of config name and imports for functions as the final node

### Demo

Current example https://learn.microsoft.com/en-us/graph/api/application-upsert?view=graph-rest-1.0&tabs=go

```diff

// Code snippets are only available for the latest major version. Current major version is $v1.*

// Dependencies
import (
	  "context"
	  abstractions "github.com/microsoft/kiota-abstractions-go"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
-	  graphapplications(uniquename='{uniquename}') "github.com/microsoftgraph/msgraph-sdk-go/applications(uniquename='{uniquename}')"
+	  graphapplicationswithuniquename "github.com/microsoftgraph/msgraph-sdk-go/applicationswithuniquename"
	  //other-imports
)

headers := abstractions.NewRequestHeaders()
headers.Add("Prefer", "create-if-missing")

+configuration := &graphapplicationswithuniquename.ApplicationsWithUniqueNameRequestBuilderPatchRequestConfiguration{
-configuration := &graphapplications(uniquename='{uniquename}').Applications(uniqueName='{uniqueName}')RequestBuilderPatchRequestConfiguration{
	Headers: headers,
}
requestBody := graphmodels.NewApplication()
displayName := "Display name"
requestBody.SetDisplayName(&displayName) 

// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go
uniqueName := "{uniqueName}"
applications, err := graphClient.ApplicationsWithUniqueName(&uniqueName).Patch(context.Background(), requestBody, configuration)

```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2051)