### PR TITLE
fix: Remove normalization for map keys in go snippets

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -456,6 +456,34 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("requestTop := int32(100)", result);
             Assert.Contains("requestSkip := int32(0)", result);
         }
+        [Fact]
+        public async Task DoesNotNormalizeKeysForMaps()
+        {
+            var sampleJson = @"
+            {
+               ""template@odata.bind"":""https://graph.microsoft.com/v1.0/teamsTemplates('standard')"",
+               ""displayName"":""My Sample Team"",
+               ""description"":""My Sample Team’s Description"",
+               ""members"":[
+                  {
+                     ""@odata.type"":""#microsoft.graph.aadUserConversationMember"",
+                     ""roles"":[
+                        ""owner""
+                     ],
+                     ""user@odata.bind"":""https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')""
+                  }
+               ]
+            }
+            ";
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Post, $"{ServiceRootUrl}/teams")
+            {
+                Content = new StringContent(sampleJson, Encoding.UTF8, "application/json")
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootBetaUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("\"user@odata.bind\" : \"https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')\"", result);
+            Assert.Contains("\"template@odata.bind\" : \"https://graph.microsoft.com/v1.0/teamsTemplates('standard')\"", result);
+        }
 
         /**
 

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -575,7 +575,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             if (isArray || String.IsNullOrWhiteSpace(propName))
                 builder.AppendLine($"{indentManager.GetIndent()}\"{child.Value}\",");
             else if (isMap)
-                builder.AppendLine($"{indentManager.GetIndent()}{propertyName.AddQuotes()} : \"{child.Value}\", ");
+                builder.AppendLine($"{indentManager.GetIndent()}{child.Name.AddQuotes()} : \"{child.Value}\", ");
             else
             {
                 builder.AppendLine($"{propertyName} := \"{child.Value}\"");


### PR DESCRIPTION
## Overview

Removes normalization of map keys for go snippets. Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/717

### Demo

```diff
// Code snippets are only available for the latest major version. Current major version is $v1.*

// Dependencies
import (
	  "context"
	  msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
	  graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
	  //other-imports
)

requestBody := graphmodels.NewTeam()
displayName := "My Sample Team"
requestBody.SetDisplayName(&displayName) 
description := "My Sample Team’s Description"
requestBody.SetDescription(&description) 


conversationMember := graphmodels.NewAadUserConversationMember()
roles := []string {
	"owner",
}
conversationMember.SetRoles(roles)
additionalData := map[string]interface{}{
-	"odataBind" : "https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')", 
+	"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')", 
}
conversationMember.SetAdditionalData(additionalData)

members := []graphmodels.ConversationMemberable {
	conversationMember,
}
requestBody.SetMembers(members)
additionalData := map[string]interface{}{
-	"odataBind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')", 
+     "template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')", 
}
requestBody.SetAdditionalData(additionalData)

// To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=go
teams, err := graphClient.Teams().Post(context.Background(), requestBody, nil)

```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2069)