### PR TITLE
Add dependency Microsoft.Extensions.DependencyInjection.Abstractions to fix ODATA snippet generation

### DIFF
--- a/CodeSnippetsReflection.OData/CodeSnippetsReflection.OData.csproj
+++ b/CodeSnippetsReflection.OData/CodeSnippetsReflection.OData.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.OData.Core" Version="8.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #2168 

JavaScript code snippets generation is failing with the following error:
```Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2167)