### PR TITLE
Add script to remove unreferenced permissions tables include files

### DIFF
--- a/pipelines/docs-permissions.yml
+++ b/pipelines/docs-permissions.yml
@@ -120,6 +120,35 @@ extends:
                   & $apidoctorPath generate-permission-files --ignore-warnings $(bootstrappingOnly) --path . --permissions-source-file $(permissionsSourceFilePath) --git-path "/bin/git"
                 displayName: "Generate permissions tables"
                 workingDirectory: microsoft-graph-docs
+                
+              - pwsh: |
+                  $apidoctorPath1 = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY\microsoft-graph-devx-api\scripts\cleanupUnusedSnippets.ps1 -Recurse).FullName
+                  
+                  Write-Host "Path to apidoctor tool: $apidoctorPath1"
 
+                displayName: "List scripts directory"
+                
+              - task: PowerShell@2
+                displayName: 'Validate updated version'
+                inputs:
+                  targetType: filePath
+                  filePath: '/scripts/cleanupUnusedSnippets.ps1'
+                  pwsh: true
+                enabled: true
+              
+              - pwsh: $(Build.SourcesDirectory)\microsoft-graph-devx-api\scripts\cleanupUnusedSnippets.ps1
+                displayName: 'Cleanup unused snippets'
+                workingDirectory: microsoft-graph-docs
+              
+              - pwsh: $(Build.SourcesDirectory)/microsoft-graph-devx-api/scripts/cleanupUnusedSnippets.ps1
+                displayName: 'Cleanup unused snippets'
+                workingDirectory: microsoft-graph-docs
+                
+              - task: PowerShell@2
+                displayName: "Cleanup unused permisssions tables .md files"
+                inputs:
+                  targetType: filePath
+                  filePath: "microsoft-graph-devx-api/scripts/cleanupUnusedSnippets.ps1"
+                  pwsh: true
 
               - template: /pipelines/templates/commit-changes.yml@self

--- a/scripts/cleanupUnusedPermissionsTablesFiles.ps1
+++ b/scripts/cleanupUnusedPermissionsTablesFiles.ps1
@@ -1,0 +1,34 @@
+$permissionsTablesFiles = Get-ChildItem -Recurse -Filter permissions | Get-ChildItem -Recurse -Filter *.md | Select-Object -ExpandProperty FullName
+
+# Get all markdown files excluding those in the permissions directory
+$docsFiles = Get-ChildItem -Recurse -Filter *.md -Exclude */permissions/*
+
+$resolvedPermissionsTablesFiles = New-Object System.Collections.Generic.HashSet[string]
+
+foreach ($docFile in $docsFiles) {
+    $content = Get-Content -Path $docFile.FullName -ErrorAction Stop
+    if ($content -cmatch ".*INCLUDE.*") {
+        # Matches this in the referencing files [!INCLUDE [permissions-table](../includes/permissions/user-list-calendars-permissions.md)]
+        $pathMatches = [regex]::Matches($content, "\(([^\)]+)\)"); # Gets the path portion of a MD link
+        foreach ($pathMatch in $pathMatches) {
+            $permissionsTablePath = $pathMatch.Groups[1].Value;
+            if ($permissionsTablePath -match ".*permissions.*" -and 
+                $permissionsTablePath -cnotmatch ".*:\/\/.*" -and 
+                $permissionsTablePath.EndsWith('.md', 'OrdinalIgnoreCase')) { # Checks that the permissions table is in a "permissions" folder and that it's not a link "://"
+                
+                # Resolve path and add to HashSet
+                $permissionsTableFullPath = (Resolve-Path -LiteralPath (Join-Path $docFile.DirectoryName $permissionsTablePath) -ErrorAction SilentlyContinue).Path
+                if ($permissionsTableFullPath) {
+                    $resolvedPermissionsTablesFiles.Add($permissionsTableFullPath) | Out-Null
+                }
+            }
+        }
+    }
+}
+
+# Remove unused permissions table markdown files
+foreach ($candidateForDeletion in $permissionsTablesFiles) {
+    if (-not $resolvedPermissionsTablesFiles.Contains($candidateForDeletion)) {
+        Remove-Item -Path $candidateForDeletion -Verbose -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
The unreferenced permissions tables files could have been caused by:
- API Doctor replacing manually created files with files that follow the naming convention
- Changes in the parent file name. The permissions tables file names depend on the name of the parent API topic

With this PR, any unreferenced permissions tables files will be removed during the daily permissions tables update run
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2207)