### PR TITLE
Add script to remove unreferenced permissions tables include files

### DIFF
--- a/pipelines/docs-permissions.yml
+++ b/pipelines/docs-permissions.yml
@@ -20,11 +20,6 @@ resources:
       endpoint: microsoftgraphdocs
       name: microsoftgraph/microsoft-graph-docs
       ref: main
-    - repository: api-doctor
-      type: github
-      endpoint: microsoftgraphdocs
-      name: OneDrive/apidoctor
-      ref: master
     - repository: 1ESPipelineTemplates
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
@@ -41,7 +36,7 @@ parameters:
 
 variables:
   buildConfiguration: "Release"
-  apidoctorProjects: "apidoctor/**/*.csproj"
+  apidoctorProjects: "microsoft-graph-devx-api/apidoctor/**/*.csproj"
   permissionsSourceFilePath: ${{ parameters.permissionsSourceFilePath }}
   ${{ if eq(parameters.bootstrappingOnly, true) }}:
     bootstrappingOnly: "--bootstrapping-only"
@@ -58,7 +53,6 @@ extends:
     sdl:
       sourceRepositoriesToScan:
         exclude:
-          - repository: "api-doctor"
           - repository: "microsoft-graph-docs"
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\.config\CredScanSuppressions.json
@@ -69,8 +63,8 @@ extends:
         jobs:
           - job: RunAPIDoctorScript
             steps:
-              - checkout: api-doctor
-                displayName: Checkout API Doctor
+              - checkout: self
+                displayName: Checkout DevX API
                 fetchDepth: 1
                 submodules: recursive
                 persistCredentials: true
@@ -114,12 +108,18 @@ extends:
                   arguments: "--configuration $(buildConfiguration)"
               
               - pwsh: |
-                  $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/apidoctor/ApiDoctor.Console/bin/Release -Recurse -Filter "apidoc.exe").FullName
+                  $apidoctorPath = (Get-ChildItem $env:BUILD_SOURCESDIRECTORY/microsoft-graph-devx-api/apidoctor/ApiDoctor.Console/bin/Release -Recurse -Filter "apidoc.exe").FullName
                   Write-Host "Path to apidoctor tool: $apidoctorPath"
 
                   & $apidoctorPath generate-permission-files --ignore-warnings $(bootstrappingOnly) --path . --permissions-source-file $(permissionsSourceFilePath) --git-path "/bin/git"
                 displayName: "Generate permissions tables"
                 workingDirectory: microsoft-graph-docs
-
+                
+              - task: PowerShell@2
+                displayName: "Cleanup unused permisssions tables .md files"
+                inputs:
+                  targetType: filePath
+                  filePath: "microsoft-graph-devx-api/scripts/cleanupUnusedPermissionsTablesFiles.ps1"
+                  pwsh: true
 
               - template: /pipelines/templates/commit-changes.yml@self

--- a/scripts/cleanupUnusedPermissionsTablesFiles.ps1
+++ b/scripts/cleanupUnusedPermissionsTablesFiles.ps1
@@ -1,0 +1,34 @@
+$permissionsTablesFiles = Get-ChildItem -Recurse -Filter permissions | Get-ChildItem -Recurse -Filter *.md | Select-Object -ExpandProperty FullName
+
+# Get all markdown files excluding those in the permissions directory
+$docsFiles = Get-ChildItem -Recurse -Filter *.md -Exclude */permissions/*
+
+$resolvedPermissionsTablesFiles = New-Object System.Collections.Generic.HashSet[string]
+
+foreach ($docFile in $docsFiles) {
+    $content = Get-Content -Path $docFile.FullName -ErrorAction Stop
+    if ($content -cmatch "\[!INCLUDE \[permissions-table\]") {
+        # Matches this in the referencing files [!INCLUDE [permissions-table](../includes/permissions/user-list-calendars-permissions.md)]
+        $pathMatches = [regex]::Matches($content, "\(([^\)]+)\)"); # Gets the path portion of a MD link
+        foreach ($pathMatch in $pathMatches) {
+            $permissionsTablePath = $pathMatch.Groups[1].Value;
+            if ($permissionsTablePath -match ".*permissions.*" -and 
+                $permissionsTablePath -cnotmatch ".*:\/\/.*" -and 
+                $permissionsTablePath.EndsWith('.md', 'OrdinalIgnoreCase')) { # Checks that the permissions table is in a "permissions" folder and that it's not a link "://"
+                
+                # Resolve path and add to HashSet
+                $permissionsTableFullPath = (Resolve-Path -LiteralPath (Join-Path $docFile.DirectoryName $permissionsTablePath) -ErrorAction SilentlyContinue).Path
+                if ($permissionsTableFullPath) {
+                    $resolvedPermissionsTablesFiles.Add($permissionsTableFullPath) | Out-Null
+                }
+            }
+        }
+    }
+}
+
+# Remove unused permissions table markdown files
+foreach ($candidateForDeletion in $permissionsTablesFiles) {
+    if (-not $resolvedPermissionsTablesFiles.Contains($candidateForDeletion)) {
+        Remove-Item -Path $candidateForDeletion -Verbose -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
The unreferenced permissions tables files could be caused by:
- API Doctor replacing manually created files with files that follow the naming convention
- Changes in the parent file name. The permissions tables file names depend on the name of the parent API topic

With this PR, any unreferenced permissions tables files will be removed during the daily permissions tables update run
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2230)