### PR TITLE
Fix go generation

### DIFF
--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -589,7 +589,7 @@ namespace CodeSnippetsReflection.OpenAPI.Test
         public async Task GeneratesConfigurationObject()
         {
             using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/{{id}}/mailFolders('inbox')/messages/delta?changeType=created&$select=subject,from,isRead,body,receivedDateTime");
-            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadataAsync());
             var result = _generator.GenerateCodeSnippet(snippetModel);
             Assert.Contains("requestParameters := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{", result);
             Assert.Contains("configuration := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{", result);

--- a/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
+++ b/CodeSnippetsReflection.OpenAPI.Test/GoGeneratorTests.cs
@@ -584,7 +584,18 @@ namespace CodeSnippetsReflection.OpenAPI.Test
             Assert.Contains("toDateTime , err := time.Parse(time.RFC3339, \"{toDateTime}\")", result);
             Assert.Contains("microsoftGraphCallRecordsGetPstnCalls, err := graphClient.Communications().CallRecords().MicrosoftGraphCallRecordsGetPstnCallsWithFromDateTimeWithToDateTime(&fromDateTime, &toDateTime).GetAsGetPstnCallsWithFromDateTimeWithToDateTimeGetResponse(context.Background(), nil)", result);
         }
-
+        
+        [Fact]
+        public async Task GeneratesConfigurationObject()
+        {
+            using var requestPayload = new HttpRequestMessage(HttpMethod.Get, $"{ServiceRootUrl}/users/{{id}}/mailFolders('inbox')/messages/delta?changeType=created&$select=subject,from,isRead,body,receivedDateTime");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, await GetV1SnippetMetadata());
+            var result = _generator.GenerateCodeSnippet(snippetModel);
+            Assert.Contains("requestParameters := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{", result);
+            Assert.Contains("configuration := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{", result);
+            Assert.Contains("delta, err := graphClient.Users().ByUserId(\"user-id\").MailFolders().ByMailFolderId(\"mailFolder-id\").Messages().Delta().GetAsDeltaGetResponse(context.Background(), configuration)", result);
+        }
+        
         [Fact]
         public async Task GenerateFindMeetingTimeAsync()
         {

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -310,28 +310,22 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string GetNestedObjectName(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
-            if (!(nodes?.Any() ?? false)) return string.Empty;
-
             var enumeratedNodes = nodes.ToList();
-            // if the first element is a collection index skip it
-            var isCollection = enumeratedNodes.First().Segment.IsCollectionIndex();
-            var isSingleElement = enumeratedNodes.Count() == 1;
-            var elementCount = enumeratedNodes.Count(); // check if its a nested element
+            if (!(enumeratedNodes?.Any() ?? false)) return string.Empty;
 
-            var filteredNodes = enumeratedNodes;
+            // if the first element is a collection index skip it
+            var isCollection = enumeratedNodes[0].Segment.IsCollectionIndex();
+            var isSingleElement = enumeratedNodes.Count == 1;
+            var elementCount = enumeratedNodes.Count; // check if its a nested element
+
+            var filteredNodes = enumeratedNodes.ToList();
             if (isCollection && !isSingleElement)
                 filteredNodes = enumeratedNodes.Skip(2).ToList();
             else if (isCollection || elementCount > 2)
                 filteredNodes = enumeratedNodes.Skip(1).ToList();
 
             if (!filteredNodes.Any()) return string.Empty;
-            return filteredNodes.Select(static x =>
-            {
-                if (x.Segment.IsCollectionIndex())
-                    return "Item";
-                else
-                    return EscapeFunctionNames(x.Segment.ToFirstCharacterUpperCase());
-            })
+            return filteredNodes.Select(static x => x.Segment.IsCollectionIndex() ? "Item" : EscapeFunctionNames(x.Segment.ToFirstCharacterUpperCase()))
                         .Aggregate((x, y) =>
                         {
                             var w = elementCount < 3 && x.EndsWith('s') && y.Equals("Item") ? x.Remove(x.Length - 1, 1) : x;

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -310,8 +310,8 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
 
         private static string GetNestedObjectName(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
-            var enumeratedNodes = nodes.ToList();
-            if (!(enumeratedNodes?.Any() ?? false)) return string.Empty;
+            var enumeratedNodes = nodes?.ToList() ?? new List<OpenApiUrlTreeNode>();
+            if (!enumeratedNodes.Any()) return string.Empty;
 
             // if the first element is a collection index skip it
             var isCollection = enumeratedNodes[0].Segment.IsCollectionIndex();

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -318,7 +318,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             var isSingleElement = enumeratedNodes.Count == 1;
             var elementCount = enumeratedNodes.Count; // check if its a nested element
 
-            var filteredNodes = enumeratedNodes.ToList();
+            var filteredNodes = enumeratedNodes;
             if (isCollection && !isSingleElement)
                 filteredNodes = enumeratedNodes.Skip(2).ToList();
             else if (isCollection || elementCount > 2)

--- a/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
+++ b/CodeSnippetsReflection.OpenAPI/LanguageGenerators/GoGenerator.cs
@@ -311,7 +311,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
         private static string GetNestedObjectName(IEnumerable<OpenApiUrlTreeNode> nodes)
         {
             var enumeratedNodes = nodes?.ToList() ?? new List<OpenApiUrlTreeNode>();
-            if (!enumeratedNodes.Any()) return string.Empty;
+            if (enumeratedNodes.Count == 0) return string.Empty;
 
             // if the first element is a collection index skip it
             var isCollection = enumeratedNodes[0].Segment.IsCollectionIndex();
@@ -324,7 +324,7 @@ namespace CodeSnippetsReflection.OpenAPI.LanguageGenerators
             else if (isCollection || elementCount > 2)
                 filteredNodes = enumeratedNodes.Skip(1).ToList();
 
-            if (!filteredNodes.Any()) return string.Empty;
+            if (filteredNodes.Count == 0) return string.Empty;
             return filteredNodes.Select(static x => x.Segment.IsCollectionIndex() ? "Item" : EscapeFunctionNames(x.Segment.ToFirstCharacterUpperCase()))
                         .Aggregate((x, y) =>
                         {


### PR DESCRIPTION
## Overview

Resolves https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/2228

Resolves referencing nested model files after flattenig

### Demo

```ts

requestParameters := &graphusers.UserItemMailFolderItemMessagesDeltaWithRequestBuilderGetQueryParameters{
        ChangeType: &requestChangeType,
        Select: [] string {"subject","from","isRead","body","receivedDateTime"},
}
configuration := &graphusers.UserItemMailFolderItemMessagesDeltaWithRequestBuilderGetRequestConfiguration{
        Headers: headers,
        QueryParameters: requestParameters,
}

```

should be 


```typescript
	requestParameters := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{
		ChangeType: &requestChangeType,
		Select:     []string{"subject", "from", "isRead", "body", "receivedDateTime"},
	}
	configuration := &graphusers.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{
		Headers:         headers,
		QueryParameters: requestParameters,
	}

```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2260)