### PR TITLE
fix sonar cloud scanner

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,18 +36,14 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 17
-      - name: Setup .NET 5 # At the moment the scanner requires dotnet 5 https://www.nuget.org/packages/dotnet-sonarscanner
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET 7
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.0.x
+        with: # At the moment the scanner requires dotnet 5 https://www.nuget.org/packages/dotnet-sonarscanner
+            dotnet-version: |
+              5.x
+              6.x
+              7.x
+              8.x    
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Fix sonar cloud scanner failing [building](https://github.com/microsoftgraph/microsoft-graph-devx-api/actions/runs/12684472757/job/35353217257)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/2280)

Build failing because of current version of dotnet runner does not recognize command argument `'--create-manifest-if-needed'`