### PR TITLE
Locking optimizations

### DIFF
--- a/SamplesService/Services/SamplesStore.cs
+++ b/SamplesService/Services/SamplesStore.cs
@@ -24,7 +24,7 @@ namespace SamplesService.Services
     /// </summary>
     public class SamplesStore : ISamplesStore
     {
-        private static readonly AsyncKeyedLocker<string> _asyncKeyedLocker = new();
+        private static readonly AsyncNonKeyedLocker _samplesLocker = new();
         private readonly IFileUtility _fileUtility;
         private readonly IHttpClientUtility _httpClientUtility;
         private readonly IMemoryCache _samplesCache;
@@ -71,7 +71,7 @@ namespace SamplesService.Services
             // making sure only a single thread at a time access the cache
             // when already seeded, lock will resolve fast and access the cache
             // when not seeded, lock will resolve slow for all other threads and seed the cache on the first thread
-            using (await _asyncKeyedLocker.LockAsync("samples"))
+            using (await _samplesLocker.LockAsync())
             {
                 // Fetch cached sample queries
                 var sampleQueriesList = await _samplesCache.GetOrCreateAsync(locale, async cacheEntry =>


### PR DESCRIPTION
Using a dictionary-based approach to locking with hardcoded strings is not optimal, hence switched to use `AsyncNonKeyedLocker`.

However in the case of GetOrCreatePermissionsDescriptionsAsync, it feels like two concurrent threads can exist as long as they have a different locale, hence the change to this method too.